### PR TITLE
android: Update all android-build dependencies

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -1,19 +1,15 @@
 // SPDX-FileCopyrightText: 2023 citron Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import android.annotation.SuppressLint
 import kotlin.collections.setOf
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
-import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("kotlin-parcelize")
     kotlin("plugin.serialization") version "1.9.20"
     id("androidx.navigation.safeargs.kotlin")
     id("org.jlleitschuh.gradle.ktlint") version "11.4.0"
-    id("com.github.triplet.play") version "3.8.6"
 }
 
 /**
@@ -27,20 +23,18 @@ val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toIn
 android {
     namespace = "org.citron.citron_emu"
 
-    compileSdkVersion = "android-35"
+    compileSdk = 36
     ndkVersion = "26.1.10909125"
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
+        resValues = true
     }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     packaging {
@@ -56,7 +50,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId = "org.citron.citron_emu"
         minSdk = 30
-        targetSdk = 35
+        targetSdk = 36
         versionName = getGitVersion()
 
         versionCode = if (System.getenv("AUTO_VERSIONED") == "true") {
@@ -66,7 +60,7 @@ android {
         }
 
         ndk {
-            @SuppressLint("ChromeOsAbiSupport")
+            //noinspection ChromeOsAbiSupport
             abiFilters += listOf("arm64-v8a")
         }
 
@@ -107,7 +101,7 @@ android {
             isMinifyEnabled = true
             isDebuggable = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
         }
@@ -121,7 +115,7 @@ android {
             isMinifyEnabled = true
             isDebuggable = true
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
             versionNameSuffix = "-relWithDebInfo"
@@ -191,15 +185,6 @@ tasks.create<Delete>("ktlintReset") {
     delete(File(buildDir.path + File.separator + "intermediates/ktLint"))
 }
 
-val showFormatHelp = {
-    logger.lifecycle(
-        "If this check fails, please try running \"gradlew ktlintFormat\" for automatic " +
-                "codestyle fixes"
-    )
-}
-tasks.getByPath("ktlintKotlinScriptCheck").doFirst { showFormatHelp.invoke() }
-tasks.getByPath("ktlintMainSourceSetCheck").doFirst { showFormatHelp.invoke() }
-tasks.getByPath("loadKtlintReporters").dependsOn("ktlintReset")
 
 ktlint {
     version.set("0.47.1")
@@ -217,34 +202,26 @@ ktlint {
     }
 }
 
-play {
-    val keyPath = System.getenv("SERVICE_ACCOUNT_KEY_PATH")
-    if (keyPath != null) {
-        serviceAccountCredentials.set(File(keyPath))
-    }
-    track.set(System.getenv("STORE_TRACK") ?: "internal")
-    releaseStatus.set(ReleaseStatus.COMPLETED)
-}
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.recyclerview:recyclerview:1.3.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.fragment:fragment-ktx:1.6.1")
-    implementation("androidx.documentfile:documentfile:1.0.1")
-    implementation("com.google.android.material:material:1.9.0")
+    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.recyclerview:recyclerview:1.4.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
+    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("androidx.documentfile:documentfile:1.1.0")
+    implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.preference:preference-ktx:1.2.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
-    implementation("io.coil-kt:coil:2.2.2")
-    implementation("androidx.core:core-splashscreen:1.0.1")
-    implementation("androidx.window:window:1.2.0-beta03")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.4")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.10.0")
+    implementation("io.coil-kt:coil:2.7.0")
+    implementation("androidx.core:core-splashscreen:1.2.0")
+    implementation("androidx.window:window:1.5.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.9.7")
+    implementation("androidx.navigation:navigation-ui-ktx:2.9.7")
     implementation("info.debatty:java-string-similarity:2.0.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 }
 
 fun runGitCommand(command: List<String>): String {

--- a/src/android/app/src/main/java/org/citron/citron_emu/ui/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/ui/GamesFragment.kt
@@ -74,7 +74,7 @@ class GamesFragment : Fragment() {
             setProgressBackgroundColorSchemeColor(
                 MaterialColors.getColor(
                     binding.swipeRefresh,
-                    com.google.android.material.R.attr.colorPrimary
+                    com.google.android.material.R.attr.colorOnPrimary
                 )
             )
             setColorSchemeColors(

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -3,9 +3,9 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
-    id("com.android.library") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
+    id("com.android.application") version "9.0.1" apply false
+    id("com.android.library") version "9.0.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 tasks.register("clean").configure {
@@ -17,6 +17,6 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.6.0")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.9.7")
     }
 }

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -14,7 +14,9 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 kotlin.parallel.tasks.in.project=true
-android.defaults.buildfeatures.buildconfig=true
 
 # Android Gradle plugin 8.0.2
 android.suppressUnsupportedCompileSdk=34
+
+# cmake verbose output
+android.native.buildOutput=verbose

--- a/src/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/android/settings.gradle.kts
+++ b/src/android/settings.gradle.kts
@@ -8,6 +8,9 @@ pluginManagement {
         mavenCentral()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {


### PR DESCRIPTION
Updates all deps on the kotlin / android side of things and makes cmake output verbose when building.

Might complicate lowering the minimum SDK since all deps are the latest.