### PR TITLE
dynarmic: update to GPLv3-dynarmic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/mozilla/cubeb.git
 [submodule "dynarmic"]
 	path = externals/dynarmic
-	url = https://github.com/yuzu-mirror/dynarmic.git
+	url = https://github.com/xinitrcn1/dynarmic
 [submodule "libusb"]
 	path = externals/libusb/libusb
 	url = https://github.com/libusb/libusb.git

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -83,13 +83,6 @@ public:
                m_memory.WriteExclusive64(vaddr, value, expected);
     }
 
-    void InterpreterFallback(u32 pc, std::size_t num_instructions) override {
-        m_parent.LogBacktrace(m_process);
-        LOG_ERROR(Core_ARM,
-                  "Unimplemented instruction @ 0x{:X} for {} instructions (instr = {:08X})", pc,
-                  num_instructions, m_memory.Read32(pc));
-    }
-
     void ExceptionRaised(u32 pc, Dynarmic::A32::Exception exception) override {
         switch (exception) {
         case Dynarmic::A32::Exception::NoExecuteFault:
@@ -186,8 +179,8 @@ std::shared_ptr<Dynarmic::A32::Jit> ArmDynarmic32::MakeJit(Common::PageTable* pa
         constexpr size_t PageBits = 12;
         constexpr size_t NumPageTableEntries = 1 << (32 - PageBits);
 
-        config.page_table = reinterpret_cast<std::array<std::uint8_t*, NumPageTableEntries>*>(
-            page_table->pointers.data());
+        config.page_table = reinterpret_cast<std::array<std::uint8_t*, NumPageTableEntries>*>(page_table->pointers.data());
+        config.page_table_log2_stride = 3;
         config.absolute_offset_page_table = true;
         config.page_table_pointer_mask_bits = Common::PageTable::ATTRIBUTE_BITS;
         config.detect_misaligned_access_via_page_table = 16 | 32 | 64 | 128;
@@ -200,7 +193,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ArmDynarmic32::MakeJit(Common::PageTable* pa
     }
 
     // Multi-process state
-    config.processor_id = m_core_index;
+    config.processor_id = uint8_t(m_core_index);
     config.global_monitor = &m_exclusive_monitor.monitor;
 
     // Timing

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -97,14 +97,6 @@ public:
                m_memory.WriteExclusive128(vaddr, value, expected);
     }
 
-    void InterpreterFallback(u64 pc, std::size_t num_instructions) override {
-        m_parent.LogBacktrace(m_process);
-        LOG_ERROR(Core_ARM,
-                  "Unimplemented instruction @ 0x{:X} for {} instructions (instr = {:08X})", pc,
-                  num_instructions, m_memory.Read32(pc));
-        ReturnException(pc, PrefetchAbort);
-    }
-
     void InstructionCacheOperationRaised(Dynarmic::A64::InstructionCacheOperation op,
                                          u64 value) override {
         switch (op) {
@@ -233,7 +225,8 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* pa
     // Memory
     if (page_table) {
         config.page_table = reinterpret_cast<void**>(page_table->pointers.data());
-        config.page_table_address_space_bits = address_space_bits;
+        config.page_table_log2_stride = 3;
+        config.page_table_address_space_bits = uint32_t(address_space_bits);
         config.page_table_pointer_mask_bits = Common::PageTable::ATTRIBUTE_BITS;
         config.silently_mirror_page_table = false;
         config.absolute_offset_page_table = true;
@@ -241,7 +234,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* pa
         config.only_detect_misalignment_via_page_table_on_page_boundary = true;
 
         config.fastmem_pointer = reinterpret_cast<uintptr_t>(page_table->fastmem_arena);
-        config.fastmem_address_space_bits = address_space_bits;
+        config.fastmem_address_space_bits = uint32_t(address_space_bits);
         config.silently_mirror_fastmem = false;
 
         config.fastmem_exclusive_access = config.fastmem_pointer.has_value();
@@ -249,7 +242,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* pa
     }
 
     // Multi-process state
-    config.processor_id = m_core_index;
+    config.processor_id = uint8_t(m_core_index);
     config.global_monitor = &m_exclusive_monitor.monitor;
 
     // System registers

--- a/src/core/hle/service/jit/jit_context.cpp
+++ b/src/core/hle/service/jit/jit_context.cpp
@@ -103,7 +103,6 @@ public:
 
     void CallSVC(u32 swi) override;
     void ExceptionRaised(u64 pc, Dynarmic::A64::Exception exception) override;
-    void InterpreterFallback(u64 pc, size_t num_instructions) override;
 
     void AddTicks(u64 ticks) override {}
     u64 GetTicksRemaining() override {
@@ -414,11 +413,6 @@ void DynarmicCallbacks64::CallSVC(u32 swi) {
 
 void DynarmicCallbacks64::ExceptionRaised(u64 pc, Dynarmic::A64::Exception exception) {
     LOG_CRITICAL(Service_JIT, "Illegal operation PC @ {:08x}", pc);
-    parent.jit->HaltExecution();
-}
-
-void DynarmicCallbacks64::InterpreterFallback(u64 pc, size_t num_instructions) {
-    LOG_CRITICAL(Service_JIT, "Unimplemented instruction PC @ {:08x}", pc);
     parent.jit->HaltExecution();
 }
 

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -352,8 +352,8 @@ void Send(Engines::Maxwell3D* maxwell3d, Macro::MethodAddress method_address, u3
 void MacroJITx64Impl::Compile_Send(Xbyak::Reg32 value) {
     Common::X64::ABI_PushRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
     mov(Common::X64::ABI_PARAM1, qword[STATE]);
-    mov(Common::X64::ABI_PARAM2, METHOD_ADDRESS);
-    mov(Common::X64::ABI_PARAM3, value);
+    mov(Common::X64::ABI_PARAM2.cvt32(), METHOD_ADDRESS);
+    mov(Common::X64::ABI_PARAM3.cvt32(), value);
     Common::X64::CallFarFunction(*this, &Send);
     Common::X64::ABI_PopRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
 


### PR DESCRIPTION
my gplv3 fork is superior to all other dynarmics at the moment

however - the obvious caveat is that Xbyak has updated, hence breaking some of the macro compiler

not tested on windows/linux