### PR TITLE
Unity clang hidden visibility flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,13 @@ else()
             -Werror=implicit-fallthrough
             -Werror=type-limits
         )
+        # apply hidden visibility to unity clang builds in the internal src subtree only.
+        if(ENABLE_UNITY_BUILD)
+            add_compile_options(
+                "$<$<COMPILE_LANGUAGE:C,CXX>:-fvisibility=hidden>"
+                "$<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>"
+            )
+        endif()
     endif()
 
     if (ARCHITECTURE_x86_64)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,7 +143,7 @@ else()
             -Werror=type-limits
         )
         # apply hidden visibility to unity clang builds in the internal src subtree only.
-        if(ENABLE_UNITY_BUILD)
+        if(ENABLE_UNITY_BUILD AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT APPLE AND NOT ANDROID)
             add_compile_options(
                 "$<$<COMPILE_LANGUAGE:C,CXX>:-fvisibility=hidden>"
                 "$<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>"


### PR DESCRIPTION
Apply -fvisibility=hidden and -fvisibility-inlines-hidden to non-*nix unity builds. This probably doesn't change much, but it might help performance a little by encouraging better inlining decisions at compile time.