### PR TITLE
Update requested fmt version in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "fmt",
-      "version": "10.1.1"
+      "version": "12.1.0"
     },
     {
       "name": "openal-soft",


### PR DESCRIPTION
update the version of fmt that vcpkg pulls if it's not found at the system level.

This is to fix compatibility with -fno-rtti if using vcpkg to obtain fmt.