### PR TITLE
fw: support 22

### DIFF
--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -273,6 +273,7 @@ Result KPageTableBase::InitializeForProcess(Svc::CreateProcessFlag as_type, bool
     // Set other basic fields.
     m_enable_aslr = enable_aslr;
     m_enable_device_address_space_merge = enable_das_merge;
+    m_allowed_exec_device_mapping = false;
     m_address_space_start = start;
     m_address_space_end = end;
     m_is_kernel = false;

--- a/src/core/hle/kernel/k_page_table_base.h
+++ b/src/core/hle/kernel/k_page_table_base.h
@@ -220,6 +220,7 @@ private:
     bool m_is_kernel{};
     bool m_enable_aslr{};
     bool m_enable_device_address_space_merge{};
+    bool m_allowed_exec_device_mapping{};
     KMemoryBlockSlabManager* m_memory_block_slab_manager{};
     KBlockInfoManager* m_block_info_manager{};
     KResourceLimit* m_resource_limit{};
@@ -248,8 +249,13 @@ public:
     bool IsKernel() const {
         return m_is_kernel;
     }
+
     bool IsAslrEnabled() const {
         return m_enable_aslr;
+    }
+
+    void AllowDeviceMappingOfExecPages() {
+        m_allowed_exec_device_mapping = true;
     }
 
     bool Contains(KProcessAddress addr) const {

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -345,6 +345,11 @@ Result KProcess::Initialize(const Svc::CreateProcessParameter& params, const KPa
     // Initialize capabilities.
     R_TRY(m_capabilities.InitializeForKip(caps, std::addressof(m_page_table)));
 
+    // Enable mapping device pages as executable on legacy processes.
+    if (m_capabilities.GetIntendedKernelMajorVersion() < 26) {
+        m_page_table.AllowDeviceMappingOfExecPages();
+    }
+
     // Initialize the process id.
     m_process_id = m_kernel.CreateNewUserProcessID();
     ASSERT(InitialProcessIdMin <= m_process_id);
@@ -440,6 +445,11 @@ Result KProcess::Initialize(const Svc::CreateProcessParameter& params,
 
     // Initialize capabilities.
     R_TRY(m_capabilities.InitializeForUser(user_caps, std::addressof(m_page_table)));
+
+    // Enable mapping device pages as executable on legacy processes.
+    if (m_capabilities.GetIntendedKernelMajorVersion() < 26) {
+        m_page_table.AllowDeviceMappingOfExecPages();
+    }
 
     // Initialize the process id.
     m_process_id = m_kernel.CreateNewUserProcessID();
@@ -992,6 +1002,9 @@ Result KProcess::Run(s32 priority, size_t stack_size) {
     // Set the thread arguments.
     main_thread->GetContext().r[0] = 0;
     main_thread->GetContext().r[1] = thread_handle;
+
+    // Pass the thread handle to the thread local region.
+    this->GetMemory().Write32(GetInteger(main_thread->GetTlsAddress()) + 0x110, thread_handle);
 
     // Update our state.
     this->ChangeState((state == State::Created) ? State::Running : State::RunningAttached);

--- a/src/core/hle/kernel/k_process_page_table.h
+++ b/src/core/hle/kernel/k_process_page_table.h
@@ -30,6 +30,10 @@ public:
         m_page_table.Finalize();
     }
 
+    void AllowDeviceMappingOfExecPages() {
+        m_page_table.AllowDeviceMappingOfExecPages();
+    }
+
     Core::Memory::Memory& GetMemory() {
         return m_page_table.GetMemory();
     }

--- a/src/core/hle/kernel/svc/svc_thread.cpp
+++ b/src/core/hle/kernel/svc/svc_thread.cpp
@@ -72,7 +72,10 @@ Result CreateThread(Core::System& system, Handle* out_handle, u64 entry_point, u
     KThread::Register(kernel, thread);
 
     // Add the thread to the handle table.
-    R_RETURN(process.GetHandleTable().Add(out_handle, thread));
+    R_TRY(process.GetHandleTable().Add(out_handle, thread));
+    // Pass the thread handle to the thread local region.
+    process.GetMemory().Write32(GetInteger(thread->GetTlsAddress()) + 0x110, *out_handle);
+    R_SUCCEED();
 }
 
 /// Starts the thread for the provided handle

--- a/src/core/hle/kernel/svc_version.h
+++ b/src/core/hle/kernel/svc_version.h
@@ -45,14 +45,12 @@ constexpr inline u32 GetKernelMinorVersion(u32 encoded) {
 // Nintendo doesn't support programs targeting SVC versions < 3.0.
 constexpr inline u32 RequiredKernelMajorVersion = 3;
 constexpr inline u32 RequiredKernelMinorVersion = 0;
-constexpr inline u32 RequiredKernelVersion =
-    EncodeKernelVersion(RequiredKernelMajorVersion, RequiredKernelMinorVersion);
+constexpr inline u32 RequiredKernelVersion = EncodeKernelVersion(RequiredKernelMajorVersion, RequiredKernelMinorVersion);
 
 // This is the highest SVC version supported, to be updated on new kernel releases.
 // NOTE: Official kernel versions have SVC major = SDK major + 4, SVC minor = SDK minor.
-constexpr inline u32 SupportedKernelMajorVersion = ConvertToSvcMajorVersion(15);
-constexpr inline u32 SupportedKernelMinorVersion = ConvertToSvcMinorVersion(3);
-constexpr inline u32 SupportedKernelVersion =
-    EncodeKernelVersion(SupportedKernelMajorVersion, SupportedKernelMinorVersion);
+constexpr inline u32 SupportedKernelMajorVersion = ConvertToSvcMajorVersion(22);
+constexpr inline u32 SupportedKernelMinorVersion = ConvertToSvcMinorVersion(2);
+constexpr inline u32 SupportedKernelVersion = EncodeKernelVersion(SupportedKernelMajorVersion, SupportedKernelMinorVersion);
 
 } // namespace Kernel::Svc

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -1209,6 +1209,13 @@ void Module::Interface::StoreSaveDataThumbnailSystem(HLERequestContext& ctx) {
     StoreSaveDataThumbnail(ctx, uuid, tid);
 }
 
+void Module::Interface::GetPinCodeLength(HLERequestContext& ctx) {
+    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push<u32>(0);
+}
+
 void Module::Interface::StoreSaveDataThumbnail(HLERequestContext& ctx, const Common::UUID& uuid,
                                                const u64 tid) {
     IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -49,6 +49,7 @@ public:
         void DebugActivateOpenContextRetention(HLERequestContext& ctx);
         void GetBaasAccountManagerForSystemService(HLERequestContext& ctx);
         void StoreSaveDataThumbnailSystem(HLERequestContext& ctx);
+        void GetPinCodeLength(HLERequestContext& ctx);
         // Additional functions for acc:su
         void GetUserRegistrationNotifier(HLERequestContext& ctx);
         void GetUserStateChangeNotifier(HLERequestContext& ctx);

--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -67,6 +67,7 @@ ACC_SU::ACC_SU(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> 
         {351, &ACC_SU::UploadNasCredential, "UploadNasCredential"}, // [20.0.0+]
         {352, &ACC_SU::CreateDeviceMigrationUserImportRequest, "CreateDeviceMigrationUserImportRequest"}, // [20.0.0+]
         {353, &ACC_SU::DeleteUserMigrationInfo, "DeleteUserMigrationInfo"}, // [20.0.0+]
+        {401, &ACC_SU::GetPinCodeLength, "GetPinCodeLength"},
         {900, &ACC_SU::SetUserUnqualifiedForDebug, "SetUserUnqualifiedForDebug"},
         {901, &ACC_SU::UnsetUserUnqualifiedForDebug, "UnsetUserUnqualifiedForDebug"},
         {902, &ACC_SU::ListUsersUnqualifiedForDebug, "ListUsersUnqualifiedForDebug"},

--- a/src/core/hle/service/acc/acc_u1.cpp
+++ b/src/core/hle/service/acc/acc_u1.cpp
@@ -41,6 +41,7 @@ ACC_U1::ACC_U1(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> 
         {152, &ACC_U1::LoadSignedDeviceIdentifierCacheForNintendoAccount, "LoadSignedDeviceIdentifierCacheForNintendoAccount"},
         {190, &ACC_U1::GetUserLastOpenedApplication, "GetUserLastOpenedApplication"},
         {191, &ACC_U1::ActivateOpenContextHolder, "ActivateOpenContextHolder"},
+        {401, &ACC_U1::GetPinCodeLength, "GetPinCodeLength"},
         {997, &ACC_U1::DebugInvalidateTokenCacheForUser, "DebugInvalidateTokenCacheForUser"},
         {998, &ACC_U1::DebugSetUserStateClose, "DebugSetUserStateClose"},
         {999, &ACC_U1::DebugSetUserStateOpen, "DebugSetUserStateOpen"},

--- a/src/core/hle/service/am/service/common_state_getter.cpp
+++ b/src/core/hle/service/am/service/common_state_getter.cpp
@@ -71,6 +71,8 @@ ICommonStateGetter::ICommonStateGetter(Core::System& system_, std::shared_ptr<Ap
         {502, nullptr, "IsSleepEnabled"},
         {503, nullptr, "IsDisablingSleepSuppressed"},
         {600, nullptr, "GetLaunchStorageInfoForDebug"},
+        {610, D<&ICommonStateGetter::Unknown610>, "Unknown610"}, //21.0.0+
+        {611, D<&ICommonStateGetter::Unknown611>, "Unknown611"}, //22.0.0+
         {700, nullptr, "ExtendSaveData"},
         {701, nullptr, "GetSaveDataSize"},
         {800, nullptr, "CreateCacheStorage"},
@@ -333,6 +335,16 @@ Result ICommonStateGetter::GetHealthWarningDisappearedSystemEvent(
     OutCopyHandle<Kernel::KReadableEvent> out_event) {
     LOG_DEBUG(Service_AM, "called");
     *out_event = m_applet->health_warning_disappeared_system_event.GetHandle();
+    R_SUCCEED();
+}
+
+Result ICommonStateGetter::Unknown610() {
+    LOG_WARNING(Service_AM, "(STUBBED) called");
+    R_SUCCEED();
+}
+
+Result ICommonStateGetter::Unknown611() {
+    LOG_WARNING(Service_AM, "(STUBBED) called");
     R_SUCCEED();
 }
 

--- a/src/core/hle/service/am/service/common_state_getter.h
+++ b/src/core/hle/service/am/service/common_state_getter.h
@@ -58,6 +58,8 @@ private:
     Result GetFriendInvitationStorageChannelEvent(OutCopyHandle<Kernel::KReadableEvent> out_event);
     Result GetNotificationStorageChannelEvent(OutCopyHandle<Kernel::KReadableEvent> out_event);
     Result GetHealthWarningDisappearedSystemEvent(OutCopyHandle<Kernel::KReadableEvent> out_event);
+    Result Unknown610();
+    Result Unknown611();
 
     void SetCpuBoostMode(HLERequestContext& ctx);
 

--- a/src/core/hle/service/am/service/library_applet_creator.cpp
+++ b/src/core/hle/service/am/service/library_applet_creator.cpp
@@ -108,9 +108,7 @@ std::shared_ptr<ILibraryAppletAccessor> CreateGuestApplet(Core::System& system,
 
     // We allow any firmware generation to be loaded as a guest process if possible.
     // If the emulator lacks the necessary keys, it will fail later and fallback to a stub.
-    const u8 min_gen = 1;
-    const u8 max_gen = 255;
-    auto process = CreateProcess(system, program_id, min_gen, max_gen);
+    auto process = CreateProcess(system, program_id, 14, 22);
     if (!process) {
         // Couldn't initialize the guest process
         return {};

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -33,6 +33,7 @@ public:
             {20100, &PlayReport::SaveSystemReport, "SaveSystemReport"},
             {20101, &PlayReport::SaveSystemReportWithUser, "SaveSystemReportWithUser"},
             {20102, &PlayReport::SaveSystemReport2, "SaveSystemReport2"},
+            {20103, &PlayReport::SaveSystemReportWithUser2, "SaveSystemReportWithUser2"},
             {20200, &PlayReport::SetOperationMode, "SetOperationMode"},
             {30100, &PlayReport::ClearStorage, "ClearStorage"},
             {30200, &PlayReport::ClearStatistics, "ClearStatistics"},
@@ -158,6 +159,30 @@ private:
         const auto& reporter{system.GetReporter()};
         reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data1, data2},
                                 std::nullopt, user_id);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    // (21.0.0+) buffers: [0x9 (X), 0x5 (A)], inbytes: 0x20
+    void SaveSystemReportWithUser2(HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        // 21.0.0+: field0 (u64), user_id (u128), title_id (u64)
+        const auto field0 = rp.PopRaw<u64>();
+        const auto user_id = rp.PopRaw<u128>();
+        const auto title_id = rp.PopRaw<u64>();
+
+        const auto data_x = ctx.ReadBufferX(0);
+        const auto data_a = ctx.ReadBufferA(0);
+
+        Common::UUID uuid{};
+        std::memcpy(uuid.uuid.data(), user_id.data(), sizeof(Common::UUID));
+
+        LOG_DEBUG(Service_PREPO, "called, user_id={}, field0={:016X}, title_id={:016X}, data_a_size={}, data_x_size={}", uuid.FormattedString(), field0, title_id, data_a.size(), data_x.size());
+
+        const auto& reporter{system.GetReporter()};
+        reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data_a, data_x}, std::nullopt, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);

--- a/src/core/hle/service/set/settings_types.h
+++ b/src/core/hle/service/set/settings_types.h
@@ -395,8 +395,13 @@ struct AccountNotificationSettings {
     FriendPresenceOverlayPermission friend_invitation_permission;
     INSERT_PADDING_BYTES(0x2);
 };
-static_assert(sizeof(AccountNotificationSettings) == 0x18,
-              "AccountNotificationSettings is an invalid size");
+static_assert(sizeof(AccountNotificationSettings) == 0x18, "AccountNotificationSettings is an invalid size");
+
+/// This is nn::settings::system::AccountUserSettings (stubbed)
+struct AccountUserSettings {
+    std::array<u8, 0x40> data;
+};
+static_assert(sizeof(AccountUserSettings) == 0x40, "AccountUserSettings is an invalid size");
 
 /// This is nn::settings::factory::BatteryLot
 struct BatteryLot {

--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -311,6 +311,9 @@ ISystemSettingsServer::ISystemSettingsServer(Core::System& system_)
         {301, C<&ISystemSettingsServer::Unknown301>, "Unknown301"}, // [20.0.0+]
         {306, C<&ISystemSettingsServer::Unknown306>, "Unknown306"}, // [20.0.0+]
         {307, C<&ISystemSettingsServer::Unknown307>, "Unknown307"}, // [20.0.0+]
+        {319, C<&ISystemSettingsServer::GetAccountUserSettings>, "GetAccountUserSettings"}, //21.0.0+
+        {320, nullptr, "SetAccountUserSettings"}, //21.0.0+
+        {321, C<&ISystemSettingsServer::GetDefaultAccountUserSettings>, "GetDefaultAccountUserSettings"}, //21.0.0+
     };
     // clang-format on
 
@@ -1452,6 +1455,21 @@ Result ISystemSettingsServer::Unknown306() {
 
 Result ISystemSettingsServer::Unknown307() {
     LOG_WARNING(Service_SET, "(STUBBED) called Unknown307 [20.0.0+]");
+    R_SUCCEED();
+}
+
+Result ISystemSettingsServer::GetAccountUserSettings(Out<u32> out_count, OutLargeData<AccountUserSettings, BufferAttr_HipcMapAlias> out_settings) {
+    LOG_WARNING(Service_SET, "(STUBBED) called");
+
+    *out_count = 0;
+    *out_settings = {};
+    R_SUCCEED();
+}
+
+Result ISystemSettingsServer::GetDefaultAccountUserSettings(Out<AccountUserSettings> out_settings) {
+    LOG_WARNING(Service_SET, "(STUBBED) called");
+
+    *out_settings = {};
     R_SUCCEED();
 }
 

--- a/src/core/hle/service/set/system_settings_server.h
+++ b/src/core/hle/service/set/system_settings_server.h
@@ -165,6 +165,8 @@ public:
     Result Unknown301(); // [20.0.0+]
     Result Unknown306(); // [20.0.0+]
     Result Unknown307(); // [20.0.0+]
+    Result GetAccountUserSettings(Out<u32> out_count, OutLargeData<AccountUserSettings, BufferAttr_HipcMapAlias> out_settings);
+    Result GetDefaultAccountUserSettings(Out<AccountUserSettings> out_settings);
 
 private:
     bool LoadSettingsFile(std::filesystem::path& path, auto&& default_func);


### PR DESCRIPTION
doesnt make qlaunch work, but atleast games shouldn't just outright crash

see
https://git.eden-emu.dev/eden-emu/eden/pulls/3761
https://github.com/Atmosphere-NX/Atmosphere/pull/2744
