### PR TITLE
Fix: make unity builds for linux work

### DIFF
--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -617,11 +617,12 @@ endif()
 
 create_target_directory_groups(citron)
 
-# [UNITY-FIX] Keep startup_checks.cpp out of UNIX unity batches.
-# It can leak X11 macros into later Qt-heavy sources.
+
+# [UNITY-FIX] Skip unity build for X11-polluted files.
 if(UNIX AND CMAKE_UNITY_BUILD)
     set_source_files_properties(
-        "${CMAKE_CURRENT_SOURCE_DIR}/startup_checks.cpp"
+        startup_checks.cpp compatdb.cpp setup_wizard.cpp
+        mod_manager/mod_service.cpp mod_manager/mod_downloader_dialog.cpp
         PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
     )
 endif()


### PR DESCRIPTION
avoids more X11 macro conflicts in unity batches by excluding stuff from the unity batches on unix builds