### PR TITLE
cmake tzdb fallback; macOS quit teardown; Xbox SDL on macOS

### DIFF
--- a/externals/nx_tzdb/CMakeLists.txt
+++ b/externals/nx_tzdb/CMakeLists.txt
@@ -35,19 +35,7 @@ set(NX_TZDB_ARCHIVE "${CMAKE_CURRENT_BINARY_DIR}/${NX_TZDB_VERSION}.zip")
 
 set(NX_TZDB_ROMFS_DIR "${CMAKE_CURRENT_BINARY_DIR}/nx_tzdb")
 
-set(NX_TZDB_HAVE_SOURCE FALSE)
-if (DEFINED TZDB_TO_NX_SOURCE_DIR AND EXISTS "${TZDB_TO_NX_SOURCE_DIR}/CMakeLists.txt")
-    set(NX_TZDB_HAVE_SOURCE TRUE)
-endif()
-
-# Build from tzdb_to_nx source only when the tree is available (git submodule or CITRON_USE_CPM).
-# Otherwise use the same pre-built release archive as Windows and DOWNLOAD_TIME_ZONE_DATA builds.
-set(NX_TZDB_USE_LOCAL_BUILD FALSE)
-if (CAN_BUILD_NX_TZDB AND NOT CITRON_DOWNLOAD_TIME_ZONE_DATA AND NX_TZDB_HAVE_SOURCE)
-    set(NX_TZDB_USE_LOCAL_BUILD TRUE)
-endif()
-
-if (NOT NX_TZDB_USE_LOCAL_BUILD AND NOT EXISTS ${NX_TZDB_ROMFS_DIR})
+if ((NOT CAN_BUILD_NX_TZDB OR CITRON_DOWNLOAD_TIME_ZONE_DATA) AND NOT EXISTS ${NX_TZDB_ROMFS_DIR})
     set(NX_TZDB_DOWNLOAD_URL "https://github.com/lat9nq/tzdb_to_nx/releases/download/${NX_TZDB_VERSION}/${NX_TZDB_VERSION}.zip")
 
     message(STATUS "Downloading time zone data from ${NX_TZDB_DOWNLOAD_URL}...")
@@ -63,8 +51,12 @@ if (NOT NX_TZDB_USE_LOCAL_BUILD AND NOT EXISTS ${NX_TZDB_ROMFS_DIR})
             ${NX_TZDB_ARCHIVE}
         DESTINATION
             ${NX_TZDB_ROMFS_DIR})
-elseif (NX_TZDB_USE_LOCAL_BUILD)
-    add_subdirectory("${TZDB_TO_NX_SOURCE_DIR}" tzdb_to_nx)
+elseif (CAN_BUILD_NX_TZDB AND NOT CITRON_DOWNLOAD_TIME_ZONE_DATA)
+    if (DEFINED TZDB_TO_NX_SOURCE_DIR AND EXISTS "${TZDB_TO_NX_SOURCE_DIR}/CMakeLists.txt")
+        add_subdirectory("${TZDB_TO_NX_SOURCE_DIR}" tzdb_to_nx)
+    else()
+        message(FATAL_ERROR "tzdb_to_nx source not found. Enable CITRON_USE_CPM so the source can be fetched.")
+    endif()
     add_dependencies(nx_tzdb x80e)
 
     set(NX_TZDB_ROMFS_DIR "${NX_TZDB_DIR}")

--- a/externals/nx_tzdb/CMakeLists.txt
+++ b/externals/nx_tzdb/CMakeLists.txt
@@ -35,7 +35,19 @@ set(NX_TZDB_ARCHIVE "${CMAKE_CURRENT_BINARY_DIR}/${NX_TZDB_VERSION}.zip")
 
 set(NX_TZDB_ROMFS_DIR "${CMAKE_CURRENT_BINARY_DIR}/nx_tzdb")
 
