### PR TITLE
feat: Disable Setup Wizard (for now)

### DIFF
--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -480,6 +480,7 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
     // Process events to ensure main window is fully rendered
     QApplication::processEvents();
 
+    /*
     // Defer the first-time setup check until after the main window is fully constructed.
     if (UISettings::values.first_start.GetValue()) {
         LOG_INFO(Frontend, "Scheduling first-time setup check.");
@@ -534,6 +535,8 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
     } else {
         LOG_INFO(Frontend, "Skipping setup wizard - first_start is false");
     }
+    */
+
 
     if (has_broken_vulkan) {
         UISettings::values.has_broken_vulkan = true;

--- a/src/citron/uisettings.h
+++ b/src/citron/uisettings.h
@@ -113,7 +113,7 @@ namespace UISettings {
                 true,
                 true};
 
-                Setting<bool> first_start{linkage, true, "firstStart", Category::Ui};
+                Setting<bool> first_start{linkage, false, "firstStart", Category::Ui};
                 Setting<bool> pause_when_in_background{linkage,
                     false,
                     "pauseWhenInBackground",


### PR DESCRIPTION
Commented out the stuff for it in main.cpp just incase someone ever had first time set to true, and changed the default of true to false to prevent the Setup Wizard from ever activating. Can easily be un-commented out & fixed for the future, as the setup wizard currently is broken and hasn't been fixed for a while.