### PR TITLE
add malloc_trim guard __GLIBC__

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -499,8 +499,8 @@ struct System::Impl {
             madvise(device_memory->buffer.BackingBasePointer(), device_memory->buffer.backing_size,
                     MADV_DONTNEED);
 
-// Only call malloc_trim on non-Android Linux (glibc)
-#ifndef __ANDROID__
+// Only call malloc_trim when building with glibc
+#ifdef __GLIBC__
             malloc_trim(0);
 #endif
 


### PR DESCRIPTION
building with musl fails with:

```
citron-neo/src/core/core.cpp:504:13: error: use of undeclared identifier 'malloc_trim'
  504 |             malloc_trim(0);
      |             ^~~~~~~~~~~
1 error generated.
```

change guard from 'not on Android' to 'only with glibc'.

fix: #195