### PR TITLE
fix: Unity build fix

### DIFF
--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -632,10 +632,3 @@ if (CITRON_USE_PRECOMPILED_HEADERS)
 endif()
 
 create_target_directory_groups(citron)
-
-if(UNIX AND CMAKE_UNITY_BUILD)
-    set_source_files_properties(
-        startup_checks.cpp compatdb.cpp setup_wizard.cpp
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
-    )
-endif()


### PR DESCRIPTION
remove the exclusion properties, so that everything gets included in one big happy unity file for unity builds