### PR TITLE
android: fix firmware detection on app restart

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -724,6 +724,9 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_isFirmwareAvailable(JNIEnv* e
         return false;
     }
 
+    // refresh to fix firmware detection on app restart
+    bis_system->Refresh();
+
     // Query an applet to see if it's available
     auto applet_nca =
         bis_system->GetEntry(0x010000000000100Dull, FileSys::ContentRecordType::Program);


### PR DESCRIPTION
Workaround for the issue with the app "forgetting" the firmware installation on app restart.