### PR TITLE
Fix Qt 6 deprecation warnings in citron UI

### DIFF
--- a/src/citron/bootmanager.cpp
+++ b/src/citron/bootmanager.cpp
@@ -810,7 +810,7 @@ void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
         img.scaled(static_cast<int>(camera_width), static_cast<int>(camera_height),
                    Qt::AspectRatioMode::IgnoreAspectRatio,
                    Qt::TransformationMode::SmoothTransformation)
-            .mirrored(false, true);
+            .flipped(Qt::Vertical);
     if (camera_data.size() != camera_width * camera_height) {
         camera_data.resize(camera_width * camera_height);
     }
@@ -929,7 +929,8 @@ void GRenderWindow::CaptureScreenshot(const QString& screenshot_path) {
         screenshot_image.bits(),
         [=, this](bool invert_y) {
             const std::string std_screenshot_path = screenshot_path.toStdString();
-            if ((invert_y ? screenshot_image.mirrored(false, true) : screenshot_image).save(screenshot_path)) {
+            if ((invert_y ? screenshot_image.flipped(Qt::Vertical) : screenshot_image)
+                    .save(screenshot_path)) {
                 LOG_INFO(Frontend, "Screenshot saved to \"{}\"", std_screenshot_path);
             } else {
                 LOG_ERROR(Frontend, "Failed to save screenshot to \"{}\"", std_screenshot_path);

--- a/src/citron/bootmanager.cpp
+++ b/src/citron/bootmanager.cpp
@@ -810,7 +810,7 @@ void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
         img.scaled(static_cast<int>(camera_width), static_cast<int>(camera_height),
                    Qt::AspectRatioMode::IgnoreAspectRatio,
                    Qt::TransformationMode::SmoothTransformation)
-            .flipped(Qt::Vertical);
+            .mirrored(false, true);
     if (camera_data.size() != camera_width * camera_height) {
         camera_data.resize(camera_width * camera_height);
     }

--- a/src/citron/game_list.cpp
+++ b/src/citron/game_list.cpp
@@ -1629,7 +1629,7 @@ GameList::GameList(std::shared_ptr<FileSys::VfsFilesystem> vfs_,
                                     QVariant orig_icon_data =
                                         original_item->data(Qt::DecorationRole);
                                     if (orig_icon_data.isValid() &&
-                                        orig_icon_data.type() == QVariant::Pixmap) {
+                                        orig_icon_data.typeId() == QMetaType::QPixmap) {
                                         QPixmap orig_pixmap = orig_icon_data.value<QPixmap>();
                                         if (!orig_pixmap.isNull()) {
                                             QPixmap rounded(icon_size, icon_size);


### PR DESCRIPTION
## Summary
- Replace deprecated QImage::mirrored with flipped()
- Replace QVariant::type() with typeId() / QMetaType::QPixmap

## Test plan
- [ ] Build citron on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screenshot rendering when inverting the Y axis, ensuring captured images display with the correct vertical orientation.
  * Improved the icon-size slider behavior so icon scaling updates reliably with the underlying icon artwork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->