### PR TITLE
Improve macOS Vulkan startup and networking compatibility

### DIFF
--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -529,7 +529,7 @@ if (TARGET LibArchive::LibArchive)
 endif()
 
 target_link_libraries(citron PRIVATE Vulkan::Headers)
-if (NOT WIN32 AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     target_link_libraries(citron PRIVATE Qt6::GuiPrivate)
 endif()
 if (UNIX AND NOT APPLE)

--- a/src/citron/applets/qt_controller.cpp
+++ b/src/citron/applets/qt_controller.cpp
@@ -271,8 +271,8 @@ void QtControllerSelectorDialog::LoadConfiguration() {
             controller->IsConnected(true) || (index == 0 && handheld->IsConnected(true));
         player_groupboxes[index]->setChecked(connected);
         connected_controller_checkboxes[index]->setChecked(connected);
-        emulated_controllers[index]->setCurrentIndex(
-            GetIndexFromControllerType(controller->GetNpadStyleIndex(true), index));
+        emulated_controllers[index]->setCurrentIndex(GetIndexFromSettingsControllerType(
+            Settings::values.players.GetValue()[index].controller_type, index));
     }
 
     UpdateDockedState(handheld->IsConnected(true));
@@ -456,34 +456,44 @@ void QtControllerSelectorDialog::SetEmulatedControllers(std::size_t player_index
     pairs.clear();
     emulated_controllers[player_index]->clear();
 
-    const auto add_item = [&](Core::HID::NpadStyleIndex controller_type,
-                              const QString& controller_name) {
-        pairs.emplace_back(emulated_controllers[player_index]->count(), controller_type);
+    const auto add_item = [&](Core::HID::NpadStyleIndex npad_style,
+                              Settings::ControllerType settings_type, const QString& controller_name) {
+        pairs.emplace_back(emulated_controllers[player_index]->count(), npad_style, settings_type);
         emulated_controllers[player_index]->addItem(controller_name);
     };
 
     if (npad_style_set.fullkey == 1) {
-        add_item(Core::HID::NpadStyleIndex::Fullkey, tr("Pro Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::ProController,
+                 tr("Pro Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::Xbox,
+                 tr("Xbox Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::DualSense,
+                 tr("DualSense (PS5)"));
     }
 
     if (npad_style_set.joycon_dual == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconDual, tr("Dual Joycons"));
+        add_item(Core::HID::NpadStyleIndex::JoyconDual, Settings::ControllerType::DualJoyconDetached,
+                 tr("Dual Joycons"));
     }
 
     if (npad_style_set.joycon_left == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconLeft, tr("Left Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconLeft, Settings::ControllerType::LeftJoycon,
+                 tr("Left Joycon"));
     }
 
     if (npad_style_set.joycon_right == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconRight, tr("Right Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconRight, Settings::ControllerType::RightJoycon,
+                 tr("Right Joycon"));
     }
 
     if (player_index == 0 && npad_style_set.handheld == 1) {
-        add_item(Core::HID::NpadStyleIndex::Handheld, tr("Handheld"));
+        add_item(Core::HID::NpadStyleIndex::Handheld, Settings::ControllerType::Handheld,
+                 tr("Handheld"));
     }
 
     if (npad_style_set.gamecube == 1) {
-        add_item(Core::HID::NpadStyleIndex::GameCube, tr("GameCube Controller"));
+        add_item(Core::HID::NpadStyleIndex::GameCube, Settings::ControllerType::GameCube,
+                 tr("GameCube Controller"));
     }
 
     // Disable all unsupported controllers
@@ -492,23 +502,28 @@ void QtControllerSelectorDialog::SetEmulatedControllers(std::size_t player_index
     }
 
     if (npad_style_set.palma == 1) {
-        add_item(Core::HID::NpadStyleIndex::Pokeball, tr("Poke Ball Plus"));
+        add_item(Core::HID::NpadStyleIndex::Pokeball, Settings::ControllerType::Pokeball,
+                 tr("Poke Ball Plus"));
     }
 
     if (npad_style_set.lark == 1) {
-        add_item(Core::HID::NpadStyleIndex::NES, tr("NES Controller"));
+        add_item(Core::HID::NpadStyleIndex::NES, Settings::ControllerType::NES,
+                 tr("NES Controller"));
     }
 
     if (npad_style_set.lucia == 1) {
-        add_item(Core::HID::NpadStyleIndex::SNES, tr("SNES Controller"));
+        add_item(Core::HID::NpadStyleIndex::SNES, Settings::ControllerType::SNES,
+                 tr("SNES Controller"));
     }
 
     if (npad_style_set.lagoon == 1) {
-        add_item(Core::HID::NpadStyleIndex::N64, tr("N64 Controller"));
+        add_item(Core::HID::NpadStyleIndex::N64, Settings::ControllerType::N64,
+                 tr("N64 Controller"));
     }
 
     if (npad_style_set.lager == 1) {
-        add_item(Core::HID::NpadStyleIndex::SegaGenesis, tr("Sega Genesis"));
+        add_item(Core::HID::NpadStyleIndex::SegaGenesis, Settings::ControllerType::SegaGenesis,
+                 tr("Sega Genesis"));
     }
 }
 
@@ -517,27 +532,49 @@ Core::HID::NpadStyleIndex QtControllerSelectorDialog::GetControllerTypeFromIndex
     const auto& pairs = index_controller_type_pairs[player_index];
 
     const auto it = std::find_if(pairs.begin(), pairs.end(),
-                                 [index](const auto& pair) { return pair.first == index; });
+                                 [index](const auto& entry) { return std::get<0>(entry) == index; });
 
     if (it == pairs.end()) {
         return Core::HID::NpadStyleIndex::Fullkey;
     }
 
-    return it->second;
+    return std::get<1>(*it);
 }
 
-int QtControllerSelectorDialog::GetIndexFromControllerType(Core::HID::NpadStyleIndex type,
-                                                           std::size_t player_index) const {
+Settings::ControllerType QtControllerSelectorDialog::GetSettingsControllerTypeFromIndex(
+    int index, std::size_t player_index) const {
     const auto& pairs = index_controller_type_pairs[player_index];
 
     const auto it = std::find_if(pairs.begin(), pairs.end(),
-                                 [type](const auto& pair) { return pair.second == type; });
+                                 [index](const auto& entry) { return std::get<0>(entry) == index; });
 
     if (it == pairs.end()) {
-        return 0;
+        return Settings::ControllerType::ProController;
     }
 
-    return it->first;
+    return std::get<2>(*it);
+}
+
+int QtControllerSelectorDialog::GetIndexFromSettingsControllerType(Settings::ControllerType type,
+                                                                   std::size_t player_index) const {
+    const auto& pairs = index_controller_type_pairs[player_index];
+
+    const auto it = std::find_if(pairs.begin(), pairs.end(),
+                                 [type](const auto& entry) { return std::get<2>(entry) == type; });
+
+    if (it != pairs.end()) {
+        return std::get<0>(*it);
+    }
+
+    const auto it_pro =
+        std::find_if(pairs.begin(), pairs.end(), [](const auto& entry) {
+            return std::get<2>(entry) == Settings::ControllerType::ProController;
+        });
+    if (it_pro != pairs.end()) {
+        return std::get<0>(*it_pro);
+    }
+
+    return 0;
 }
 
 void QtControllerSelectorDialog::UpdateControllerIcon(std::size_t player_index) {
@@ -588,6 +625,10 @@ void QtControllerSelectorDialog::UpdateControllerIcon(std::size_t player_index) 
 
 void QtControllerSelectorDialog::UpdateControllerState(std::size_t player_index) {
     auto* controller = system.HIDCore().GetEmulatedControllerByIndex(player_index);
+
+    Settings::values.players.GetValue()[player_index].controller_type =
+        GetSettingsControllerTypeFromIndex(emulated_controllers[player_index]->currentIndex(),
+                                           player_index);
 
     const auto controller_type = GetControllerTypeFromIndex(
         emulated_controllers[player_index]->currentIndex(), player_index);

--- a/src/citron/applets/qt_controller.h
+++ b/src/citron/applets/qt_controller.h
@@ -5,7 +5,10 @@
 
 #include <array>
 #include <memory>
+#include <tuple>
+#include <vector>
 #include <QDialog>
+#include "common/settings_input.h"
 #include "core/frontend/applets/controller.h"
 
 class GMainWindow;
@@ -79,8 +82,12 @@ private:
     // Gets the Controller Type for a given controller combobox index per player.
     Core::HID::NpadStyleIndex GetControllerTypeFromIndex(int index, std::size_t player_index) const;
 
-    // Gets the controller combobox index for a given Controller Type per player.
-    int GetIndexFromControllerType(Core::HID::NpadStyleIndex type, std::size_t player_index) const;
+    Settings::ControllerType GetSettingsControllerTypeFromIndex(int index,
+                                                                std::size_t player_index) const;
+
+    // Gets combobox index for a persisted settings controller type per player.
+    int GetIndexFromSettingsControllerType(Settings::ControllerType type,
+                                         std::size_t player_index) const;
 
     // Updates the controller icons per player.
     void UpdateControllerIcon(std::size_t player_index);
@@ -147,8 +154,9 @@ private:
     // Comboboxes with a list of emulated controllers per player.
     std::array<QComboBox*, NUM_PLAYERS> emulated_controllers;
 
-    /// Pairs of emulated controller index and Controller Type enum per player.
-    std::array<std::vector<std::pair<int, Core::HID::NpadStyleIndex>>, NUM_PLAYERS>
+    /// Per player: combobox index, emulated Npad style, persisted settings controller type.
+    std::array<std::vector<std::tuple<int, Core::HID::NpadStyleIndex, Settings::ControllerType>>,
+               NUM_PLAYERS>
         index_controller_type_pairs;
 
     // Labels representing the number of connected controllers

--- a/src/citron/configuration/configure_dialog.cpp
+++ b/src/citron/configuration/configure_dialog.cpp
@@ -108,8 +108,6 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
                 &GMainWindow::RefreshGameList);
     }
 
-    Settings::SetConfiguringGlobal(true);
-
     const bool is_gamescope = UISettings::IsGamescope();
     if (is_gamescope) {
         // GameScope: Use Window flags instead of Dialog to ensure mouse focus

--- a/src/citron/configuration/configure_input_player.cpp
+++ b/src/citron/configuration/configure_input_player.cpp
@@ -774,6 +774,8 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         UpdateControllerEnabledButtons();
         UpdateControllerButtonNames();
         UpdateMotionButtons();
+        Settings::values.players.GetValue()[player_index].controller_type =
+            GetSettingsControllerTypeFromIndex(ui->comboControllerType->currentIndex());
         const Core::HID::NpadStyleIndex type =
             GetControllerTypeFromIndex(ui->comboControllerType->currentIndex());
 
@@ -896,8 +898,8 @@ void ConfigureInputPlayer::LoadConfiguration() {
         return;
     }
 
-    const int comboBoxIndex =
-        GetIndexFromControllerType(emulated_controller->GetNpadStyleIndex(true));
+    const int comboBoxIndex = GetIndexFromSettingsControllerType(
+        Settings::values.players.GetValue()[player_index].controller_type);
     ui->comboControllerType->setCurrentIndex(comboBoxIndex);
     ui->groupConnectedController->setChecked(emulated_controller->IsConnected(true));
 }
@@ -1095,37 +1097,51 @@ void ConfigureInputPlayer::UpdateUI() {
 
 void ConfigureInputPlayer::SetConnectableControllers() {
     const auto npad_style_set = hid_core.GetSupportedStyleTag();
-    index_controller_type_pairs.clear();
+    controller_combo_entries.clear();
     ui->comboControllerType->clear();
 
-    const auto add_item = [&](Core::HID::NpadStyleIndex controller_type,
-                              const QString& controller_name) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(), controller_type);
+    const auto add_item = [&](Core::HID::NpadStyleIndex npad_style,
+                              Settings::ControllerType settings_type, const QString& controller_name) {
+        controller_combo_entries.push_back(ControllerComboEntry{
+            .combo_index = ui->comboControllerType->count(),
+            .npad_style = npad_style,
+            .settings_type = settings_type,
+        });
         ui->comboControllerType->addItem(controller_name);
     };
 
     if (npad_style_set.fullkey == 1) {
-        add_item(Core::HID::NpadStyleIndex::Fullkey, tr("Pro Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::ProController,
+                 tr("Pro Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::Xbox,
+                 tr("Xbox Controller"));
+        add_item(Core::HID::NpadStyleIndex::Fullkey, Settings::ControllerType::DualSense,
+                 tr("DualSense (PS5)"));
     }
 
     if (npad_style_set.joycon_dual == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconDual, tr("Dual Joycons"));
+        add_item(Core::HID::NpadStyleIndex::JoyconDual, Settings::ControllerType::DualJoyconDetached,
+                 tr("Dual Joycons"));
     }
 
     if (npad_style_set.joycon_left == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconLeft, tr("Left Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconLeft, Settings::ControllerType::LeftJoycon,
+                 tr("Left Joycon"));
     }
 
     if (npad_style_set.joycon_right == 1) {
-        add_item(Core::HID::NpadStyleIndex::JoyconRight, tr("Right Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconRight, Settings::ControllerType::RightJoycon,
+                 tr("Right Joycon"));
     }
 
     if (player_index == 0 && npad_style_set.handheld == 1) {
-        add_item(Core::HID::NpadStyleIndex::Handheld, tr("Handheld"));
+        add_item(Core::HID::NpadStyleIndex::Handheld, Settings::ControllerType::Handheld,
+                 tr("Handheld"));
     }
 
     if (npad_style_set.gamecube == 1) {
-        add_item(Core::HID::NpadStyleIndex::GameCube, tr("GameCube Controller"));
+        add_item(Core::HID::NpadStyleIndex::GameCube, Settings::ControllerType::GameCube,
+                 tr("GameCube Controller"));
     }
 
     // Disable all unsupported controllers
@@ -1134,48 +1150,74 @@ void ConfigureInputPlayer::SetConnectableControllers() {
     }
 
     if (npad_style_set.palma == 1) {
-        add_item(Core::HID::NpadStyleIndex::Pokeball, tr("Poke Ball Plus"));
+        add_item(Core::HID::NpadStyleIndex::Pokeball, Settings::ControllerType::Pokeball,
+                 tr("Poke Ball Plus"));
     }
 
     if (npad_style_set.lark == 1) {
-        add_item(Core::HID::NpadStyleIndex::NES, tr("NES Controller"));
+        add_item(Core::HID::NpadStyleIndex::NES, Settings::ControllerType::NES,
+                 tr("NES Controller"));
     }
 
     if (npad_style_set.lucia == 1) {
-        add_item(Core::HID::NpadStyleIndex::SNES, tr("SNES Controller"));
+        add_item(Core::HID::NpadStyleIndex::SNES, Settings::ControllerType::SNES,
+                 tr("SNES Controller"));
     }
 
     if (npad_style_set.lagoon == 1) {
-        add_item(Core::HID::NpadStyleIndex::N64, tr("N64 Controller"));
+        add_item(Core::HID::NpadStyleIndex::N64, Settings::ControllerType::N64,
+                 tr("N64 Controller"));
     }
 
     if (npad_style_set.lager == 1) {
-        add_item(Core::HID::NpadStyleIndex::SegaGenesis, tr("Sega Genesis"));
+        add_item(Core::HID::NpadStyleIndex::SegaGenesis, Settings::ControllerType::SegaGenesis,
+                 tr("Sega Genesis"));
     }
 }
 
 Core::HID::NpadStyleIndex ConfigureInputPlayer::GetControllerTypeFromIndex(int index) const {
     const auto it =
-        std::find_if(index_controller_type_pairs.begin(), index_controller_type_pairs.end(),
-                     [index](const auto& pair) { return pair.first == index; });
+        std::find_if(controller_combo_entries.begin(), controller_combo_entries.end(),
+                     [index](const ControllerComboEntry& e) { return e.combo_index == index; });
 
-    if (it == index_controller_type_pairs.end()) {
+    if (it == controller_combo_entries.end()) {
         return Core::HID::NpadStyleIndex::Fullkey;
     }
 
-    return it->second;
+    return it->npad_style;
 }
 
-int ConfigureInputPlayer::GetIndexFromControllerType(Core::HID::NpadStyleIndex type) const {
+Settings::ControllerType ConfigureInputPlayer::GetSettingsControllerTypeFromIndex(int index) const {
     const auto it =
-        std::find_if(index_controller_type_pairs.begin(), index_controller_type_pairs.end(),
-                     [type](const auto& pair) { return pair.second == type; });
+        std::find_if(controller_combo_entries.begin(), controller_combo_entries.end(),
+                     [index](const ControllerComboEntry& e) { return e.combo_index == index; });
 
-    if (it == index_controller_type_pairs.end()) {
-        return -1;
+    if (it == controller_combo_entries.end()) {
+        return Settings::ControllerType::ProController;
     }
 
-    return it->first;
+    return it->settings_type;
+}
+
+int ConfigureInputPlayer::GetIndexFromSettingsControllerType(Settings::ControllerType type) const {
+    const auto it =
+        std::find_if(controller_combo_entries.begin(), controller_combo_entries.end(),
+                     [type](const ControllerComboEntry& e) { return e.settings_type == type; });
+
+    if (it != controller_combo_entries.end()) {
+        return it->combo_index;
+    }
+
+    const auto it_pro =
+        std::find_if(controller_combo_entries.begin(), controller_combo_entries.end(),
+                     [](const ControllerComboEntry& e) {
+                         return e.settings_type == Settings::ControllerType::ProController;
+                     });
+    if (it_pro != controller_combo_entries.end()) {
+        return it_pro->combo_index;
+    }
+
+    return 0;
 }
 
 void ConfigureInputPlayer::UpdateInputDevices() {

--- a/src/citron/configuration/configure_input_player.h
+++ b/src/citron/configuration/configure_input_player.h
@@ -133,11 +133,13 @@ private:
     /// Sets the available controllers.
     void SetConnectableControllers();
 
-    /// Gets the Controller Type for a given controller combobox index.
+    /// Gets the emulated Npad style for a given controller combobox index.
     Core::HID::NpadStyleIndex GetControllerTypeFromIndex(int index) const;
 
-    /// Gets the controller combobox index for a given Controller Type.
-    int GetIndexFromControllerType(Core::HID::NpadStyleIndex type) const;
+    Settings::ControllerType GetSettingsControllerTypeFromIndex(int index) const;
+
+    /// Gets the combobox index for a persisted settings controller type.
+    int GetIndexFromSettingsControllerType(Settings::ControllerType type) const;
 
     /// Update the available input devices.
     void UpdateInputDevices();
@@ -188,8 +190,12 @@ private:
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;
 
-    /// Stores a pair of "Connected Controllers" combobox index and Controller Type enum.
-    std::vector<std::pair<int, Core::HID::NpadStyleIndex>> index_controller_type_pairs;
+    struct ControllerComboEntry {
+        int combo_index;
+        Core::HID::NpadStyleIndex npad_style;
+        Settings::ControllerType settings_type;
+    };
+    std::vector<ControllerComboEntry> controller_combo_entries;
 
     /// This will be the the setting function when an input is awaiting configuration.
     std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -4469,6 +4469,10 @@ void GMainWindow::OnConfigure() {
 #endif
 
     Settings::SetConfiguringGlobal(true);
+    SCOPE_EXIT {
+        system->HIDCore().DisableAllControllerConfiguration();
+        Settings::SetConfiguringGlobal(false);
+    };
     ConfigureDialog configure_dialog(this, hotkey_registry, input_subsystem.get(),
                                      vk_device_records, *system,
                                      !multiplayer_state->IsHostingPublicRoom());

--- a/src/citron/qt_common.cpp
+++ b/src/citron/qt_common.cpp
@@ -14,6 +14,7 @@
 #include <qpa/qplatformnativeinterface.h>
 #elif defined(__APPLE__)
 #include <objc/message.h>
+#include <objc/runtime.h>
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__)
@@ -32,6 +33,59 @@
 #endif
 
 namespace QtCommon {
+#if defined(__APPLE__)
+namespace {
+
+id SendId(id receiver, const char* selector) {
+    return reinterpret_cast<id (*)(id, SEL)>(objc_msgSend)(receiver, sel_registerName(selector));
+}
+
+void SendVoidId(id receiver, const char* selector, id argument) {
+    reinterpret_cast<void (*)(id, SEL, id)>(objc_msgSend)(receiver, sel_registerName(selector),
+                                                          argument);
+}
+
+void SendVoidBool(id receiver, const char* selector, BOOL argument) {
+    reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(receiver, sel_registerName(selector),
+                                                            argument);
+}
+
+void SendVoidDouble(id receiver, const char* selector, double argument) {
+    reinterpret_cast<void (*)(id, SEL, double)>(objc_msgSend)(receiver, sel_registerName(selector),
+                                                              argument);
+}
+
+bool IsKindOfClass(id object, Class klass) {
+    return reinterpret_cast<BOOL (*)(id, SEL, Class)>(objc_msgSend)(
+               object, sel_registerName("isKindOfClass:"), klass) == YES;
+}
+
+id GetOrCreateMetalLayer(QWindow* window) {
+    id view = reinterpret_cast<id>(window->winId());
+    id layer = SendId(view, "layer");
+    Class metal_layer_class = objc_getClass("CAMetalLayer");
+
+    if (!metal_layer_class || (layer && IsKindOfClass(layer, metal_layer_class))) {
+        return layer;
+    }
+
+    SendVoidBool(view, "setWantsLayer:", YES);
+
+    id metal_layer = reinterpret_cast<id (*)(Class, SEL)>(objc_msgSend)(
+        metal_layer_class, sel_registerName("layer"));
+    if (!metal_layer) {
+        return layer;
+    }
+
+    SendVoidDouble(metal_layer, "setContentsScale:", window->devicePixelRatio());
+    SendVoidBool(metal_layer, "setOpaque:", YES);
+    SendVoidId(view, "setLayer:", metal_layer);
+    return metal_layer;
+}
+
+} // Anonymous namespace
+#endif
+
 Core::Frontend::WindowSystemType GetWindowSystemType() {
     // Determine WSI type based on Qt platform.
     QString platform_name = QGuiApplication::platformName();
@@ -60,8 +114,7 @@ Core::Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* window)
     // Our Win32 Qt external doesn't have the private API.
     wsi.render_surface = reinterpret_cast<void*>(window->winId());
 #elif defined(__APPLE__)
-    wsi.render_surface = reinterpret_cast<void* (*)(id, SEL)>(objc_msgSend)(
-        reinterpret_cast<id>(window->winId()), sel_registerName("layer"));
+    wsi.render_surface = GetOrCreateMetalLayer(window);
 #else
     QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
     wsi.display_connection = pni->nativeResourceForWindow("display", window);

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -603,10 +603,8 @@ private:
 
 class HostMemory::Impl {
 public:
-    explicit Impl(size_t /*backing_size */, size_t /* virtual_size */) {
-        // This is just a place holder.
-        // Please implement fastmem in a proper way on your platform.
-        throw std::bad_alloc{};
+    explicit Impl(size_t backing_size, size_t /*virtual_size*/) : backing_buffer{backing_size} {
+        backing_base = backing_buffer.data();
     }
 
     void Map(size_t virtual_offset, size_t host_offset, size_t length, MemoryPermission perm) {}
@@ -619,6 +617,9 @@ public:
 
     u8* backing_base{nullptr};
     u8* virtual_base{nullptr};
+
+private:
+    VirtualBuffer<u8> backing_buffer;
 };
 
 #endif // ^^^ Generic ^^^

--- a/src/common/settings_input.h
+++ b/src/common/settings_input.h
@@ -380,6 +380,8 @@ enum class ControllerType {
     SNES,
     N64,
     SegaGenesis,
+    Xbox,
+    DualSense,
 };
 
 struct PlayerInput {

--- a/src/common/socket_types.h
+++ b/src/common/socket_types.h
@@ -14,6 +14,7 @@ namespace Network {
 enum class Domain : u8 {
     Unspecified, ///< Represents 0, used in getaddrinfo hints
     INET,        ///< Address family for IPv4
+    INET6,       ///< Address family for IPv6
 };
 
 /// Socket types

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -1028,6 +1028,9 @@ std::pair<s32, Errno> BSD::RecvImpl(s32 fd, u32 flags, std::vector<u8>& message)
     if (Settings::values.airplane_mode.GetValue()) {
         return {-1, Errno::AGAIN};
     }
+    if (!descriptor.is_connection_based) {
+        return {-1, Errno::AGAIN};
+    }
 
     // Apply flags
     using Network::FLAG_MSG_DONTWAIT;
@@ -1057,6 +1060,10 @@ std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& mess
 
     FileDescriptor& descriptor = *file_descriptors[fd];
     if (Settings::values.airplane_mode.GetValue()) {
+        addr.clear();
+        return {-1, Errno::AGAIN};
+    }
+    if (!descriptor.is_connection_based) {
         addr.clear();
         return {-1, Errno::AGAIN};
     }
@@ -1109,7 +1116,12 @@ std::pair<s32, Errno> BSD::SendImpl(s32 fd, u32 flags, std::span<const u8> messa
     if (Settings::values.airplane_mode.GetValue()) {
         return {static_cast<s32>(message.size()), Errno::SUCCESS};
     }
-    return Translate(file_descriptors[fd]->socket->Send(message, flags));
+    FileDescriptor& descriptor = *file_descriptors[fd];
+    if (!descriptor.is_connection_based) {
+        LOG_DEBUG(Service, "Dropping datagram send without destination fd={}", fd);
+        return {static_cast<s32>(message.size()), Errno::SUCCESS};
+    }
+    return Translate(descriptor.socket->Send(message, flags));
 }
 
 std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, std::span<const u8> message,
@@ -1127,8 +1139,8 @@ std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, std::span<const u8> mes
 
     // For datagram sockets (UDP), a destination address is required
     if (!descriptor.is_connection_based && addr.empty()) {
-        LOG_ERROR(Service, "SendTo called on datagram socket without destination address");
-        return {-1, Errno::INVAL};
+        LOG_DEBUG(Service, "Dropping datagram sendto without destination fd={}", fd);
+        return {static_cast<s32>(message.size()), Errno::SUCCESS};
     }
 
     Network::SockAddrIn addr_in;

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "common/settings.h"
 #include "common/socket_types.h"
 #include "core/core.h"
 #include "core/hle/kernel/k_thread.h"
@@ -520,6 +521,12 @@ void BSD::ExecuteWork(HLERequestContext& ctx, Work work) {
 }
 
 std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protocol) {
+    if (Settings::values.airplane_mode.GetValue()) {
+        LOG_INFO(Service, "Airplane mode: rejecting socket creation domain={} type={} protocol={}",
+                 domain, type, protocol);
+        return {-1, Errno::CONNREFUSED};
+    }
+
     if (type == Type::SEQPACKET) {
         UNIMPLEMENTED_MSG("SOCK_SEQPACKET errno management");
     } else if (type == Type::RAW && (domain != Domain::INET || protocol != Protocol::ICMP)) {
@@ -692,6 +699,9 @@ Errno BSD::ConnectImpl(s32 fd, std::span<const u8> addr) {
     }
     if (!file_descriptors[fd]->socket)
         return Errno::BADF;
+    if (Settings::values.airplane_mode.GetValue()) {
+        return Errno::CONNREFUSED;
+    }
 
     UNIMPLEMENTED_IF(addr.size() != sizeof(SockAddrIn));
     auto addr_in = GetValue<SockAddrIn>(addr);
@@ -904,6 +914,9 @@ std::pair<s32, Errno> BSD::RecvImpl(s32 fd, u32 flags, std::vector<u8>& message)
     }
 
     FileDescriptor& descriptor = *file_descriptors[fd];
+    if (Settings::values.airplane_mode.GetValue()) {
+        return {-1, Errno::AGAIN};
+    }
 
     // Apply flags
     using Network::FLAG_MSG_DONTWAIT;
@@ -932,6 +945,10 @@ std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& mess
     }
 
     FileDescriptor& descriptor = *file_descriptors[fd];
+    if (Settings::values.airplane_mode.GetValue()) {
+        addr.clear();
+        return {-1, Errno::AGAIN};
+    }
 
     Network::SockAddrIn addr_in{};
     Network::SockAddrIn* p_addr_in = nullptr;
@@ -978,6 +995,9 @@ std::pair<s32, Errno> BSD::SendImpl(s32 fd, u32 flags, std::span<const u8> messa
     }
     if (!file_descriptors[fd]->socket)
         return {-1, Errno::BADF};
+    if (Settings::values.airplane_mode.GetValue()) {
+        return {static_cast<s32>(message.size()), Errno::SUCCESS};
+    }
     return Translate(file_descriptors[fd]->socket->Send(message, flags));
 }
 
@@ -988,6 +1008,9 @@ std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, std::span<const u8> mes
     }
     if (!file_descriptors[fd]->socket)
         return {-1, Errno::BADF};
+    if (Settings::values.airplane_mode.GetValue()) {
+        return {static_cast<s32>(message.size()), Errno::SUCCESS};
+    }
 
     FileDescriptor& descriptor = *file_descriptors[fd];
 

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -52,6 +52,119 @@ void PutValue(std::span<u8> buffer, const T& t) {
     std::memcpy(buffer.data(), &t, std::min(sizeof(T), buffer.size()));
 }
 
+class OfflineSocket final : public Network::SocketBase {
+public:
+    Network::Errno Initialize(Network::Domain domain_, Network::Type type_,
+                              Network::Protocol protocol_) override {
+        domain = domain_;
+        type = type_;
+        protocol = protocol_;
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno Close() override {
+        opened = false;
+        return Network::Errno::SUCCESS;
+    }
+
+    std::pair<AcceptResult, Network::Errno> Accept() override {
+        return {AcceptResult{}, Network::Errno::NETDOWN};
+    }
+
+    Network::Errno Connect(Network::SockAddrIn) override {
+        return Network::Errno::NETDOWN;
+    }
+
+    std::pair<Network::SockAddrIn, Network::Errno> GetPeerName() override {
+        return {{}, Network::Errno::NOTCONN};
+    }
+
+    std::pair<Network::SockAddrIn, Network::Errno> GetSockName() override {
+        return {{}, Network::Errno::SUCCESS};
+    }
+
+    Network::Errno Bind(Network::SockAddrIn) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno Listen(s32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno Shutdown(Network::ShutdownHow) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    std::pair<s32, Network::Errno> Recv(int, std::span<u8>) override {
+        return {-1, Network::Errno::AGAIN};
+    }
+
+    std::pair<s32, Network::Errno> RecvFrom(int, std::span<u8>, Network::SockAddrIn*) override {
+        return {-1, Network::Errno::AGAIN};
+    }
+
+    std::pair<s32, Network::Errno> Send(std::span<const u8> message, int) override {
+        return {static_cast<s32>(message.size()), Network::Errno::SUCCESS};
+    }
+
+    std::pair<s32, Network::Errno> SendTo(u32, std::span<const u8> message,
+                                          const Network::SockAddrIn*) override {
+        return {static_cast<s32>(message.size()), Network::Errno::SUCCESS};
+    }
+
+    Network::Errno SetLinger(bool, u32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetReuseAddr(bool) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetKeepAlive(bool) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetBroadcast(bool) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetSndBuf(u32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetRcvBuf(u32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetSndTimeo(u32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetRcvTimeo(u32) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    Network::Errno SetNonBlock(bool) override {
+        return Network::Errno::SUCCESS;
+    }
+
+    std::pair<Network::Errno, Network::Errno> GetPendingError() override {
+        return {Network::Errno::SUCCESS, Network::Errno::SUCCESS};
+    }
+
+    bool IsOpened() const override {
+        return opened;
+    }
+
+    void HandleProxyPacket(const Network::ProxyPacket&) override {}
+
+private:
+    Network::Domain domain = Network::Domain::INET;
+    Network::Type type = Network::Type::DGRAM;
+    Network::Protocol protocol = Network::Protocol::UDP;
+    bool opened = true;
+};
+
 } // Anonymous namespace
 
 void BSD::PollWork::Execute(BSD* bsd) {
@@ -521,12 +634,6 @@ void BSD::ExecuteWork(HLERequestContext& ctx, Work work) {
 }
 
 std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protocol) {
-    if (Settings::values.airplane_mode.GetValue()) {
-        LOG_INFO(Service, "Airplane mode: rejecting socket creation domain={} type={} protocol={}",
-                 domain, type, protocol);
-        return {-1, Errno::CONNREFUSED};
-    }
-
     if (type == Type::SEQPACKET) {
         UNIMPLEMENTED_MSG("SOCK_SEQPACKET errno management");
     } else if (type == Type::RAW && (domain != Domain::INET || protocol != Protocol::ICMP)) {
@@ -559,7 +666,11 @@ std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protoco
     descriptor.protocol = Translate(protocol);
     descriptor.is_connection_based = IsConnectionBased(type);
 
-    if (using_proxy) {
+    if (Settings::values.airplane_mode.GetValue()) {
+        descriptor.socket = std::make_shared<OfflineSocket>();
+        descriptor.socket->Initialize(descriptor.domain, descriptor.type, descriptor.protocol);
+        LOG_INFO(Service, "Airplane mode: created offline socket fd={}", fd);
+    } else if (using_proxy) {
         descriptor.socket = std::make_shared<Network::ProxySocket>(room_network);
         descriptor.socket->Initialize(descriptor.domain, descriptor.type, descriptor.protocol);
         LOG_DEBUG(Service, "Created new ProxySocket for fd={}", fd);

--- a/src/core/hle/service/sockets/sockets.h
+++ b/src/core/hle/service/sockets/sockets.h
@@ -25,6 +25,7 @@ enum class Errno : u32 {
     NOTCONN = 107,
     TIMEDOUT = 110,
     CONNREFUSED = 111,
+    DESTADDRREQ = 89,
     INPROGRESS = 115,
 };
 
@@ -50,6 +51,7 @@ enum class GetAddrInfoError : s32 {
 enum class Domain : u32 {
     Unspecified = 0,
     INET = 2,
+    INET6 = 28,
 };
 
 enum class Type : u32 {

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -36,6 +36,8 @@ Errno Translate(Network::Errno value) {
         return Errno::CONNABORTED;
     case Network::Errno::CONNRESET:
         return Errno::CONNRESET;
+    case Network::Errno::DESTADDRREQ:
+        return Errno::DESTADDRREQ;
     case Network::Errno::INPROGRESS:
         return Errno::INPROGRESS;
     case Network::Errno::OTHER:
@@ -135,6 +137,8 @@ Network::Domain Translate(Domain domain) {
         return Network::Domain::Unspecified;
     case Domain::INET:
         return Network::Domain::INET;
+    case Domain::INET6:
+        return Network::Domain::INET6;
     default:
         UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return {};
@@ -147,6 +151,8 @@ Domain Translate(Network::Domain domain) {
         return Domain::Unspecified;
     case Network::Domain::INET:
         return Domain::INET;
+    case Network::Domain::INET6:
+        return Domain::INET6;
     default:
         UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return {};

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -1034,6 +1034,7 @@ public:
             {3, &ISslServiceForSystem::VerifySignature, "VerifySignature"},
             {4, nullptr, "SetCertificateAndPrivateKeyInternal"},
             {5, &ISslServiceForSystem::FlushSessionCache, "FlushSessionCache"},
+            {100, &ISslServiceForSystem::SetInterfaceVersion, "SetInterfaceVersion"},
         };
         // clang-format on
 
@@ -1086,6 +1087,16 @@ private:
 
     void VerifySignature(HLERequestContext& ctx) {
         LOG_WARNING(Service_SSL, "(STUBBED) called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void SetInterfaceVersion(HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const u32 ssl_version = rp.Pop<u32>();
+
+        LOG_DEBUG(Service_SSL, "called, ssl_version={}", ssl_version);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);

--- a/src/core/internal_network/network.cpp
+++ b/src/core/internal_network/network.cpp
@@ -154,6 +154,10 @@ Errno TranslateNativeError(int e, CallType call_type = CallType::Other) {
         return Errno::NETUNREACH;
     case WSAEMSGSIZE:
         return Errno::MSGSIZE;
+#ifdef WSAEDESTADDRREQ
+    case WSAEDESTADDRREQ:
+        return Errno::DESTADDRREQ;
+#endif
     case WSAETIMEDOUT:
         return Errno::TIMEDOUT;
     case WSAEINPROGRESS:
@@ -295,6 +299,10 @@ Errno TranslateNativeError(int e, CallType call_type = CallType::Other) {
         return Errno::NETUNREACH;
     case EMSGSIZE:
         return Errno::MSGSIZE;
+#ifdef EDESTADDRREQ
+    case EDESTADDRREQ:
+        return Errno::DESTADDRREQ;
+#endif
     case ETIMEDOUT:
         return Errno::TIMEDOUT;
     case EINPROGRESS:
@@ -384,6 +392,10 @@ Domain TranslateDomainFromNative(int domain) {
         return Domain::Unspecified;
     case AF_INET:
         return Domain::INET;
+#ifdef AF_INET6
+    case AF_INET6:
+        return Domain::INET6;
+#endif
     default:
         UNIMPLEMENTED_MSG("Unhandled domain={}", domain);
         return Domain::INET;
@@ -396,6 +408,8 @@ int TranslateDomainToNative(Domain domain) {
         return 0;
     case Domain::INET:
         return AF_INET;
+    case Domain::INET6:
+        return AF_INET6;
     default:
         UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return 0;

--- a/src/core/internal_network/network.h
+++ b/src/core/internal_network/network.h
@@ -44,6 +44,7 @@ enum class Errno {
     NETUNREACH,
     TIMEDOUT,
     MSGSIZE,
+    DESTADDRREQ,
     INPROGRESS,
     OTHER,
 };

--- a/src/hid_core/frontend/emulated_controller.cpp
+++ b/src/hid_core/frontend/emulated_controller.cpp
@@ -58,6 +58,9 @@ NpadStyleIndex EmulatedController::MapSettingsTypeToNPad(Settings::ControllerTyp
         return NpadStyleIndex::N64;
     case Settings::ControllerType::SegaGenesis:
         return NpadStyleIndex::SegaGenesis;
+    case Settings::ControllerType::Xbox:
+    case Settings::ControllerType::DualSense:
+        return NpadStyleIndex::Fullkey;
     default:
         return NpadStyleIndex::Fullkey;
     }
@@ -648,7 +651,14 @@ void EmulatedController::SaveCurrentConfig() {
     const auto player_index = Service::HID::NpadIdTypeToIndex(npad_id_type);
     auto& player = Settings::values.players.GetValue()[player_index];
     player.connected = is_connected;
-    player.controller_type = MapNPadToSettingsType(npad_type);
+    const auto from_npad = MapNPadToSettingsType(npad_type);
+    if (from_npad != Settings::ControllerType::ProController) {
+        player.controller_type = from_npad;
+    } else if (player.controller_type != Settings::ControllerType::Xbox &&
+               player.controller_type != Settings::ControllerType::DualSense &&
+               player.controller_type != Settings::ControllerType::ProController) {
+        player.controller_type = Settings::ControllerType::ProController;
+    }
     player.body_color = controller.body_color;
     player.gyro_overlay_visible = controller.gyro_overlay_visible;
     for (std::size_t index = 0; index < player.buttons.size(); ++index) {

--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2018 Citra Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cctype>
+#include <string>
+
 #include "common/logging.h"
 #include "common/math_util.h"
 #include "common/param_package.h"
@@ -19,6 +22,58 @@ Common::UUID GetGUID(SDL_Joystick* joystick) {
     // Clear controller name crc
     std::memset(data.data() + 2, 0, sizeof(u16));
     return Common::UUID{data};
+}
+
+std::string NormalizedGamepadName(SDL_GameController* controller) {
+    if (controller == nullptr) {
+        return {};
+    }
+    const char* name = SDL_GameControllerName(controller);
+    if (name == nullptr) {
+        return {};
+    }
+    std::string s(name);
+    for (char& c : s) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return s;
+}
+
+bool IsSonyGamepad(SDL_GameController* controller) {
+    if (controller == nullptr) {
+        return false;
+    }
+    const auto ctype = SDL_GameControllerGetType(controller);
+    if (ctype == SDL_CONTROLLER_TYPE_PS3 || ctype == SDL_CONTROLLER_TYPE_PS4 ||
+        ctype == SDL_CONTROLLER_TYPE_PS5) {
+        return true;
+    }
+    if (SDL_Joystick* j = SDL_GameControllerGetJoystick(controller)) {
+        if (SDL_JoystickGetVendor(j) == 0x054c) {
+            return true;
+        }
+    }
+    const std::string s = NormalizedGamepadName(controller);
+    return s.find("dualsense") != std::string::npos || s.find("dualshock") != std::string::npos ||
+           s.find("playstation") != std::string::npos || s.find("ps5") != std::string::npos ||
+           s.find("ps4") != std::string::npos;
+}
+
+bool IsMicrosoftGamepad(SDL_GameController* controller) {
+    if (controller == nullptr) {
+        return false;
+    }
+    const auto ctype = SDL_GameControllerGetType(controller);
+    if (ctype == SDL_CONTROLLER_TYPE_XBOX360 || ctype == SDL_CONTROLLER_TYPE_XBOXONE) {
+        return true;
+    }
+    if (SDL_Joystick* j = SDL_GameControllerGetJoystick(controller)) {
+        if (SDL_JoystickGetVendor(j) == 0x045e) {
+            return true;
+        }
+    }
+    const std::string s = NormalizedGamepadName(controller);
+    return s.find("xbox") != std::string::npos;
 }
 } // Anonymous namespace
 
@@ -775,7 +830,8 @@ Common::ParamPackage SDLDriver::BuildParamPackageForBinding(
 
 Common::ParamPackage SDLDriver::BuildParamPackageForAnalog(PadIdentifier identifier, int axis_x,
                                                            int axis_y, float offset_x,
-                                                           float offset_y) const {
+                                                           float offset_y, const char* invert_x,
+                                                           const char* invert_y) const {
     Common::ParamPackage params;
     params.Set("engine", GetEngineName());
     params.Set("port", static_cast<int>(identifier.port));
@@ -784,8 +840,8 @@ Common::ParamPackage SDLDriver::BuildParamPackageForAnalog(PadIdentifier identif
     params.Set("axis_y", axis_y);
     params.Set("offset_x", offset_x);
     params.Set("offset_y", offset_y);
-    params.Set("invert_x", "+");
-    params.Set("invert_y", "+");
+    params.Set("invert_x", invert_x);
+    params.Set("invert_y", invert_y);
     return params;
 }
 
@@ -842,11 +898,29 @@ ButtonBindings SDLDriver::GetDefaultButtonBinding(
         srr_button = SDL_CONTROLLER_BUTTON_PADDLE1;
     }
 
+    // Switch: B=south / A=east vs SDL A=south / B=east, and transposed X/Y. Sony uses SDL face
+    // order like Xbox; other pads use Switch-style A/B mapping.
+    SDL_GameController* controller = joystick->GetSDLGameController();
+    const SDL_GameControllerType controller_type =
+        controller ? SDL_GameControllerGetType(controller) : SDL_CONTROLLER_TYPE_UNKNOWN;
+    const bool nintendo_xy_swap =
+        controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO ||
+        controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT ||
+        controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT ||
+        controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR;
+    const bool sony = IsSonyGamepad(controller);
+    const SDL_GameControllerButton sdl_a = sony ? SDL_CONTROLLER_BUTTON_A : SDL_CONTROLLER_BUTTON_B;
+    const SDL_GameControllerButton sdl_b = sony ? SDL_CONTROLLER_BUTTON_B : SDL_CONTROLLER_BUTTON_A;
+    const SDL_GameControllerButton sdl_x =
+        nintendo_xy_swap ? SDL_CONTROLLER_BUTTON_Y : SDL_CONTROLLER_BUTTON_X;
+    const SDL_GameControllerButton sdl_y =
+        nintendo_xy_swap ? SDL_CONTROLLER_BUTTON_X : SDL_CONTROLLER_BUTTON_Y;
+
     return {
-        std::pair{Settings::NativeButton::A, SDL_CONTROLLER_BUTTON_B},
-        {Settings::NativeButton::B, SDL_CONTROLLER_BUTTON_A},
-        {Settings::NativeButton::X, SDL_CONTROLLER_BUTTON_Y},
-        {Settings::NativeButton::Y, SDL_CONTROLLER_BUTTON_X},
+        std::pair{Settings::NativeButton::A, sdl_a},
+        {Settings::NativeButton::B, sdl_b},
+        {Settings::NativeButton::X, sdl_x},
+        {Settings::NativeButton::Y, sdl_y},
         {Settings::NativeButton::LStick, SDL_CONTROLLER_BUTTON_LEFTSTICK},
         {Settings::NativeButton::RStick, SDL_CONTROLLER_BUTTON_RIGHTSTICK},
         {Settings::NativeButton::L, SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
@@ -956,6 +1030,8 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         return {};
     }
 
+    const char* const stick_invert_y = IsMicrosoftGamepad(controller) ? "-" : "+";
+
     AnalogMapping mapping = {};
     const auto& binding_left_x =
         SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_LEFTX);
@@ -971,7 +1047,8 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         mapping.insert_or_assign(Settings::NativeAnalog::LStick,
                                  BuildParamPackageForAnalog(identifier, binding_left_x.value.axis,
                                                             binding_left_y.value.axis,
-                                                            left_offset_x, left_offset_y));
+                                                            left_offset_x, left_offset_y, "+",
+                                                            stick_invert_y));
     } else {
         const auto identifier = joystick->GetPadIdentifier();
         PreSetController(identifier);
@@ -982,7 +1059,8 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         mapping.insert_or_assign(Settings::NativeAnalog::LStick,
                                  BuildParamPackageForAnalog(identifier, binding_left_x.value.axis,
                                                             binding_left_y.value.axis,
-                                                            left_offset_x, left_offset_y));
+                                                            left_offset_x, left_offset_y, "+",
+                                                            stick_invert_y));
     }
     const auto& binding_right_x =
         SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX);
@@ -997,7 +1075,7 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
     mapping.insert_or_assign(Settings::NativeAnalog::RStick,
                              BuildParamPackageForAnalog(identifier, binding_right_x.value.axis,
                                                         binding_right_y.value.axis, right_offset_x,
-                                                        right_offset_y));
+                                                        right_offset_y, "+", stick_invert_y));
     return mapping;
 }
 

--- a/src/input_common/drivers/sdl_driver.h
+++ b/src/input_common/drivers/sdl_driver.h
@@ -92,8 +92,9 @@ private:
         int port, const Common::UUID& guid, const SDL_GameControllerButtonBind& binding) const;
 
     Common::ParamPackage BuildParamPackageForAnalog(PadIdentifier identifier, int axis_x,
-                                                    int axis_y, float offset_x,
-                                                    float offset_y) const;
+                                                    int axis_y, float offset_x, float offset_y,
+                                                    const char* invert_x = "+",
+                                                    const char* invert_y = "+") const;
 
     /// Returns the default button bindings list
     ButtonBindings GetDefaultButtonBinding(const std::shared_ptr<SDLJoystick>& joystick) const;

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -478,8 +478,23 @@ void EmitSetPatch(EmitContext& ctx, IR::Patch patch, Id value) {
 
 void EmitSetFragColor(EmitContext& ctx, u32 index, u32 component, Id value) {
     const Id component_id{ctx.Const(component)};
-    const Id pointer{ctx.OpAccessChain(ctx.output_f32, ctx.frag_color.at(index), component_id)};
-    ctx.OpStore(pointer, value);
+    switch (ctx.runtime_info.frag_color_types[index]) {
+    case FragmentOutputType::Float: {
+        const Id pointer{ctx.OpAccessChain(ctx.output_f32, ctx.frag_color.at(index), component_id)};
+        ctx.OpStore(pointer, value);
+        break;
+    }
+    case FragmentOutputType::SignedInt: {
+        const Id pointer{ctx.OpAccessChain(ctx.output_s32, ctx.frag_color.at(index), component_id)};
+        ctx.OpStore(pointer, ctx.OpBitcast(ctx.S32[1], value));
+        break;
+    }
+    case FragmentOutputType::UnsignedInt: {
+        const Id pointer{ctx.OpAccessChain(ctx.output_u32, ctx.frag_color.at(index), component_id)};
+        ctx.OpStore(pointer, ctx.OpBitcast(ctx.U32[1], value));
+        break;
+    }
+    }
 }
 
 void EmitSetSampleMask(EmitContext& ctx, Id value) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -156,6 +156,18 @@ Id DefineInput(EmitContext& ctx, Id type, bool per_invocation,
     return DefineVariable(ctx, type, builtin, spv::StorageClass::Input);
 }
 
+Id GetFragmentOutputTypeId(EmitContext& ctx, FragmentOutputType type) {
+    switch (type) {
+    case FragmentOutputType::Float:
+        return ctx.F32[4];
+    case FragmentOutputType::SignedInt:
+        return ctx.S32[4];
+    case FragmentOutputType::UnsignedInt:
+        return ctx.U32[4];
+    }
+    throw InvalidArgument("Invalid fragment output type");
+}
+
 Id DefineOutput(EmitContext& ctx, Id type, std::optional<u32> invocations,
                 std::optional<spv::BuiltIn> builtin = std::nullopt,
                 std::optional<Id> initializer = std::nullopt) {
@@ -556,6 +568,7 @@ void EmitContext::DefineCommonTypes(const Info& info) {
 
     output_f32 = Name(TypePointer(spv::StorageClass::Output, F32[1]), "output_f32");
     output_u32 = Name(TypePointer(spv::StorageClass::Output, U32[1]), "output_u32");
+    output_s32 = Name(TypePointer(spv::StorageClass::Output, S32[1]), "output_s32");
 
     if (info.uses_int8 && profile.support_int8) {
         AddCapability(spv::Capability::Int8);
@@ -1669,10 +1682,11 @@ void EmitContext::DefineOutputs(const IR::Program& program) {
                 !(index == 0 && runtime_info.alpha_to_coverage_enabled)) {
                 continue;
             }
-            frag_color[index] = DefineOutput(*this, F32[4], std::nullopt);
+            const FragmentOutputType type{runtime_info.frag_color_types[index]};
+            frag_color[index] = DefineOutput(*this, GetFragmentOutputTypeId(*this, type), std::nullopt);
             Decorate(frag_color[index], spv::Decoration::Location, index);
             // OPTIMIZED FOR LOW GPU ACCURACY - mediump for fragment outputs
-            if (profile.force_fragment_relaxed_precision) {
+            if (type == FragmentOutputType::Float && profile.force_fragment_relaxed_precision) {
                 Decorate(frag_color[index], spv::Decoration::RelaxedPrecision);
             }
             Name(frag_color[index], fmt::format("frag_color{}", index));

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -250,6 +250,7 @@ public:
 
     Id output_f32{};
     Id output_u32{};
+    Id output_s32{};
 
     Id image_buffer_type{};
     Id image_u32{};

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -58,6 +58,12 @@ enum class CompareFunction {
     Always,
 };
 
+enum class FragmentOutputType : u8 {
+    Float,
+    SignedInt,
+    UnsignedInt,
+};
+
 enum class TessPrimitive {
     Isolines,
     Triangles,
@@ -95,6 +101,7 @@ struct RuntimeInfo {
     std::optional<CompareFunction> alpha_test_func;
     float alpha_test_reference{};
     bool alpha_to_coverage_enabled{};
+    std::array<FragmentOutputType, 8> frag_color_types{};
 
     /// Static Y negate value
     bool y_negate{};

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -39,7 +39,7 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d, DynamicFe
     extended_dynamic_state_3_blend.Assign(features.has_extended_dynamic_state_3_blend ? 1 : 0);
     extended_dynamic_state_3_enables.Assign(features.has_extended_dynamic_state_3_enables ? 1 : 0);
     dynamic_vertex_input.Assign(features.has_dynamic_vertex_input ? 1 : 0);
-    xfb_enabled.Assign(regs.transform_feedback_enabled != 0);
+    xfb_enabled.Assign(features.has_transform_feedback && regs.transform_feedback_enabled != 0);
     ndc_minus_one_to_one.Assign(regs.depth_mode == Tegra::Engines::Maxwell3D::Regs::DepthMode::MinusOneToOne ? 1 : 0);
     polygon_mode.Assign(PackPolygonMode(regs.polygon_mode_front));
     tessellation_primitive.Assign(static_cast<u32>(regs.tessellation.params.domain_type.Value()));

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -22,6 +22,7 @@ struct DynamicFeatures {
     bool has_extended_dynamic_state_3_blend;
     bool has_extended_dynamic_state_3_enables;
     bool has_dynamic_vertex_input;
+    bool has_transform_feedback;
 };
 
 struct FixedPipelineState {

--- a/src/video_core/renderer_vulkan/present/util.cpp
+++ b/src/video_core/renderer_vulkan/present/util.cpp
@@ -397,12 +397,13 @@ static vk::Pipeline CreateWrappedPipelineImpl(
         .pVertexAttributeDescriptions = nullptr,
     };
 
-    constexpr VkPipelineInputAssemblyStateCreateInfo input_assembly_ci{
+    const VkPipelineInputAssemblyStateCreateInfo input_assembly_ci{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
         .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-        .primitiveRestartEnable = VK_FALSE,
+        .primitiveRestartEnable =
+            device.GetDriverID() == VK_DRIVER_ID_MOLTENVK ? VK_TRUE : VK_FALSE,
     };
 
     constexpr VkPipelineViewportStateCreateInfo viewport_state_ci{

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -618,18 +618,23 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             input_assembly_topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
         }
     }
+    const bool supports_primitive_restart =
+        (input_assembly_topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
+         device.IsTopologyListPrimitiveRestartSupported()) ||
+        SupportsPrimitiveRestart(input_assembly_topology) ||
+        (input_assembly_topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
+         device.IsPatchListPrimitiveRestartSupported());
+    const bool force_mvk_primitive_restart =
+        device.GetDriverID() == VK_DRIVER_ID_MOLTENVK &&
+        SupportsPrimitiveRestart(input_assembly_topology);
     const VkPipelineInputAssemblyStateCreateInfo input_assembly_ci{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
         .topology = input_assembly_topology,
         .primitiveRestartEnable =
-            dynamic.primitive_restart_enable != 0 &&
-                    ((input_assembly_topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
-                      device.IsTopologyListPrimitiveRestartSupported()) ||
-                     SupportsPrimitiveRestart(input_assembly_topology) ||
-                     (input_assembly_topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
-                      device.IsPatchListPrimitiveRestartSupported()))
+            (force_mvk_primitive_restart ||
+             (dynamic.primitive_restart_enable != 0 && supports_primitive_restart))
                 ? VK_TRUE
                 : VK_FALSE,
     };
@@ -860,12 +865,11 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
         }
         dynamic_states.insert(dynamic_states.end(), extended.begin(), extended.end());
         if (key.state.extended_dynamic_state_2) {
-            static constexpr std::array extended2{
-                VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT,
-                VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT,
-                VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT,
-            };
-            dynamic_states.insert(dynamic_states.end(), extended2.begin(), extended2.end());
+            dynamic_states.push_back(VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT);
+            if (device.GetDriverID() != VK_DRIVER_ID_MOLTENVK) {
+                dynamic_states.push_back(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT);
+            }
+            dynamic_states.push_back(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT);
         }
         if (key.state.extended_dynamic_state_2_extra) {
             dynamic_states.push_back(VK_DYNAMIC_STATE_LOGIC_OP_EXT);

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -37,6 +37,7 @@
 #include "video_core/shader_cache.h"
 #include "video_core/shader_environment.h"
 #include "video_core/shader_notify.h"
+#include "video_core/surface.h"
 #include "video_core/vulkan_common/vulkan_device.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -141,6 +142,20 @@ Shader::AttributeType AttributeType(const FixedPipelineState& state, size_t inde
     return Shader::AttributeType::Disabled;
 }
 
+Shader::FragmentOutputType GetFragmentOutputType(u8 encoded_format) {
+    const auto format{static_cast<Tegra::RenderTargetFormat>(encoded_format)};
+    if (format == Tegra::RenderTargetFormat::NONE) {
+        return Shader::FragmentOutputType::Float;
+    }
+    const auto pixel_format{VideoCore::Surface::PixelFormatFromRenderTargetFormat(format)};
+    if (!VideoCore::Surface::IsPixelFormatInteger(pixel_format)) {
+        return Shader::FragmentOutputType::Float;
+    }
+    return VideoCore::Surface::IsPixelFormatSignedInteger(pixel_format)
+               ? Shader::FragmentOutputType::SignedInt
+               : Shader::FragmentOutputType::UnsignedInt;
+}
+
 Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> programs,
                                     const GraphicsPipelineCacheKey& key,
                                     const Shader::IR::Program& program,
@@ -224,6 +239,8 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
         info.convert_depth_mode = gl_ndc;
         break;
     case Shader::Stage::Fragment: {
+        std::ranges::transform(key.state.color_formats, info.frag_color_types.begin(),
+                               &GetFragmentOutputType);
         // OPTIMIZED FOR LOW GPU ACCURACY - skip alpha test to reduce shader complexity
         if (!Settings::IsGPULevelLow()) {
             info.alpha_test_func = MaxwellToCompareFunction(

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -426,6 +426,7 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
         .has_extended_dynamic_state_3_enables =
             allow_eds3 && device.IsExtExtendedDynamicState3EnablesSupported(),
         .has_dynamic_vertex_input = allow_eds3 && device.IsExtVertexInputDynamicStateSupported(),
+        .has_transform_feedback = device.IsExtTransformFeedbackSupported(),
     };
 }
 
@@ -602,7 +603,8 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
                 dynamic_features.has_extended_dynamic_state_3_blend ||
             (key.state.extended_dynamic_state_3_enables != 0) !=
                 dynamic_features.has_extended_dynamic_state_3_enables ||
-            (key.state.dynamic_vertex_input != 0) != dynamic_features.has_dynamic_vertex_input) {
+            (key.state.dynamic_vertex_input != 0) != dynamic_features.has_dynamic_vertex_input ||
+            (key.state.xfb_enabled != 0) != dynamic_features.has_transform_feedback) {
             return;
         }
         workers.QueueWork([this, key, envs_ = std::move(envs), &state, &callback]() mutable {

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -1478,6 +1478,11 @@ VideoCommon::StreamerInterface* QueryCacheRuntime::GetStreamerInterface(QueryTyp
     case QueryType::Payload:
         return &impl->guest_streamer;
     case QueryType::ZPassPixelCount64:
+        if (impl->device.GetDriverID() == VK_DRIVER_ID_MOLTENVK) {
+            // MoltenVK maps occlusion queries to Metal visibility results. On Apple GPUs this can
+            // fault inside the driver for some titles, so prefer the guest fallback over crashing.
+            return &impl->guest_streamer;
+        }
         return &impl->sample_streamer;
     case QueryType::StreamingByteCount:
         return &impl->tfb_streamer;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1369,6 +1369,9 @@ void RasterizerVulkan::UpdatePrimitiveRestartEnable(Tegra::Engines::Maxwell3D::R
     if (!state_tracker.TouchPrimitiveRestartEnable()) {
         return;
     }
+    if (device.GetDriverID() == VK_DRIVER_ID_MOLTENVK) {
+        return;
+    }
     scheduler.Record([enable = regs.primitive_restart.enabled](vk::CommandBuffer cmdbuf) {
         cmdbuf.SetPrimitiveRestartEnableEXT(enable);
     });

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -441,6 +441,14 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         nvidia_arch = GetNvidiaArchitecture(physical, supported_extensions);
     }
 
+    if (is_mvk) {
+        LOG_INFO(Render_Vulkan, "Disabling Vulkan buffer robustness on MoltenVK");
+        features.features.robustBufferAccess = false;
+        features2.features.robustBufferAccess = false;
+        RemoveExtensionFeature(extensions.robustness_2, features.robustness2,
+                               VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    }
+
     // FIXED: Android Adreno 740 native ASTC eviction
     // Detect Adreno GPUs and check for native ASTC support
     is_adreno = is_qualcomm || is_turnip;


### PR DESCRIPTION
## Summary

### Graphics (macOS / Vulkan / MoltenVK)
- Reduce macOS startup issues: host memory fallback, MoltenVK surface / Metal layer usage where relevant.
- Tame MoltenVK warnings on Apple GPUs (robustness, primitive restart, and related paths).
- Fix **Mario Kart 8 Deluxe** pipeline issues on MoltenVK by emitting integer fragment outputs for integer render targets.
- Misc. Vulkan pipeline/present/query fixes touched by this branch.

### Networking / sockets
- Improve socket behavior for real-world titles (e.g. IPv6 domain handling, safer error translation).
- Related updates in BSD sockets, internal network, and SSL paths as needed for compatibility.

### Input (Xbox / DualSense)
- Add **Xbox Controller** and **DualSense (PS5)** entries in Input settings and the controller applet; both still emulate **Fullkey (Pro Controller)**.
- Extend `Settings::ControllerType` with `Xbox` and `DualSense`; preserve those types on save when the emulated pad is Fullkey.
- **SDL:** Detect Sony / Microsoft gamepads (SDL type, USB VID, device name). Face buttons: Switch-style A/B and Nintendo X/Y swap where appropriate; PlayStation uses SDL A/B and X/Y like Xbox. Sticks: `invert_y` is `"-"` for Microsoft pads and `"+"` otherwise so vertical feel matches after global SDL Y handling.
- **Configure dialog:** Remove duplicate `SetConfiguringGlobal(true)` from the dialog ctor. **`OnConfigure`:** `SCOPE_EXIT` calls `DisableAllControllerConfiguration()` and `SetConfiguringGlobal(false)` after the dialog closes so in-game input is not left in mapping-only mode.

### Other
- Small CMake / Qt / host-memory tweaks included in this PR as needed for the above.

## Notes
- macOS: helps titles such as Cuphead and MK8D; Minecraft may still hit missing MoltenVK/Metal features (e.g. geometry shaders, shader cull distance).
- After changing SDL defaults, use **Restore defaults** or remap once so saved bindings match.

## Testing
- macOS arm64: configure + build; smoke-test `citron.app`.
- Cuphead / MK8D as applicable to this branch.
- **DualSense / Xbox:** mapping UI and in-game input after closing **Emulation → Configure**.
