### PR TITLE
fix android: Fix installFileToNand callback type mismatch

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -106,7 +106,7 @@ object NativeLibrary {
      */
     external fun installFileToNand(
         filename: String,
-        callback: (max: Long, progress: Long) -> Boolean
+        callback: (max: Double, progress: Double) -> Boolean
     ): Int
 
     external fun doesUpdateMatchProgram(programId: String, updatePath: String): Boolean

--- a/src/android/app/src/main/java/org/citron/citron_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/ui/main/MainActivity.kt
@@ -516,14 +516,14 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             var error = 0
             documents.forEach {
                 messageCallback.invoke(FileUtil.getFilename(it))
-                when (
-                    InstallResult.from(
-                        NativeLibrary.installFileToNand(
-                            it.toString(),
-                            progressCallback
-                        )
-                    )
-                ) {
+             
+                val installCode = NativeLibrary.installFileToNand(
+                    it.toString()
+                ) { max: Double, progress: Double ->
+                    progressCallback(max.toLong(), progress.toLong())
+                }
+
+                when (InstallResult.from(installCode))  {
                     InstallResult.Success -> {
                         installSuccess += 1
                     }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -821,10 +821,23 @@ jint Java_org_citron_citron_1emu_NativeLibrary_verifyGameContents(JNIEnv* env, j
     auto jlambdaClass = env->GetObjectClass(jcallback);
     auto jlambdaInvokeMethod = env->GetMethodID(
         jlambdaClass, "invoke", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-    const auto callback = [env, jcallback, jlambdaInvokeMethod](size_t max, size_t progress) {
-        auto jwasCancelled = env->CallObjectMethod(jcallback, jlambdaInvokeMethod,
-                                                   Common::Android::ToJDouble(env, max),
-                                                   Common::Android::ToJDouble(env, progress));
+
+    jclass jLongClass = env->FindClass("java/lang/Long");
+    jmethodID jLongValueOf = env->GetStaticMethodID(jLongClass, "valueOf", "(J)Ljava/lang/Long;");
+
+    const auto callback = [env, jcallback, jlambdaInvokeMethod, jLongClass, jLongValueOf](size_t max, size_t progress) {
+        jobject jmax = env->CallStaticObjectMethod(jLongClass, jLongValueOf, static_cast<jlong>(max));
+        jobject jprogress = env->CallStaticObjectMethod(jLongClass, jLongValueOf, static_cast<jlong>(progress));
+
+        jobject jwasCancelled = env->CallObjectMethod(jcallback, jlambdaInvokeMethod, jmax, jprogress);
+        
+        env->DeleteLocalRef(jmax);
+        env->DeleteLocalRef(jprogress);
+
+        if (jwasCancelled == nullptr) {
+            return false;
+        }
+
         return Common::Android::GetJBoolean(env, jwasCancelled);
     };
     auto& session = EmulationSession::GetInstance();


### PR DESCRIPTION
The progress callback in installFileToNand was declared with Long parameters in Kotlin, but the native side passed double values. This caused a ClassCastException when installing updates or DLC.

Changes:
- Update callback signature in NativeLibrary.kt to use Double
- Update call site in MainActivity.kt with proper .toLong() conversion

Tested: Installing base game + update + DLC no longer crashes.

Closes #155