### PR TITLE
fix: video_core: clear big_page_continuous bit on Unmap and MapSparse

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -165,6 +165,9 @@ GPUVAddr MemoryManager::BigPageTableOp(GPUVAddr gpu_addr, [[maybe_unused]] DAddr
                 return true;
             })();
             SetBigPageContinuous(index, is_continuous);
+        } else {
+            const auto index = PageEntryIndex<true>(current_gpu_addr);
+            SetBigPageContinuous(index, false);
         }
         remaining_size -= big_page_size;
     }


### PR DESCRIPTION
edit: fixed stupid markdown stuff

BigPageTableOp only called SetBigPageContinuous inside the Mapped-only
if constexpr block, leaving the bit set when Free or Reserved paths ran.
A stale true value after unmap could cause ReadBlockImpl to call
GetPointer on invalidated device memory and pass null to memcpy.

Crash dump analysis from Tomodachi Life on clangtron-windows provided by SolarRift !?
https://discord.com/channels/1479842146491306205/1495691799304470608/1496986827696115793
[bruh'.txt](https://github.com/user-attachments/files/27035969/bruh.txt)

Shows 
FAILURE_BUCKET_ID: INVALID_POINTER_READ_c0000005_ucrtbase.dll!memcpy
ExceptionCode:     c0000005 (Access violation)
Attempt to read from address 0000000000000000

STACK_TEXT:
  ucrtbase!memcpy+0x240
  citron!Tegra::MemoryManager::MemoryOperation<true, ...>+0x133
    (inlined) citron!Tegra::MemoryManager::ReadBlockImpl<true>
    (inlined) citron!Tegra::MemoryManager::ReadBlock
    (inlined) citron!Core::Memory::GuestMemory<...>::Read
  citron!Tegra::DmaPusher::Step+0x296
    (inlined) citron!Tegra::DmaPusher::DispatchCalls
  citron!Tegra::Control::Scheduler::Push+0x1ed
  citron!VideoCommon::GPUThread::RunThread+0x47e


The register state at the crash confirms the `src` pointer passed to `memcpy` was null: `rcx=0x000002513e1f9b60` + `rdx=0xfffffdaec1e064a0` = `0x0`.

The fix:
Clear the continuity bit on unmap and sparse-map so that a stale true value from a previous mapping cannot cause a null de-reference if this big page is later re-mapped and GetPointer returns null before the actual memory is ready.