### PR TITLE
chore: repo hygiene gitignore for MoltenVK and device logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,14 @@ pgo-profiles-backup/
 *.tar.gz
 *.tar
 
+# Local device crash reports and debug logs (not part of the project)
+device-crashes/
+citron_ios_device_log.txt
+
+# Local MoltenVK SDK drops for debugging / iOS builds (downloaded by CMake for desktop)
+externals/moltenvk-all/
+externals/moltenvk-ios/
+
 # misc
 *.index
 *.keys


### PR DESCRIPTION
## Summary
- Ignore local MoltenVK SDK drops under `externals/moltenvk-*`
- Ignore device crash reports and local iOS debug logs

Split from `moltenvk-xfb` (file-group checkout, not cherry-pick).

## Test plan
- [ ] Confirm `.gitignore` only; no build impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude additional local development and build artifacts, including device crash reports, iOS debug logs, and MoltenVK SDK directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->