### PR TITLE
build: No debug ffmpeg dlls in release builds for MSVC

### DIFF
--- a/CMakeModules/CopyCitronFFmpegDeps.cmake
+++ b/CMakeModules/CopyCitronFFmpegDeps.cmake
@@ -5,36 +5,68 @@ function(copy_citron_FFmpeg_deps target_dir)
     include(WindowsCopyFiles)
     set(DLL_DEST "$<TARGET_FILE_DIR:${target_dir}>/")
 
-    if(NOT DEFINED FFmpeg_LIBRARY_DIR OR NOT EXISTS "${FFmpeg_LIBRARY_DIR}")
-        message(WARNING
-            "FFmpeg_LIBRARY_DIR ('${FFmpeg_LIBRARY_DIR}') is not set or does not exist "
-            "— skipping FFmpeg DLL copy. The build will succeed but the DLLs will be "
-            "absent from the output directory.")
-        return()
-    endif()
-
     if(DEFINED FFmpeg_PATH AND EXISTS "${FFmpeg_PATH}/requirements.txt")
-        # Bundled pre-built FFmpeg (MinGW / Clangtron path).
+        # ── Bundled pre-built FFmpeg (MinGW / Clangtron path) ────────────────
         # The archive ships a requirements.txt with the exact DLL filenames.
+        if(NOT DEFINED FFmpeg_LIBRARY_DIR OR NOT EXISTS "${FFmpeg_LIBRARY_DIR}")
+            message(WARNING
+                "FFmpeg_LIBRARY_DIR ('${FFmpeg_LIBRARY_DIR}') is not set or does not "
+                "exist — skipping FFmpeg DLL copy.")
+            return()
+        endif()
         file(READ "${FFmpeg_PATH}/requirements.txt" FFmpeg_REQUIRED_DLLS)
         string(STRIP "${FFmpeg_REQUIRED_DLLS}" FFmpeg_REQUIRED_DLLS)
-        windows_copy_files(${target_dir} ${FFmpeg_LIBRARY_DIR} ${DLL_DEST} ${FFmpeg_REQUIRED_DLLS})
+        windows_copy_files(${target_dir} ${FFmpeg_LIBRARY_DIR} ${DLL_DEST}
+            ${FFmpeg_REQUIRED_DLLS})
+
     else()
-        # vcpkg (MSVC) path: DLL names are versioned, e.g. avcodec-61.dll.
-        # Glob for each of the four components at configure time; vcpkg has
-        # already installed them into FFmpeg_LIBRARY_DIR before CMake runs.
-        foreach(_ffmpeg_comp avcodec avfilter avutil swscale)
-            file(GLOB _ffmpeg_dll LIST_DIRECTORIES false
-                "${FFmpeg_LIBRARY_DIR}/${_ffmpeg_comp}-*.dll")
-            if(_ffmpeg_dll)
-                get_filename_component(_ffmpeg_dll_name "${_ffmpeg_dll}" NAME)
-                windows_copy_files(${target_dir} "${FFmpeg_LIBRARY_DIR}"
-                    "${DLL_DEST}" "${_ffmpeg_dll_name}")
+        # ── vcpkg (MSVC) path ────────────────────────────────────────────────
+        # DLL names are versioned (e.g. avcodec-62.dll) and differ between
+        # release and debug trees only by directory, not filename.
+        #
+        # The source directory is chosen at *build* time via a generator
+        # expression so that a Debug build copies from debug/bin/ and a Release
+        # build copies from bin/.  This is why FFmpeg_LIBRARY_DIR_DEBUG is also
+        # exported from externals/ffmpeg/CMakeLists.txt.
+
+        if(NOT DEFINED FFmpeg_LIBRARY_DIR OR NOT EXISTS "${FFmpeg_LIBRARY_DIR}")
+            message(WARNING
+                "FFmpeg_LIBRARY_DIR ('${FFmpeg_LIBRARY_DIR}') is not set or does not "
+                "exist — skipping FFmpeg DLL copy.")
+            return()
+        endif()
+
+        # If no debug dir was exported (shouldn't happen, but be safe) fall
+        # back to the release dir so at least Release builds work.
+        if(NOT DEFINED FFmpeg_LIBRARY_DIR_DEBUG OR NOT EXISTS "${FFmpeg_LIBRARY_DIR_DEBUG}")
+            set(FFmpeg_LIBRARY_DIR_DEBUG "${FFmpeg_LIBRARY_DIR}")
+        endif()
+
+        # Collect the versioned DLL names from the release tree at configure
+        # time.  The same filenames exist in the debug tree.
+        set(_ffmpeg_dll_names "")
+        foreach(_comp avcodec avfilter avutil swscale)
+            file(GLOB _found LIST_DIRECTORIES false
+                "${FFmpeg_LIBRARY_DIR}/${_comp}-*.dll")
+            if(_found)
+                get_filename_component(_name "${_found}" NAME)
+                list(APPEND _ffmpeg_dll_names "${_name}")
             else()
                 message(WARNING
-                    "FFmpeg DLL for component '${_ffmpeg_comp}' not found in "
-                    "'${FFmpeg_LIBRARY_DIR}' — it will be missing from the output directory.")
+                    "FFmpeg DLL for '${_comp}' not found in '${FFmpeg_LIBRARY_DIR}' "
+                    "— it will be missing from the output directory.")
             endif()
         endforeach()
