### PR TITLE
Halt loading screen animations safely during teardown

### DIFF
--- a/src/citron/loading_screen.cpp
+++ b/src/citron/loading_screen.cpp
@@ -288,6 +288,6 @@ void LoadingScreen::paintEvent(QPaintEvent* event) {
 }
 
 void LoadingScreen::Clear() {
+    HaltTransitions();
     ui->game_icon->clear();
-    loading_text_animation_timer->stop();
 }

--- a/src/citron/loading_screen.cpp
+++ b/src/citron/loading_screen.cpp
@@ -46,7 +46,22 @@ LoadingScreen::LoadingScreen(QWidget* parent)
 }
 
 LoadingScreen::~LoadingScreen() {
-    loading_text_animation_timer->stop();
+    HaltTransitions();
+}
+
+void LoadingScreen::HaltTransitions() {
+    if (loading_text_animation_timer) {
+        loading_text_animation_timer->stop();
+    }
+    if (fadeout_animation) {
+        // stop() can emit finished(); block so teardown does not run the hide/Hidden callback.
+        fadeout_animation->blockSignals(true);
+        fadeout_animation->stop();
+        fadeout_animation->blockSignals(false);
+    }
+    if (movie) {
+        movie->stop();
+    }
 }
 
 void LoadingScreen::Prepare(Loader::AppLoader& loader) {
@@ -171,7 +186,7 @@ void LoadingScreen::UpdateLoadingText() {
 }
 
 void LoadingScreen::OnLoadComplete() {
-    loading_text_animation_timer->stop();
+    HaltTransitions();
     fadeout_animation->start();
 }
 

--- a/src/citron/loading_screen.h
+++ b/src/citron/loading_screen.h
@@ -37,6 +37,8 @@ public:
     ~LoadingScreen();
 
     void Prepare(Loader::AppLoader& loader);
+    /// Stop progress/fade animations so teardown does not touch widgets from the event loop later.
+    void HaltTransitions();
     void Clear();
     void OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
     void OnLoadComplete();


### PR DESCRIPTION
## Summary
- Add HaltTransitions() to stop fade/text animations before teardown
- Call from destructor, Clear(), and OnLoadComplete()

## Test plan
- [ ] Launch game, confirm loading screen fades out cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loading screen shutdown and transition teardown to reliably stop the loading text timer, fade-out animation, and any active video playback during application termination or when loading completes.

* **Refactor**
  * Centralized transition/animation cleanup into a single helper method and updated key lifecycle actions to use it for consistent, reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->