### PR TITLE
common/cpu_detect: Remove SSE/SSE2/FMA4 detection

### DIFF
--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -416,7 +416,7 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
         } else if (caps.avx2) {
             cpu_string += '2';
         }
-        if (caps.fma || caps.fma4) {
+        if (caps.fma) {
             cpu_string += " | FMA";
         }
     }

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -103,8 +103,6 @@ static CPUCaps DetectCPUCapabilities() {
     // DetectCPUCapabilities family and other miscellaneous features
     if (max_std_fn >= 1) {
         __cpuid(cpu_id, 0x00000001);
-        caps.sse = Common::Bit<25>(cpu_id[3]);
-        caps.sse2 = Common::Bit<26>(cpu_id[3]);
         caps.sse3 = Common::Bit<0>(cpu_id[2]);
         caps.pclmulqdq = Common::Bit<1>(cpu_id[2]);
         caps.ssse3 = Common::Bit<9>(cpu_id[2]);
@@ -167,7 +165,6 @@ static CPUCaps DetectCPUCapabilities() {
         // Check for more features
         __cpuid(cpu_id, 0x80000001);
         caps.lzcnt = Common::Bit<5>(cpu_id[2]);
-        caps.fma4 = Common::Bit<16>(cpu_id[2]);
         caps.monitorx = Common::Bit<29>(cpu_id[2]);
     }
 

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -36,8 +36,6 @@ struct CPUCaps {
     u32 crystal_frequency;
     u64 tsc_frequency; // Derived from the above three values
 
-    bool sse : 1;
-    bool sse2 : 1;
     bool sse3 : 1;
     bool ssse3 : 1;
     bool sse4_1 : 1;
@@ -59,7 +57,6 @@ struct CPUCaps {
     bool bmi2 : 1;
     bool f16c : 1;
     bool fma : 1;
-    bool fma4 : 1;
     bool gfni : 1;
     bool invariant_tsc : 1;
     bool lzcnt : 1;


### PR DESCRIPTION
Removes detection for the SSE, SSE2 and FMA4 extensions. They are unused, SSE/SSE2 are always true for x64 and FMA4 is an deprecated AMD exclusive extension. Code cleanup