+
+        if(NOT _ffmpeg_dll_names)
+            return()
+        endif()
+
+        # Generator expression selects the correct source tree per config.
+        set(_src_dir
+            "$<IF:$<CONFIG:Debug>,${FFmpeg_LIBRARY_DIR_DEBUG},${FFmpeg_LIBRARY_DIR}>")
+
+        windows_copy_files(${target_dir} "${_src_dir}" "${DLL_DEST}"
+            ${_ffmpeg_dll_names})
     endif()
 endfunction(copy_citron_FFmpeg_deps)

--- a/externals/ffmpeg/CMakeLists.txt
+++ b/externals/ffmpeg/CMakeLists.txt
@@ -265,15 +265,23 @@ elseif(WIN32)
                 "vcpkg install has completed successfully.")
         endif()
 
-        # Derive the DLL directory from the first .lib in FFmpeg_LIBRARIES.
-        # vcpkg layout:  vcpkg_installed/<triplet>/lib/avcodec.lib
-        #                vcpkg_installed/<triplet>/bin/avcodec-XX.dll
-        # CopyCitronFFmpegDeps.cmake reads FFmpeg_LIBRARY_DIR to locate DLLs.
-        list(GET FFmpeg_LIBRARIES 0 _ffmpeg_first_lib)
-        get_filename_component(_ffmpeg_lib_dir "${_ffmpeg_first_lib}" DIRECTORY)
-        get_filename_component(_ffmpeg_install_root "${_ffmpeg_lib_dir}" DIRECTORY)
-        set(FFmpeg_LIBRARY_DIR "${_ffmpeg_install_root}/bin"
-            CACHE PATH "Path to FFmpeg DLL directory" FORCE)
+        # Derive the DLL directories from the include path.
+        # vcpkg layout:
+        #   <triplet>/include/libavcodec/avcodec.h   ← always release tree
+        #   <triplet>/bin/avcodec-NN.dll             ← release DLLs
+        #   <triplet>/debug/bin/avcodec-NN.dll       ← debug DLLs
+        #
+        # Using the include path (not the lib path) as the anchor avoids the
+        # config-unaware find_library() problem: for a multi-config generator
+        # CMAKE_BUILD_TYPE is undefined at configure time, so vcpkg injects both
+        # the release and debug lib dirs into CMAKE_LIBRARY_PATH and find_library()
+        # may return the debug .lib.  The include dir is always in the release
+        # tree regardless of which lib was found.
+        get_filename_component(_vcpkg_triplet_root "${FFmpeg_INCLUDE_avcodec}" DIRECTORY)
+        set(FFmpeg_LIBRARY_DIR       "${_vcpkg_triplet_root}/bin"
+            CACHE PATH "Path to FFmpeg release DLLs" FORCE)
+        set(FFmpeg_LIBRARY_DIR_DEBUG "${_vcpkg_triplet_root}/debug/bin"
+            CACHE PATH "Path to FFmpeg debug DLLs"   FORCE)
 
         # Promote to CACHE and PARENT_SCOPE so video_core and the copy helper
         # can read these variables regardless of CMake call depth.
@@ -285,7 +293,8 @@ elseif(WIN32)
         set(FFmpeg_INCLUDE_DIR "${FFmpeg_INCLUDE_DIR}" PARENT_SCOPE)
         set(FFmpeg_LIBRARIES   "${FFmpeg_LIBRARIES}"   PARENT_SCOPE)
         set(FFmpeg_LDFLAGS     ""                      PARENT_SCOPE)
-        set(FFmpeg_LIBRARY_DIR "${FFmpeg_LIBRARY_DIR}" PARENT_SCOPE)
+        set(FFmpeg_LIBRARY_DIR       "${FFmpeg_LIBRARY_DIR}"       PARENT_SCOPE)
+        set(FFmpeg_LIBRARY_DIR_DEBUG "${FFmpeg_LIBRARY_DIR_DEBUG}" PARENT_SCOPE)
     else()
         # ── MinGW / Clangtron (llvm-mingw) path ──────────────────────────────
         # For Clangtron cross-builds, rebuild_ffmpeg_pthread_free() in


### PR DESCRIPTION
Encourage CMake to choose correctly between debug and release builds of ffmpeg.