-if ((NOT CAN_BUILD_NX_TZDB OR CITRON_DOWNLOAD_TIME_ZONE_DATA) AND NOT EXISTS ${NX_TZDB_ROMFS_DIR})
+set(NX_TZDB_HAVE_SOURCE FALSE)
+if (DEFINED TZDB_TO_NX_SOURCE_DIR AND EXISTS "${TZDB_TO_NX_SOURCE_DIR}/CMakeLists.txt")
+    set(NX_TZDB_HAVE_SOURCE TRUE)
+endif()
+
+# Build from tzdb_to_nx source only when the tree is available (git submodule or CITRON_USE_CPM).
+# Otherwise use the same pre-built release archive as Windows and DOWNLOAD_TIME_ZONE_DATA builds.
+set(NX_TZDB_USE_LOCAL_BUILD FALSE)
+if (CAN_BUILD_NX_TZDB AND NOT CITRON_DOWNLOAD_TIME_ZONE_DATA AND NX_TZDB_HAVE_SOURCE)
+    set(NX_TZDB_USE_LOCAL_BUILD TRUE)
+endif()
+
+if (NOT NX_TZDB_USE_LOCAL_BUILD AND NOT EXISTS ${NX_TZDB_ROMFS_DIR})
     set(NX_TZDB_DOWNLOAD_URL "https://github.com/lat9nq/tzdb_to_nx/releases/download/${NX_TZDB_VERSION}/${NX_TZDB_VERSION}.zip")
 
     message(STATUS "Downloading time zone data from ${NX_TZDB_DOWNLOAD_URL}...")
