### PR TITLE
fix: Compiler Issue w/ Linux/macOS

### DIFF
--- a/src/citron/multiplayer/chat_room.h
+++ b/src/citron/multiplayer/chat_room.h
@@ -37,7 +37,6 @@ class ChatRoom;
 namespace Network {
 struct ChatEntry;
 struct StatusMessageEntry;
-struct RoomInformation;
 }
 
 class QPushButton;


### PR DESCRIPTION
Removed the struct for RoomInformation since it's handled by another file.