### PR TITLE
fix: mk8d applet

### DIFF
--- a/src/core/hle/service/am/service/library_applet_accessor.cpp
+++ b/src/core/hle/service/am/service/library_applet_accessor.cpp
@@ -107,10 +107,10 @@ Result ILibraryAppletAccessor::PushInData(SharedPointer<IStorage> storage) {
 Result ILibraryAppletAccessor::PopOutData(Out<SharedPointer<IStorage>> out_storage) {
     LOG_DEBUG(Service_AM, "called");
     if (auto caller_applet = m_applet->caller_applet.lock(); caller_applet) {
-        Event m_system_event = caller_applet->lifecycle_manager.GetSystemEvent();
-        m_system_event.Signal();
+        caller_applet->lifecycle_manager.GetSystemEvent().Signal();
         caller_applet->lifecycle_manager.RequestResumeNotification();
-        m_system_event.Clear();
+        caller_applet->lifecycle_manager.GetSystemEvent().Clear();
+        caller_applet->lifecycle_manager.UpdateRequestedFocusState();
     }
     R_RETURN(m_broker->GetOutData().Pop(out_storage.Get()));
 }


### PR DESCRIPTION
This will completely fix the problem with the Mario Kart 8 Deluxe controller applet and other games that use it. The current solution is missing just one small detail to be perfect.