@@ -51,12 +63,8 @@ if ((NOT CAN_BUILD_NX_TZDB OR CITRON_DOWNLOAD_TIME_ZONE_DATA) AND NOT EXISTS ${N
             ${NX_TZDB_ARCHIVE}
         DESTINATION
             ${NX_TZDB_ROMFS_DIR})
-elseif (CAN_BUILD_NX_TZDB AND NOT CITRON_DOWNLOAD_TIME_ZONE_DATA)
-    if (DEFINED TZDB_TO_NX_SOURCE_DIR AND EXISTS "${TZDB_TO_NX_SOURCE_DIR}/CMakeLists.txt")
-        add_subdirectory("${TZDB_TO_NX_SOURCE_DIR}" tzdb_to_nx)
-    else()
-        message(FATAL_ERROR "tzdb_to_nx source not found. Enable CITRON_USE_CPM so the source can be fetched.")
-    endif()
+elseif (NX_TZDB_USE_LOCAL_BUILD)
+    add_subdirectory("${TZDB_TO_NX_SOURCE_DIR}" tzdb_to_nx)
     add_dependencies(nx_tzdb x80e)
 
     set(NX_TZDB_ROMFS_DIR "${NX_TZDB_DIR}")

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -6186,6 +6186,11 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     PgoAutoSweep(L"close");
 #endif
 
+    // Stop periodic SDL event pumping and any pending emu shutdown timer so they cannot fire
+    // during controller unload, render close, or HID teardown (avoids exit crashes on macOS).
+    update_input_timer.stop();
+    shutdown_timer.stop();
+
     // 1. STOP the emulation first
     if (emu_thread != nullptr) {
         // Request exit before shutdown so Qlaunch (and other applets) receive the request

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -2500,6 +2500,7 @@ bool GMainWindow::OnShutdownBegin() {
         shutdown_time = 5000;
     }
 
+    disconnect(&shutdown_timer, nullptr, this, nullptr);
     shutdown_timer.setSingleShot(true);
     shutdown_timer.start(shutdown_time);
     connect(&shutdown_timer, &QTimer::timeout, this, &GMainWindow::OnEmulationStopTimeExpired);
@@ -6036,6 +6037,9 @@ void GMainWindow::UpdateUISettings() {
 }
 
 void GMainWindow::UpdateInputDrivers() {
+    if (main_window_is_closing) {
+        return;
+    }
     // Do not process any controller input while the loading screen is active
     if (loading_screen && loading_screen->isVisible()) {
         return;
@@ -6180,6 +6184,8 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
+    main_window_is_closing = true;
+
 #if defined(_MSC_VER) && defined(CITRON_ENABLE_PGO_GENERATE)
     // Explicitly flush PGO profile data when closing via X or File->Exit.
     // Without this, .pgc may not be written on some shutdown paths.
@@ -6189,7 +6195,9 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     // Stop periodic SDL event pumping and any pending emu shutdown timer so they cannot fire
     // during controller unload, render close, or HID teardown (avoids exit crashes on macOS).
     update_input_timer.stop();
+    disconnect(&update_input_timer, nullptr, this, nullptr);
     shutdown_timer.stop();
+    disconnect(&shutdown_timer, nullptr, this, nullptr);
 
     // 1. STOP the emulation first
     if (emu_thread != nullptr) {
@@ -6228,12 +6236,16 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     UISettings::SaveWindowState();
     hotkey_registry.SaveHotkeys();
 
-    // 4. NOW it is safe to kill the hardware devices
+    // 4. Tear down HID input before the render window: ~GRenderWindow calls
+    // input_subsystem->Shutdown(), which must not run while emulated SDL devices still exist.
+    if (system) {
+        system->HIDCore().UnloadInputDevices();
+    }
+
     render_window->close();
     multiplayer_state->Close();
 
     if (system) {
-        system->HIDCore().UnloadInputDevices();
         system->GetRoomNetwork().Shutdown();
     }
 

--- a/src/citron/main.h
+++ b/src/citron/main.h
@@ -474,6 +474,8 @@ private:
     QTimer status_bar_update_timer;
     std::unique_ptr<QtConfig> config;
     bool emulation_running = false;
+    /// Set for the duration of closeEvent; blocks UpdateInputDrivers / SDL pump during teardown.
+    bool main_window_is_closing = false;
     std::unique_ptr<EmuThread> emu_thread;
     QString current_game_path;
     bool user_flag_cmd_line = false;

--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -581,9 +581,12 @@ SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_en
     // Share the same button mapping with non-Nintendo controllers
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
 
-    // Disable hidapi driver for xbox. Already default on Windows, this causes conflict with native
-    // driver on Linux.
+    // On Linux, HIDAPI Xbox competes with the evdev/kernel Xbox driver; force it off. On macOS (and
+    // other non-Linux), leave the default so Xbox controllers can use HIDAPI and expose a proper
+    // GameController mapping (otherwise SDL may only see a generic joystick and bindings are empty).
+#if defined(__linux__)
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX, "0");
+#endif
 
     // If the frontend is going to manage the event loop, then we don't start one here
     start_thread = SDL_WasInit(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) == 0;
@@ -898,8 +901,8 @@ ButtonBindings SDLDriver::GetDefaultButtonBinding(
         srr_button = SDL_CONTROLLER_BUTTON_PADDLE1;
     }
 
-    // Switch: B=south / A=east vs SDL A=south / B=east, and transposed X/Y. Sony uses SDL face
-    // order like Xbox; other pads use Switch-style A/B mapping.
+    // Switch: B=south / A=east vs SDL A=south / B=east, and transposed X/Y. PlayStation and Xbox
+    // use SDL face buttons like their printed A/B; other pads use Switch-style positional A/B swap.
     SDL_GameController* controller = joystick->GetSDLGameController();
     const SDL_GameControllerType controller_type =
         controller ? SDL_GameControllerGetType(controller) : SDL_CONTROLLER_TYPE_UNKNOWN;
@@ -908,9 +911,12 @@ ButtonBindings SDLDriver::GetDefaultButtonBinding(
         controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT ||
         controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT ||
         controller_type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR;
-    const bool sony = IsSonyGamepad(controller);
-    const SDL_GameControllerButton sdl_a = sony ? SDL_CONTROLLER_BUTTON_A : SDL_CONTROLLER_BUTTON_B;
-    const SDL_GameControllerButton sdl_b = sony ? SDL_CONTROLLER_BUTTON_B : SDL_CONTROLLER_BUTTON_A;
+    const bool use_printed_face_ab =
+        IsSonyGamepad(controller) || IsMicrosoftGamepad(controller);
+    const SDL_GameControllerButton sdl_a =
+        use_printed_face_ab ? SDL_CONTROLLER_BUTTON_A : SDL_CONTROLLER_BUTTON_B;
+    const SDL_GameControllerButton sdl_b =
+        use_printed_face_ab ? SDL_CONTROLLER_BUTTON_B : SDL_CONTROLLER_BUTTON_A;
     const SDL_GameControllerButton sdl_x =
         nintendo_xy_swap ? SDL_CONTROLLER_BUTTON_Y : SDL_CONTROLLER_BUTTON_X;
     const SDL_GameControllerButton sdl_y =
@@ -1030,7 +1036,13 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         return {};
     }
 
+    // Linux/Windows: Xbox kernel/SDL stack often needs stick Y flipped vs Switch; PS5 and others use
+    // "+". macOS: all pads (including Xbox HIDAPI and DualSense) use the same "+" polarity here.
+#if defined(__APPLE__)
+    const char* const stick_invert_y = "+";
+#else
     const char* const stick_invert_y = IsMicrosoftGamepad(controller) ? "-" : "+";
+#endif
 
     AnalogMapping mapping = {};
     const auto& binding_left_x =


### PR DESCRIPTION
## Part 1 — CMake / nx_tzdb

### Problem

On POSIX hosts (e.g. macOS), `externals/nx_tzdb` assumes a local **tzdb_to_nx** tree when `CAN_BUILD_NX_TZDB` is true and `CITRON_DOWNLOAD_TIME_ZONE_DATA` is off. If the repo was configured **without** `CITRON_USE_CPM` (and without that source checked out), `TZDB_TO_NX_SOURCE_DIR` is unset and CMake fails with:

```text
tzdb_to_nx source not found. Enable CITRON_USE_CPM so the source can be fetched.
```

### Change

Treat a local tzdb build as optional: only use `add_subdirectory(tzdb_to_nx)` when `TZDB_TO_NX_SOURCE_DIR` exists and contains `CMakeLists.txt`. Otherwise, use the **same prebuilt release zip** already used on Windows and for download-based builds (no new CMake option required).

### Result

Default macOS/Linux configures succeed when CPM/submodule is not used; developers who **do** provide tzdb_to_nx keep the local build path.

### How to verify

- From a clean or existing build directory: `cmake -S . -B build` (without `CITRON_USE_CPM`) — configure completes; first run may download the timezone archive.
- Optional: `-DCITRON_DOWNLOAD_TIME_ZONE_DATA=ON` still forces the zip path explicitly.

---

## Part 2 — macOS / quit shutdown (two commits)

### Problem

- Periodic SDL pumping (`update_input_timer`) and `shutdown_timer` could still run while controllers, render, or HID were tearing down.
- **`render_window->close()` ran before `UnloadInputDevices()`**. `~GRenderWindow` calls `input_subsystem->Shutdown()` and tears down SDL while HID still held emulated devices bound to those engines → use-after-teardown on exit.

### Change

1. In `closeEvent`: stop `update_input_timer` and `shutdown_timer`, then **disconnect** their signals to this widget; set **`main_window_is_closing`** so **`UpdateInputDrivers`** no-ops during teardown.
2. **Call `HIDCore::UnloadInputDevices()` before `render_window->close()`** so emulated devices are released before `input_subsystem->Shutdown()`.
3. In **`OnShutdownBegin`**: `disconnect` `shutdown_timer` from this before reconnecting (avoids stacked timeout slots across repeated shutdowns).

### How to verify

- Quit from the main window (with and without a game running); no crash during the last phase of shutdown.

---

## Part 3 — Xbox (and stick Y on Apple) via SDL

### Problem

- Forcing `SDL_HINT_JOYSTICK_HIDAPI_XBOX` off on **all** OSes broke proper `GameController` mapping on macOS (joystick-only / empty mappings), similar in spirit to needing HIDAPI paths for PS5.
- Face buttons: treat Xbox like DualSense (printed A/B vs SDL indices).
- Stick **Y** invert: Linux/Windows Xbox stack still uses the legacy flip; **Apple** uses the same `"+"` stick polarity as other SDL pads (matches DualSense on macOS).

### Change (`sdl_driver.cpp`)

- Set `SDL_HINT_JOYSTICK_HIDAPI_XBOX` to `"0"` **only on Linux** (comment documents macOS leaving defaults).
- `use_printed_face_ab = IsSonyGamepad || IsMicrosoftGamepad` for default button bindings.
- `stick_invert_y`: `"+"` on **`__APPLE__`**; on other platforms keep `IsMicrosoftGamepad ? "-" : "+"`.

### How to verify

- macOS: Xbox controller registers as a gamepad, face buttons and sticks feel correct; PS5 unchanged on Apple (same stick path as other pads in that block).
