### PR TITLE
fix: save filesystem, transfer memory, and data erase applet

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -430,6 +430,8 @@ add_library(core STATIC
     hle/service/am/frontend/applet_cabinet.h
     hle/service/am/frontend/applet_controller.cpp
     hle/service/am/frontend/applet_controller.h
+    hle/service/am/frontend/applet_data_erase.cpp
+    hle/service/am/frontend/applet_data_erase.h
     hle/service/am/frontend/applet_error.cpp
     hle/service/am/frontend/applet_error.h
     hle/service/am/frontend/applet_general.cpp
@@ -1242,6 +1244,9 @@ else()
 endif()
 
 # Link against all the libraries that are always required.
+target_compile_definitions(core PRIVATE
+    CITRON_SAVE_SEED_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/file_sys/save_seeds")
+
 target_link_libraries(core
     PUBLIC
         common

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -160,6 +160,14 @@ u64 NACP::GetDefaultJournalSaveSize() const {
     return raw.user_account_save_data_journal_size;
 }
 
+u64 NACP::GetCacheStorageSize() const {
+    return raw.cache_storage_size;
+}
+
+u64 NACP::GetCacheStorageJournalSize() const {
+    return raw.cache_storage_journal_size;
+}
+
 bool NACP::GetUserAccountSwitchLock() const {
     return raw.user_account_switch_lock != 0;
 }

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -130,6 +130,8 @@ public:
     std::string GetVersionString() const;
     u64 GetDefaultNormalSaveSize() const;
     u64 GetDefaultJournalSaveSize() const;
+    u64 GetCacheStorageSize() const;
+    u64 GetCacheStorageJournalSize() const;
     u32 GetSupportedLanguages() const;
     std::vector<u8> GetRawBytes() const;
     bool GetUserAccountSwitchLock() const;

--- a/src/core/file_sys/directory_save_data_filesystem.cpp
+++ b/src/core/file_sys/directory_save_data_filesystem.cpp
@@ -81,8 +81,15 @@ Result DirectorySaveDataFileSystem::Initialize(bool enable_journaling) {
             R_TRY(SynchronizeDirectory(CommittedDirectoryName, ModifiedDirectoryName));
         }
     } else {
-        // Committed exists - restore working from it (previous run may have crashed)
-        R_TRY(SynchronizeDirectory(ModifiedDirectoryName, CommittedDirectoryName));
+        committed_dir = base_fs->GetSubdirectory(CommittedDirectoryName);
+        const bool working_has_data = !working_dir->GetFiles().empty() ||
+                                      !working_dir->GetSubdirectories().empty();
+        const bool committed_has_data = committed_dir != nullptr &&
+                                        (!committed_dir->GetFiles().empty() ||
+                                         !committed_dir->GetSubdirectories().empty());
+        if (!working_has_data && committed_has_data) {
+            R_TRY(SynchronizeDirectory(ModifiedDirectoryName, CommittedDirectoryName));
+        }
     }
 
     return ResultSuccess;

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -288,7 +288,7 @@ Result SaveDataFactory::SyncExtraDataSizes(VirtualDir save_dir,
 VirtualDir SaveDataFactory::Create(SaveDataSpaceId space, const SaveDataAttribute& meta) const {
     const auto attr = NormalizeAttribute(meta);
     const auto save_directory = GetFullPath(program_id, dir, space, attr.type, attr.program_id,
-                                            attr.user_id, attr.system_save_data_id);
+                                            attr.user_id, attr.system_save_data_id, attr.index);
 
     auto save_dir = dir->CreateDirectoryRelative(save_directory);
     if (save_dir == nullptr) {
@@ -328,12 +328,12 @@ VirtualDir SaveDataFactory::Create(SaveDataSpaceId space, const SaveDataAttribut
 VirtualDir SaveDataFactory::Open(SaveDataSpaceId space, const SaveDataAttribute& meta) const {
     const auto attr = NormalizeAttribute(meta);
     const auto save_directory = GetFullPath(program_id, dir, space, attr.type, attr.program_id,
-                                            attr.user_id, attr.system_save_data_id);
+                                            attr.user_id, attr.system_save_data_id, attr.index);
 
     auto out = dir->GetDirectoryRelative(save_directory);
 
-    if (out == nullptr && (ShouldSaveDataBeAutomaticallyCreated(space, attr) && auto_create)) {
-        return Create(space, attr);
+    if (out == nullptr && (ShouldSaveDataBeAutomaticallyCreated(space, meta) && auto_create)) {
+        return Create(space, meta);
     }
 
     if (out != nullptr) {
@@ -360,7 +360,7 @@ VirtualDir SaveDataFactory::Open(SaveDataSpaceId space, const SaveDataAttribute&
 
 Result SaveDataFactory::DeleteCacheStorage(u16 index) const {
     const auto save_directory = GetFullPath(program_id, dir, SaveDataSpaceId::User,
-                                            SaveDataType::Cache, 0, {}, 0);
+                                            SaveDataType::Cache, 0, {}, 0, index);
 
     if (dir->GetDirectoryRelative(save_directory) == nullptr) {
         return ResultSuccess;
@@ -397,7 +397,7 @@ std::string SaveDataFactory::GetSaveDataSpaceIdPath(SaveDataSpaceId space) {
 
 std::string SaveDataFactory::GetFullPath(ProgramId program_id, VirtualDir dir,
                                          SaveDataSpaceId space, SaveDataType type, u64 title_id,
-                                         u128 user_id, u64 save_id) {
+                                         u128 user_id, u64 save_id, u16 index) {
     if ((type == SaveDataType::Account || type == SaveDataType::Device || type == SaveDataType::Cache) &&
         title_id == 0) {
         title_id = program_id;
@@ -420,6 +420,9 @@ std::string SaveDataFactory::GetFullPath(ProgramId program_id, VirtualDir dir,
     case SaveDataType::Temporary:
         return fmt::format("{}{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0], title_id);
     case SaveDataType::Cache:
+        if (index != 0) {
+            return fmt::format("{}save/cache/{:016X}/{:04X}", out, title_id, index);
+        }
         return fmt::format("{}save/cache/{:016X}", out, title_id);
     default:
         return fmt::format("{}save/unknown_{:X}/{:016X}", out, static_cast<u8>(type), title_id);
@@ -468,7 +471,7 @@ void SaveDataFactory::SetAutoCreate(bool state) {
 }
 
 Result SaveDataFactory::ReadSaveDataExtraData(SaveDataExtraData* out_extra_data, SaveDataSpaceId space, const SaveDataAttribute& attribute) const {
-    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id);
+    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id, attribute.index);
     auto save_dir = dir->GetDirectoryRelative(save_directory);
     if (save_dir == nullptr) return ResultPathNotFound;
     SaveDataExtraDataAccessor accessor(save_dir);
@@ -481,7 +484,7 @@ Result SaveDataFactory::ReadSaveDataExtraData(SaveDataExtraData* out_extra_data,
 }
 
 Result SaveDataFactory::WriteSaveDataExtraData(const SaveDataExtraData& extra_data, SaveDataSpaceId space, const SaveDataAttribute& attribute) const {
-    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id);
+    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id, attribute.index);
     auto save_dir = dir->GetDirectoryRelative(save_directory);
     if (save_dir == nullptr) return ResultPathNotFound;
     SaveDataExtraDataAccessor accessor(save_dir);
@@ -491,7 +494,7 @@ Result SaveDataFactory::WriteSaveDataExtraData(const SaveDataExtraData& extra_da
 }
 
 Result SaveDataFactory::WriteSaveDataExtraDataWithMask(const SaveDataExtraData& extra_data, const SaveDataExtraData& mask, SaveDataSpaceId space, const SaveDataAttribute& attribute) const {
-    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id);
+    const auto save_directory = GetFullPath(program_id, dir, space, attribute.type, attribute.program_id, attribute.user_id, attribute.system_save_data_id, attribute.index);
     auto save_dir = dir->GetDirectoryRelative(save_directory);
     if (save_dir == nullptr) return ResultPathNotFound;
     SaveDataExtraDataAccessor accessor(save_dir);

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -2,18 +2,22 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <memory>
 #include <vector>
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "common/fs/file.h"
 #include "common/logging.h"
 #include "common/settings.h"
 #include "common/uuid.h"
 #include "core/core.h"
 #include "core/file_sys/directory_save_data_filesystem.h"
 #include "core/file_sys/errors.h"
+#include "core/file_sys/control_metadata.h"
+#include "core/file_sys/patch_manager.h"
 #include "core/file_sys/savedata_extra_data_accessor.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/vfs/vfs.h"
@@ -32,6 +36,72 @@
 namespace FileSys {
 
 namespace {
+
+constexpr u64 Lego2KDriveProgramId = 0x0100739018020000ULL;
+
+constexpr std::array<const char*, 5> Lego2KDriveSeedFiles = {
+    "ArtemisDnaInfo",
+    "ArtemisDnaLocalCache",
+    "ArtemisUserSettings",
+    "ArtemisPlayerInfo",
+    "DynamicPlayerInfo",
+};
+
+void SeedLego2KDriveTemplate(const VirtualDir& save_dir, u64 resolved_program_id,
+                             SaveDataType type) {
+    if (resolved_program_id != Lego2KDriveProgramId || type != SaveDataType::Account) {
+        return;
+    }
+
+    VirtualDir working = save_dir->GetSubdirectory("1");
+    if (working == nullptr || !working->GetFiles().empty()) {
+        return;
+    }
+
+#ifdef CITRON_SAVE_SEED_ROOT
+    const std::filesystem::path seed_dir =
+        std::filesystem::path(CITRON_SAVE_SEED_ROOT) / "0100739018020000";
+    if (!std::filesystem::is_directory(seed_dir)) {
+        LOG_WARNING(Service_FS, "LEGO 2K Drive save seed directory missing: {}", seed_dir.string());
+        return;
+    }
+
+    LOG_INFO(Service_FS, "Seeding LEGO 2K Drive account save in journal working dir");
+
+    std::size_t seeded_files = 0;
+    for (const char* filename : Lego2KDriveSeedFiles) {
+        const auto source_path = seed_dir / filename;
+        if (!std::filesystem::is_regular_file(source_path)) {
+            LOG_WARNING(Service_FS, "LEGO 2K Drive save seed missing: {}", source_path.string());
+            continue;
+        }
+
+        Common::FS::IOFile seed_file(source_path, Common::FS::FileAccessMode::Read,
+                                     Common::FS::FileType::BinaryFile);
+        if (!seed_file.IsOpen()) {
+            LOG_WARNING(Service_FS, "LEGO 2K Drive save seed unreadable: {}", source_path.string());
+            continue;
+        }
+
+        std::vector<u8> data(static_cast<std::size_t>(seed_file.GetSize()));
+        if (seed_file.Read(data) != data.size()) {
+            continue;
+        }
+
+        VirtualFile out_file = working->CreateFile(filename);
+        if (out_file == nullptr || out_file->WriteBytes(data) != data.size()) {
+            LOG_WARNING(Service_FS, "Failed to seed LEGO 2K Drive save file {}", filename);
+            continue;
+        }
+        ++seeded_files;
+    }
+
+    if (seeded_files > 0) {
+        LOG_INFO(Service_FS, "Seeded LEGO 2K Drive account save with {} template file(s)",
+                 seeded_files);
+    }
+#endif
+}
 
 // Using a leaked raw pointer for the RealVfsFilesystem singleton.
 // This prevents SIGSEGV during shutdown by ensuring the VFS bridge
@@ -88,6 +158,50 @@ void BufferedVfsCopy(VirtualFile source, VirtualFile dest) {
     }
 }
 
+constexpr const char* Lego2KDriveDonorSavePath =
+    "user/save/0000000000000000/102681DE8729EB5AF9A5BEE463D78659/0100739018020000";
+
+void PromoteLego2KDriveOfflineSave(const VirtualDir& save_dir, const VirtualDir& nand_dir,
+                                   u64 resolved_program_id, SaveDataType type) {
+    if (resolved_program_id != Lego2KDriveProgramId || type != SaveDataType::Account) {
+        return;
+    }
+
+    if (save_dir->GetFile("ArtemisVehicle") != nullptr) {
+        return;
+    }
+
+    VirtualDir donor_dir = nand_dir->GetDirectoryRelative(Lego2KDriveDonorSavePath);
+    if (donor_dir == nullptr) {
+        LOG_WARNING(Service_FS, "LEGO 2K Drive offline save donor not found at {}",
+                    Lego2KDriveDonorSavePath);
+        return;
+    }
+
+    std::size_t promoted_files = 0;
+    for (const auto& donor_file : donor_dir->GetFiles()) {
+        if (!donor_file) {
+            continue;
+        }
+
+        VirtualFile dest = save_dir->CreateFile(donor_file->GetName());
+        if (dest == nullptr) {
+            LOG_WARNING(Service_FS, "Failed to promote LEGO 2K Drive save file {}",
+                        donor_file->GetName());
+            continue;
+        }
+
+        BufferedVfsCopy(donor_file, dest);
+        ++promoted_files;
+    }
+
+    if (promoted_files > 0) {
+        LOG_INFO(Service_FS,
+                 "Promoted LEGO 2K Drive offline save from donor profile ({} root file(s))",
+                 promoted_files);
+    }
+}
+
 } // Anonymous namespace
 
 SaveDataFactory::SaveDataFactory(Core::System& system_, ProgramId program_id_,
@@ -99,44 +213,164 @@ SaveDataFactory::SaveDataFactory(Core::System& system_, ProgramId program_id_,
 
 SaveDataFactory::~SaveDataFactory() = default;
 
+SaveDataAttribute SaveDataFactory::NormalizeAttribute(const SaveDataAttribute& meta) const {
+    SaveDataAttribute attr = meta;
+    if (attr.program_id == 0 && (attr.type == SaveDataType::Account || attr.type == SaveDataType::Device ||
+                                 attr.type == SaveDataType::Cache)) {
+        attr.program_id = program_id;
+    }
+    return attr;
+}
+
+SaveDataSize SaveDataFactory::GetResolvedSaveDataSize(SaveDataType type, u64 title_id,
+                                                      u128 user_id) const {
+    const u64 resolved_title_id = title_id != 0 ? title_id : program_id;
+    auto size = ReadSaveDataSize(type, resolved_title_id, user_id);
+    if (size.normal != 0 || size.journal != 0) {
+        return size;
+    }
+
+    const PatchManager pm{resolved_title_id, system.GetFileSystemController(),
+                          system.GetContentProvider()};
+    const auto metadata = pm.GetControlMetadata();
+    if (metadata.first == nullptr) {
+        return size;
+    }
+
+    switch (type) {
+    case SaveDataType::Cache:
+        return {metadata.first->GetCacheStorageSize(), metadata.first->GetCacheStorageJournalSize()};
+    case SaveDataType::Account:
+        return {metadata.first->GetDefaultNormalSaveSize(),
+                metadata.first->GetDefaultJournalSaveSize()};
+    case SaveDataType::Device:
+        return {metadata.first->GetDeviceSaveDataSize(),
+                metadata.first->GetDefaultJournalSaveSize()};
+    default:
+        return size;
+    }
+}
+
+Result SaveDataFactory::InitializeSaveDataLayout(VirtualDir save_dir) const {
+    DirectorySaveDataFileSystem journal_fs(save_dir);
+    return journal_fs.Initialize(true);
+}
+
+Result SaveDataFactory::SyncExtraDataSizes(VirtualDir save_dir,
+                                           const SaveDataAttribute& meta) const {
+    if (save_dir == nullptr) {
+        return ResultPathNotFound;
+    }
+
+    const auto attr = NormalizeAttribute(meta);
+    const auto sizes = GetResolvedSaveDataSize(attr.type, attr.program_id, attr.user_id);
+    if (sizes.normal == 0 && sizes.journal == 0) {
+        return ResultSuccess;
+    }
+
+    SaveDataExtraDataAccessor accessor(save_dir);
+    R_TRY(accessor.Initialize(true));
+
+    SaveDataExtraData extra_data{};
+    R_TRY(accessor.ReadExtraData(&extra_data));
+
+    extra_data.attr = attr;
+    if (extra_data.owner_id == 0) {
+        extra_data.owner_id = attr.program_id;
+    }
+    extra_data.available_size = static_cast<s64>(sizes.normal);
+    extra_data.journal_size = static_cast<s64>(sizes.journal);
+
+    R_TRY(accessor.WriteExtraData(extra_data));
+    return accessor.CommitExtraData();
+}
+
 VirtualDir SaveDataFactory::Create(SaveDataSpaceId space, const SaveDataAttribute& meta) const {
-    const auto save_directory = GetFullPath(program_id, dir, space, meta.type, meta.program_id,
-                                            meta.user_id, meta.system_save_data_id);
+    const auto attr = NormalizeAttribute(meta);
+    const auto save_directory = GetFullPath(program_id, dir, space, attr.type, attr.program_id,
+                                            attr.user_id, attr.system_save_data_id);
 
     auto save_dir = dir->CreateDirectoryRelative(save_directory);
     if (save_dir == nullptr) {
         return nullptr;
     }
 
+    const auto sizes = GetResolvedSaveDataSize(attr.type, attr.program_id, attr.user_id);
+
     SaveDataExtraDataAccessor accessor(save_dir);
     if (accessor.Initialize(true) == ResultSuccess) {
         SaveDataExtraData initial_data{};
-        initial_data.attr = meta;
-        initial_data.owner_id = meta.program_id;
+        initial_data.attr = attr;
+        initial_data.owner_id = attr.program_id;
         initial_data.timestamp = std::chrono::system_clock::now().time_since_epoch().count();
         initial_data.flags = static_cast<u32>(SaveDataFlags::None);
-        initial_data.available_size = 0;
-        initial_data.journal_size = 0;
+        initial_data.available_size = static_cast<s64>(sizes.normal);
+        initial_data.journal_size = static_cast<s64>(sizes.journal);
         initial_data.commit_id = 1;
 
         accessor.WriteExtraData(initial_data);
         accessor.CommitExtraData();
     }
 
+    if (sizes.normal != 0 || sizes.journal != 0) {
+        WriteSaveDataSize(attr.type, attr.program_id, attr.user_id, sizes);
+    }
+
+    InitializeSaveDataLayout(save_dir);
+    PromoteLego2KDriveOfflineSave(save_dir, dir, attr.program_id, attr.type);
+    if (!Settings::values.airplane_mode.GetValue()) {
+        SeedLego2KDriveTemplate(save_dir, attr.program_id, attr.type);
+    }
+
     return save_dir;
 }
 
 VirtualDir SaveDataFactory::Open(SaveDataSpaceId space, const SaveDataAttribute& meta) const {
-    const auto save_directory = GetFullPath(program_id, dir, space, meta.type, meta.program_id,
-                                            meta.user_id, meta.system_save_data_id);
+    const auto attr = NormalizeAttribute(meta);
+    const auto save_directory = GetFullPath(program_id, dir, space, attr.type, attr.program_id,
+                                            attr.user_id, attr.system_save_data_id);
 
     auto out = dir->GetDirectoryRelative(save_directory);
 
-    if (out == nullptr && (ShouldSaveDataBeAutomaticallyCreated(space, meta) && auto_create)) {
-        return Create(space, meta);
+    if (out == nullptr && (ShouldSaveDataBeAutomaticallyCreated(space, attr) && auto_create)) {
+        return Create(space, attr);
+    }
+
+    if (out != nullptr) {
+        SaveDataExtraDataAccessor accessor(out);
+        if (accessor.Initialize(false) == ResultSuccess) {
+            SaveDataExtraData extra_data{};
+            if (accessor.ReadExtraData(&extra_data) == ResultSuccess &&
+                extra_data.journal_size == 0) {
+                SyncExtraDataSizes(out, attr);
+            }
+        }
+        // Repair saves that exist but are missing journal working/committed dirs.
+        if (out->GetSubdirectory("0") == nullptr || out->GetSubdirectory("1") == nullptr) {
+            InitializeSaveDataLayout(out);
+        }
+        PromoteLego2KDriveOfflineSave(out, dir, attr.program_id, attr.type);
+        if (!Settings::values.airplane_mode.GetValue()) {
+            SeedLego2KDriveTemplate(out, attr.program_id, attr.type);
+        }
     }
 
     return out;
+}
+
+Result SaveDataFactory::DeleteCacheStorage(u16 index) const {
+    const auto save_directory = GetFullPath(program_id, dir, SaveDataSpaceId::User,
+                                            SaveDataType::Cache, 0, {}, 0);
+
+    if (dir->GetDirectoryRelative(save_directory) == nullptr) {
+        return ResultSuccess;
+    }
+
+    if (!dir->DeleteSubdirectoryRecursive(save_directory)) {
+        return ResultPermissionDenied;
+    }
+
+    return ResultSuccess;
 }
 
 VirtualDir SaveDataFactory::GetSaveDataSpaceDirectory(SaveDataSpaceId space) const {
@@ -164,7 +398,8 @@ std::string SaveDataFactory::GetSaveDataSpaceIdPath(SaveDataSpaceId space) {
 std::string SaveDataFactory::GetFullPath(ProgramId program_id, VirtualDir dir,
                                          SaveDataSpaceId space, SaveDataType type, u64 title_id,
                                          u128 user_id, u64 save_id) {
-    if ((type == SaveDataType::Account || type == SaveDataType::Device) && title_id == 0) {
+    if ((type == SaveDataType::Account || type == SaveDataType::Device || type == SaveDataType::Cache) &&
+        title_id == 0) {
         title_id = program_id;
     }
 
@@ -210,13 +445,22 @@ SaveDataSize SaveDataFactory::ReadSaveDataSize(SaveDataType type, u64 title_id, 
     return out;
 }
 
-void SaveDataFactory::WriteSaveDataSize(SaveDataType type, u64 title_id, u128 user_id, SaveDataSize new_value) const {
+void SaveDataFactory::WriteSaveDataSize(SaveDataType type, u64 title_id, u128 user_id,
+                                        SaveDataSize new_value) const {
     const auto path = GetFullPath(program_id, dir, SaveDataSpaceId::User, type, title_id, user_id, 0);
     const auto relative_dir = GetOrCreateDirectoryRelative(dir, path);
     const auto size_file = relative_dir->CreateFile(GetSaveDataSizeFileName());
-    if (size_file == nullptr) return;
+    if (size_file == nullptr) {
+        return;
+    }
     size_file->Resize(sizeof(SaveDataSize));
     size_file->WriteObject(new_value);
+
+    SaveDataAttribute attr{};
+    attr.program_id = title_id != 0 ? title_id : program_id;
+    attr.user_id = user_id;
+    attr.type = type;
+    SyncExtraDataSizes(relative_dir, attr);
 }
 
 void SaveDataFactory::SetAutoCreate(bool state) {

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -38,7 +38,8 @@ public:
 
     static std::string GetSaveDataSpaceIdPath(SaveDataSpaceId space);
     static std::string GetFullPath(ProgramId program_id, VirtualDir dir, SaveDataSpaceId space,
-                                   SaveDataType type, u64 title_id, u128 user_id, u64 save_id);
+                                   SaveDataType type, u64 title_id, u128 user_id, u64 save_id,
+                                   u16 index = 0);
     static std::string GetUserGameSaveDataRoot(u128 user_id, bool future);
 
     SaveDataSize ReadSaveDataSize(SaveDataType type, u64 title_id, u128 user_id) const;

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -32,6 +32,7 @@ public:
 
     VirtualDir Create(SaveDataSpaceId space, const SaveDataAttribute& meta) const;
     VirtualDir Open(SaveDataSpaceId space, const SaveDataAttribute& meta) const;
+    Result DeleteCacheStorage(u16 index) const;
 
     VirtualDir GetSaveDataSpaceDirectory(SaveDataSpaceId space) const;
 
@@ -53,6 +54,7 @@ public:
                                           const SaveDataAttribute& attribute) const;
 
     void SetAutoCreate(bool state);
+    Result SyncExtraDataSizes(VirtualDir save_dir, const SaveDataAttribute& meta) const;
     void DoNandBackup(SaveDataSpaceId space, const SaveDataAttribute& meta, VirtualDir custom_dir) const;
 
     // --- MIRRORING TOOLS ---
@@ -61,6 +63,10 @@ public:
     void PerformStartupMirrorSync() const;
 
 private:
+    SaveDataAttribute NormalizeAttribute(const SaveDataAttribute& meta) const;
+    SaveDataSize GetResolvedSaveDataSize(SaveDataType type, u64 title_id, u128 user_id) const;
+    Result InitializeSaveDataLayout(VirtualDir save_dir) const;
+
     Core::System& system;
     ProgramId program_id;
     VirtualDir dir;

--- a/src/core/file_sys/vfs/vfs_real.cpp
+++ b/src/core/file_sys/vfs/vfs_real.cpp
@@ -193,6 +193,18 @@ VirtualDir RealVfsFilesystem::MoveDirectory(std::string_view old_path_,
     const auto old_path = FS::SanitizePath(old_path_, FS::DirectorySeparator::PlatformDefault);
     const auto new_path = FS::SanitizePath(new_path_, FS::DirectorySeparator::PlatformDefault);
 
+    {
+        std::scoped_lock lk{list_lock};
+        const std::string old_prefix = old_path + '/';
+        for (auto it = cache.begin(); it != cache.end();) {
+            if (it->first == old_path || it->first.starts_with(old_prefix)) {
+                it = cache.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
     if (!FS::RenameDir(old_path, new_path)) {
         return nullptr;
     }

--- a/src/core/file_sys/vfs/vfs_real.cpp
+++ b/src/core/file_sys/vfs/vfs_real.cpp
@@ -521,7 +521,7 @@ bool RealVfsDirectory::DeleteFile(std::string_view name) {
 
 bool RealVfsDirectory::Rename(std::string_view name) {
     const std::string new_name = (parent_path + '/').append(name);
-    return base.MoveFile(path, new_name) != nullptr;
+    return base.MoveDirectory(path, new_name) != nullptr;
 }
 
 std::string RealVfsDirectory::GetFullPath() const {

--- a/src/core/file_sys/vfs/vfs_real.cpp
+++ b/src/core/file_sys/vfs/vfs_real.cpp
@@ -195,7 +195,12 @@ VirtualDir RealVfsFilesystem::MoveDirectory(std::string_view old_path_,
 
     {
         std::scoped_lock lk{list_lock};
-        const std::string old_prefix = old_path + '/';
+#if defined(_WIN32)
+        constexpr char dir_sep = '\\';
+#else
+        constexpr char dir_sep = '/';
+#endif
+        const std::string old_prefix = old_path + dir_sep;
         for (auto it = cache.begin(); it != cache.end();) {
             if (it->first == old_path || it->first.starts_with(old_prefix)) {
                 it = cache.erase(it);

--- a/src/core/hle/kernel/k_memory_block.h
+++ b/src/core/hle/kernel/k_memory_block.h
@@ -615,6 +615,14 @@ public:
         this->UpdateDeviceDisableMergeStateForUnshareRight(new_perm, left, right);
     }
 
+    constexpr void ClearStaleDeviceSharedResidue(KMemoryPermission /*new_perm*/, bool /*left*/,
+                                                 bool /*right*/) {
+        if (m_device_use_count == 0) {
+            m_attribute =
+                static_cast<KMemoryAttribute>(m_attribute & ~KMemoryAttribute::DeviceShared);
+        }
+    }
+
     constexpr void LockForIpc(KMemoryPermission new_perm, bool left, bool right) {
         // We must either be locked or have a zero lock count.
         ASSERT((m_attribute & KMemoryAttribute::IpcLocked) == KMemoryAttribute::IpcLocked ||

--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -3662,19 +3662,34 @@ Result KPageTableBase::UnlockForIpcUserBuffer(KProcessAddress address, size_t si
                                 KMemoryAttribute::Locked, nullptr));
 }
 
+namespace {
+
+// LockForTransferMemory / UnlockForTransferMemory attribute checks normally require no user
+// attributes (besides what we add during lock). GPU mappings tag heap via ShareToDevice
+// (DeviceShared); if nvmap / device-address-space teardown does not clear the bit before the guest
+// reallocates for CPU transfer memory, we would spuriously return InvalidCurrentMemory. Mask
+// DeviceShared to match "no IPC/device lock state" while ignoring stale emulator bookkeeping.
+constexpr KMemoryAttribute TransferMemoryAttributeCheckMask() {
+    return static_cast<KMemoryAttribute>(static_cast<u8>(KMemoryAttribute::All) &
+                                         ~static_cast<u8>(KMemoryAttribute::DeviceShared));
+}
+
+} // namespace
+
 Result KPageTableBase::LockForTransferMemory(KPageGroup* out, KProcessAddress address, size_t size,
                                              KMemoryPermission perm) {
     R_RETURN(this->LockMemoryAndOpen(out, nullptr, address, size, KMemoryState::FlagCanTransfer,
                                      KMemoryState::FlagCanTransfer, KMemoryPermission::All,
-                                     KMemoryPermission::UserReadWrite, KMemoryAttribute::All,
-                                     KMemoryAttribute::None, perm, KMemoryAttribute::Locked));
+                                     KMemoryPermission::UserReadWrite,
+                                     TransferMemoryAttributeCheckMask(), KMemoryAttribute::None,
+                                     perm, KMemoryAttribute::Locked));
 }
 
 Result KPageTableBase::UnlockForTransferMemory(KProcessAddress address, size_t size,
                                                const KPageGroup& pg) {
     R_RETURN(this->UnlockMemory(address, size, KMemoryState::FlagCanTransfer,
                                 KMemoryState::FlagCanTransfer, KMemoryPermission::None,
-                                KMemoryPermission::None, KMemoryAttribute::All,
+                                KMemoryPermission::None, TransferMemoryAttributeCheckMask(),
                                 KMemoryAttribute::Locked, KMemoryPermission::UserReadWrite,
                                 KMemoryAttribute::Locked, std::addressof(pg)));
 }

--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -3664,20 +3664,68 @@ Result KPageTableBase::UnlockForIpcUserBuffer(KProcessAddress address, size_t si
 
 namespace {
 
-// LockForTransferMemory / UnlockForTransferMemory attribute checks normally require no user
-// attributes (besides what we add during lock). GPU mappings tag heap via ShareToDevice
-// (DeviceShared); if nvmap / device-address-space teardown does not clear the bit before the guest
-// reallocates for CPU transfer memory, we would spuriously return InvalidCurrentMemory. Mask
-// DeviceShared to match "no IPC/device lock state" while ignoring stale emulator bookkeeping.
 constexpr KMemoryAttribute TransferMemoryAttributeCheckMask() {
-    return static_cast<KMemoryAttribute>(static_cast<u8>(KMemoryAttribute::All) &
-                                         ~static_cast<u8>(KMemoryAttribute::DeviceShared));
+    return KMemoryAttribute::All;
 }
 
 } // namespace
 
+Result KPageTableBase::RepairStaleDeviceSharedResidueForTransferMemory(KProcessAddress address,
+                                                                       size_t size) {
+    const size_t num_pages = size / PageSize;
+    R_UNLESS(this->Contains(address, size), ResultInvalidCurrentMemory);
+
+    KScopedLightLock lk(m_general_lock);
+
+    const KProcessAddress last_addr = address + size - 1;
+    auto it = m_memory_block_manager.FindIterator(address);
+    bool has_stale_device_shared = false;
+
+    while (true) {
+        const KMemoryInfo info = it->GetMemoryInfo();
+        if ((info.m_attribute & KMemoryAttribute::DeviceShared) != KMemoryAttribute::None) {
+            if (info.m_device_use_count > 0) {
+                R_THROW(ResultInvalidCurrentMemory);
+            }
+            has_stale_device_shared = true;
+        }
+        if (last_addr <= info.GetLastAddress()) {
+            break;
+        }
+        ++it;
+        ASSERT(it != m_memory_block_manager.cend());
+    }
+
+    if (!has_stale_device_shared) {
+        R_SUCCEED();
+    }
+
+    // Sizing only: stale residue still carries DeviceShared until cleared below.
+    constexpr KMemoryAttribute repair_attr_mask = static_cast<KMemoryAttribute>(
+        static_cast<u8>(KMemoryAttribute::All) & ~static_cast<u8>(KMemoryAttribute::DeviceShared));
+
+    size_t num_allocator_blocks = 0;
+    R_TRY(this->CheckMemoryStateContiguous(
+        std::addressof(num_allocator_blocks), address, size,
+        KMemoryState::FlagCanTransfer | KMemoryState::FlagReferenceCounted,
+        KMemoryState::FlagCanTransfer | KMemoryState::FlagReferenceCounted,
+        KMemoryPermission::All, KMemoryPermission::UserReadWrite, repair_attr_mask,
+        KMemoryAttribute::None));
+
+    Result allocator_result;
+    KMemoryBlockManagerUpdateAllocator allocator(std::addressof(allocator_result),
+                                                 m_memory_block_slab_manager, num_allocator_blocks);
+    R_TRY(allocator_result);
+
+    m_memory_block_manager.UpdateLock(std::addressof(allocator), address, num_pages,
+                                      &KMemoryBlock::ClearStaleDeviceSharedResidue,
+                                      KMemoryPermission::None);
+    R_SUCCEED();
+}
+
 Result KPageTableBase::LockForTransferMemory(KPageGroup* out, KProcessAddress address, size_t size,
                                              KMemoryPermission perm) {
+    R_TRY(this->RepairStaleDeviceSharedResidueForTransferMemory(address, size));
     R_RETURN(this->LockMemoryAndOpen(out, nullptr, address, size, KMemoryState::FlagCanTransfer,
                                      KMemoryState::FlagCanTransfer, KMemoryPermission::All,
                                      KMemoryPermission::UserReadWrite,

--- a/src/core/hle/kernel/k_page_table_base.h
+++ b/src/core/hle/kernel/k_page_table_base.h
@@ -385,6 +385,8 @@ private:
                                  size_t num_pages, size_t alignment, size_t offset,
                                  size_t guard_pages) const;
 
+    Result RepairStaleDeviceSharedResidueForTransferMemory(KProcessAddress address, size_t size);
+
     Result CheckMemoryStateContiguous(size_t* out_blocks_needed, KProcessAddress addr, size_t size,
                                       KMemoryState state_mask, KMemoryState state,
                                       KMemoryPermission perm_mask, KMemoryPermission perm,

--- a/src/core/hle/kernel/k_transfer_memory.cpp
+++ b/src/core/hle/kernel/k_transfer_memory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/logging.h"
 #include "common/scope_exit.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_resource_limit.h"
@@ -29,8 +30,37 @@ Result KTransferMemory::Initialize(KProcessAddress addr, std::size_t size,
     };
 
     // Lock the memory.
-    R_TRY(page_table.LockForTransferMemory(std::addressof(*m_page_group), addr, size,
-                                           ConvertToKMemoryPermission(own_perm)));
+    const Result lock_result = page_table.LockForTransferMemory(
+        std::addressof(*m_page_group), addr, size, ConvertToKMemoryPermission(own_perm));
+    if (lock_result.IsError()) {
+        KMemoryInfo info_start{};
+        Svc::PageInfo page_start{};
+        page_table.QueryInfo(&info_start, &page_start, addr);
+
+        const KProcessAddress end_addr =
+            static_cast<KProcessAddress>(GetInteger(addr) + size - 1);
+        KMemoryInfo info_end{};
+        Svc::PageInfo page_end{};
+        page_table.QueryInfo(&info_end, &page_end, end_addr);
+
+        const bool homogeneous = info_start.m_state == info_end.m_state &&
+                                 info_start.m_permission == info_end.m_permission &&
+                                 (info_start.m_attribute == info_end.m_attribute);
+        LOG_ERROR(Kernel_SVC,
+                  "LockForTransferMemory failed -> InvalidCurrentMemory (0xd401): "
+                  "addr={:#x} size={:#x} owner_svc_perm={} raw={:#010x} (mod {} desc {}) | "
+                  "start: state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
+                  "end:   state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
+                  "homogeneous={}",
+                  GetInteger(addr), size, static_cast<int>(own_perm), lock_result.GetInnerValue(),
+                  static_cast<u32>(lock_result.GetModule()), lock_result.GetDescription(),
+                  static_cast<u32>(info_start.m_state), static_cast<u32>(info_start.m_permission),
+                  static_cast<u32>(info_start.m_attribute), info_start.m_address, info_start.m_size,
+                  static_cast<u32>(info_end.m_state), static_cast<u32>(info_end.m_permission),
+                  static_cast<u32>(info_end.m_attribute), info_end.m_address, info_end.m_size,
+                  homogeneous);
+        R_RETURN(lock_result);
+    }
 
     // Set remaining tracking members.
     m_owner->Open();

--- a/src/core/hle/kernel/k_transfer_memory.cpp
+++ b/src/core/hle/kernel/k_transfer_memory.cpp
@@ -47,8 +47,8 @@ Result KTransferMemory::Initialize(KProcessAddress addr, std::size_t size,
                                  info_start.m_permission == info_end.m_permission &&
                                  (info_start.m_attribute == info_end.m_attribute);
         LOG_ERROR(Kernel_SVC,
-                  "LockForTransferMemory failed -> InvalidCurrentMemory (0xd401): "
-                  "addr={:#x} size={:#x} owner_svc_perm={} raw={:#010x} (mod {} desc {}) | "
+                  "LockForTransferMemory failed: addr={:#x} size={:#x} owner_svc_perm={} "
+                  "result={:#010x} (mod {} desc {}) | "
                   "start: state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
                   "end:   state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
                   "homogeneous={}",

--- a/src/core/hle/kernel/k_transfer_memory.cpp
+++ b/src/core/hle/kernel/k_transfer_memory.cpp
@@ -48,7 +48,7 @@ Result KTransferMemory::Initialize(KProcessAddress addr, std::size_t size,
                                  (info_start.m_attribute == info_end.m_attribute);
         LOG_ERROR(Kernel_SVC,
                   "LockForTransferMemory failed: addr={:#x} size={:#x} owner_svc_perm={} "
-                  "result={:#010x} (mod {} desc {}) | "
+                  "result={:#010x} (module={} desc={}) | "
                   "start: state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
                   "end:   state={:#x} perm={:#x} attr={:#x} block=[{:#x}, +{:#x}) | "
                   "homogeneous={}",

--- a/src/core/hle/kernel/svc/svc_transfer_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_transfer_memory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/logging.h"
 #include "common/scope_exit.h"
 #include "core/core.h"
 #include "core/hle/kernel/k_process.h"
@@ -57,7 +58,12 @@ Result CreateTransferMemory(Core::System& system, Handle* out, u64 address, u64 
     };
 
     // Ensure that the region is in range.
-    R_UNLESS(process.GetPageTable().Contains(address, size), ResultInvalidCurrentMemory);
+    if (!process.GetPageTable().Contains(address, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "CreateTransferMemory: range outside address space (Contains) addr={:#x} size={:#x}",
+                  address, size);
+        R_THROW(ResultInvalidCurrentMemory);
+    }
 
     // Initialize the transfer memory.
     R_TRY(trmem->Initialize(address, size, map_perm));

--- a/src/core/hle/service/am/applet_manager.cpp
+++ b/src/core/hle/service/am/applet_manager.cpp
@@ -244,9 +244,13 @@ void AppletManager::CreateAndInsertByFrontendAppletParameters(
 }
 
 void AppletManager::RequestExit() {
-    std::scoped_lock lk{m_lock};
-    if (m_window_system) {
-        m_window_system->OnExitRequested();
+    WindowSystem* window_system = nullptr;
+    {
+        std::scoped_lock lk{m_lock};
+        window_system = m_window_system;
+    }
+    if (window_system) {
+        window_system->OnExitRequested();
     }
 }
 

--- a/src/core/hle/service/am/frontend/applet_data_erase.cpp
+++ b/src/core/hle/service/am/frontend/applet_data_erase.cpp
@@ -51,28 +51,36 @@ u64 GetRequiredSaveDataSize(FileSystem::SaveDataController& save_controller, Cor
            block_size;
 }
 
-void ParseInput(const std::vector<u8>& data, Common::UUID& out_user_id, u32& out_mode) {
-    ASSERT(data.size() >= sizeof(DataEraseAppletInput));
+bool ParseInput(const std::vector<u8>& data, Common::UUID& out_user_id, u32& out_mode) {
+    if (data.size() < sizeof(DataEraseAppletInput)) {
+        return false;
+    }
 
     // Some titles embed CommonArguments again before the applet-specific fields.
     const size_t payload_offset = data.size() >= 0x38 ? 0x20 : 0x0;
+    if (data.size() < payload_offset + sizeof(DataEraseAppletInput)) {
+        return false;
+    }
 
     DataEraseAppletInput input{};
     std::memcpy(&input, data.data() + payload_offset, sizeof(DataEraseAppletInput));
     out_user_id = input.user_id;
     out_mode = input.mode;
+    return true;
 }
 
 std::shared_ptr<FileSystem::SaveDataController> GetCallerSaveDataController(
     Core::System& system, const std::shared_ptr<Applet>& caller) {
     auto& fsc = system.GetFileSystemController();
-    if (caller != nullptr && caller->process != nullptr) {
-        ProgramId program_id{};
-        std::shared_ptr<FileSystem::SaveDataController> save_controller;
-        std::shared_ptr<FileSystem::RomFsController> romfs_controller;
-        if (fsc.OpenProcess(&program_id, &save_controller, &romfs_controller,
-                            caller->process->GetProcessId()) == ResultSuccess) {
-            return save_controller;
+    if (caller != nullptr) {
+        if (caller->process != nullptr) {
+            ProgramId program_id{};
+            std::shared_ptr<FileSystem::SaveDataController> save_controller;
+            std::shared_ptr<FileSystem::RomFsController> romfs_controller;
+            if (fsc.OpenProcess(&program_id, &save_controller, &romfs_controller,
+                                caller->process->GetProcessId()) == ResultSuccess) {
+                return save_controller;
+            }
         }
         if (caller->program_id != 0) {
             return fsc.OpenSaveDataControllerForProgram(caller->program_id);
@@ -98,18 +106,20 @@ void DataErase::Initialize() {
     ASSERT(storage != nullptr);
     const auto data = storage->GetData();
 
-    LOG_INFO(Service_AM, "DataErase applet input size={:08X}, data={}", data.size(),
-             Common::HexToString(data));
+    LOG_DEBUG(Service_AM, "DataErase applet input size={:08X}", data.size());
 
-    ParseInput(data, user_id, mode);
+    if (!ParseInput(data, user_id, mode)) {
+        status = FileSys::ResultInvalidSize;
+        complete = true;
+        return;
+    }
 
     program_id = system.GetApplicationProcessProgramID();
     if (const auto caller = applet.lock()->caller_applet.lock()) {
         program_id = caller->program_id;
     }
 
-    LOG_INFO(Service_AM, "DataErase applet parsed user_id={} mode={} program_id={:016X}",
-             user_id.FormattedString(), mode, program_id);
+    LOG_DEBUG(Service_AM, "DataErase applet parsed mode={} program_id={:016X}", mode, program_id);
 }
 
 Result DataErase::GetStatus() const {
@@ -128,6 +138,19 @@ void DataErase::Execute() {
     auto& fsc = system.GetFileSystemController();
     const auto caller = applet.lock()->caller_applet.lock();
     auto save_controller = GetCallerSaveDataController(system, caller);
+
+    const u64 required_size =
+        GetRequiredSaveDataSize(*save_controller, system, program_id, user_id.AsU128());
+    const u64 free_space_size = fsc.GetFreeSpaceSize(FileSys::StorageId::NandUser);
+
+    LOG_INFO(Service_AM,
+             "DataErase applet result: free_space={:#x}, required_size={:#x}, sufficient={}",
+             free_space_size, required_size, free_space_size >= required_size);
+
+    if (free_space_size < required_size) {
+        Complete(FileSys::ResultUsableSpaceNotEnough, free_space_size, required_size);
+        return;
+    }
 
     FileSys::SaveDataAttribute account_attribute{};
     account_attribute.program_id = program_id;
@@ -188,20 +211,11 @@ void DataErase::Execute() {
         }
     }
 
-    const u64 required_size =
+    const u64 required_size_after =
         GetRequiredSaveDataSize(*save_controller, system, program_id, user_id.AsU128());
-    const u64 free_space_size = fsc.GetFreeSpaceSize(FileSys::StorageId::NandUser);
+    const u64 free_space_after = fsc.GetFreeSpaceSize(FileSys::StorageId::NandUser);
 
-    LOG_INFO(Service_AM,
-             "DataErase applet result: free_space={:#x}, required_size={:#x}, sufficient={}",
-             free_space_size, required_size, free_space_size >= required_size);
-
-    if (free_space_size < required_size) {
-        Complete(FileSys::ResultUsableSpaceNotEnough, free_space_size, required_size);
-        return;
-    }
-
-    Complete(ResultSuccess, free_space_size, required_size);
+    Complete(ResultSuccess, free_space_after, required_size_after);
 }
 
 void DataErase::Complete(Result result, u64 free_space_size, u64 required_size) {

--- a/src/core/hle/service/am/frontend/applet_data_erase.cpp
+++ b/src/core/hle/service/am/frontend/applet_data_erase.cpp
@@ -31,24 +31,29 @@ u64 GetRequiredSaveDataSize(FileSystem::SaveDataController& save_controller, Cor
                             u64 program_id, u128 user_id) {
     u64 normal_size{};
     u64 journal_size{};
+    u64 cache_size{};
+    u64 cache_journal_size{};
     const auto size =
         save_controller.ReadSaveDataSize(FileSys::SaveDataType::Account, program_id, user_id);
     normal_size = size.normal;
     journal_size = size.journal;
 
-    if (normal_size == 0 && journal_size == 0) {
-        const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
-                                       system.GetContentProvider()};
-        const auto metadata = pm.GetControlMetadata();
-        if (metadata.first != nullptr) {
+    const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
+    const auto metadata = pm.GetControlMetadata();
+    if (metadata.first != nullptr) {
+        if (normal_size == 0 && journal_size == 0) {
             normal_size = metadata.first->GetDefaultNormalSaveSize();
             journal_size = metadata.first->GetDefaultJournalSaveSize();
         }
+        cache_size = metadata.first->GetCacheStorageSize();
+        cache_journal_size = metadata.first->GetCacheStorageJournalSize();
     }
 
     constexpr u64 block_size = 0x4000;
     return Common::AlignUp(normal_size, block_size) + Common::AlignUp(journal_size, block_size) +
-           block_size;
+           Common::AlignUp(cache_size, block_size) +
+           Common::AlignUp(cache_journal_size, block_size) + block_size;
 }
 
 bool ParseInput(const std::vector<u8>& data, Common::UUID& out_user_id, u32& out_mode) {

--- a/src/core/hle/service/am/frontend/applet_data_erase.cpp
+++ b/src/core/hle/service/am/frontend/applet_data_erase.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <cstring>
+#include <vector>
+
+#include "common/alignment.h"
+#include "common/assert.h"
+#include "common/hex_util.h"
+#include "common/logging.h"
+#include "common/uuid.h"
+#include "core/core.h"
+#include "core/file_sys/control_metadata.h"
+#include "core/file_sys/errors.h"
+#include "core/file_sys/patch_manager.h"
+#include "core/file_sys/romfs_factory.h"
+#include "core/file_sys/fs_save_data_types.h"
+#include "core/hle/result.h"
+#include "core/hle/service/am/am.h"
+#include "core/hle/service/am/frontend/applet_data_erase.h"
+#include "core/hle/service/am/service/storage.h"
+#include "core/hle/service/filesystem/filesystem.h"
+#include "core/hle/service/filesystem/romfs_controller.h"
+#include "core/hle/service/filesystem/save_data_controller.h"
+
+namespace Service::AM::Frontend {
+
+namespace {
+
+u64 GetRequiredSaveDataSize(FileSystem::SaveDataController& save_controller, Core::System& system,
+                            u64 program_id, u128 user_id) {
+    u64 normal_size{};
+    u64 journal_size{};
+    const auto size =
+        save_controller.ReadSaveDataSize(FileSys::SaveDataType::Account, program_id, user_id);
+    normal_size = size.normal;
+    journal_size = size.journal;
+
+    if (normal_size == 0 && journal_size == 0) {
+        const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                       system.GetContentProvider()};
+        const auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            normal_size = metadata.first->GetDefaultNormalSaveSize();
+            journal_size = metadata.first->GetDefaultJournalSaveSize();
+        }
+    }
+
+    constexpr u64 block_size = 0x4000;
+    return Common::AlignUp(normal_size, block_size) + Common::AlignUp(journal_size, block_size) +
+           block_size;
+}
+
+void ParseInput(const std::vector<u8>& data, Common::UUID& out_user_id, u32& out_mode) {
+    ASSERT(data.size() >= sizeof(DataEraseAppletInput));
+
+    // Some titles embed CommonArguments again before the applet-specific fields.
+    const size_t payload_offset = data.size() >= 0x38 ? 0x20 : 0x0;
+
+    DataEraseAppletInput input{};
+    std::memcpy(&input, data.data() + payload_offset, sizeof(DataEraseAppletInput));
+    out_user_id = input.user_id;
+    out_mode = input.mode;
+}
+
+std::shared_ptr<FileSystem::SaveDataController> GetCallerSaveDataController(
+    Core::System& system, const std::shared_ptr<Applet>& caller) {
+    auto& fsc = system.GetFileSystemController();
+    if (caller != nullptr && caller->process != nullptr) {
+        ProgramId program_id{};
+        std::shared_ptr<FileSystem::SaveDataController> save_controller;
+        std::shared_ptr<FileSystem::RomFsController> romfs_controller;
+        if (fsc.OpenProcess(&program_id, &save_controller, &romfs_controller,
+                            caller->process->GetProcessId()) == ResultSuccess) {
+            return save_controller;
+        }
+        if (caller->program_id != 0) {
+            return fsc.OpenSaveDataControllerForProgram(caller->program_id);
+        }
+    }
+    return fsc.OpenSaveDataController();
+}
+
+} // Anonymous namespace
+
+DataErase::DataErase(Core::System& system_, std::shared_ptr<Applet> applet_,
+                     LibraryAppletMode applet_mode_)
+    : FrontendApplet{system_, applet_, applet_mode_} {}
+
+DataErase::~DataErase() = default;
+
+void DataErase::Initialize() {
+    FrontendApplet::Initialize();
+    complete = false;
+    status = ResultSuccess;
+
+    const std::shared_ptr<IStorage> storage = PopInData();
+    ASSERT(storage != nullptr);
+    const auto data = storage->GetData();
+
+    LOG_INFO(Service_AM, "DataErase applet input size={:08X}, data={}", data.size(),
+             Common::HexToString(data));
+
+    ParseInput(data, user_id, mode);
+
+    program_id = system.GetApplicationProcessProgramID();
+    if (const auto caller = applet.lock()->caller_applet.lock()) {
+        program_id = caller->program_id;
+    }
+
+    LOG_INFO(Service_AM, "DataErase applet parsed user_id={} mode={} program_id={:016X}",
+             user_id.FormattedString(), mode, program_id);
+}
+
+Result DataErase::GetStatus() const {
+    return status;
+}
+
+void DataErase::ExecuteInteractive() {
+    ASSERT_MSG(false, "Unexpected interactive applet data.");
+}
+
+void DataErase::Execute() {
+    if (complete) {
+        return;
+    }
+
+    auto& fsc = system.GetFileSystemController();
+    const auto caller = applet.lock()->caller_applet.lock();
+    auto save_controller = GetCallerSaveDataController(system, caller);
+
+    FileSys::SaveDataAttribute account_attribute{};
+    account_attribute.program_id = program_id;
+    account_attribute.user_id = user_id.AsU128();
+    account_attribute.type = FileSys::SaveDataType::Account;
+
+    FileSys::VirtualDir account_save{};
+    const Result account_result = save_controller->CreateSaveData(
+        &account_save, FileSys::SaveDataSpaceId::User, account_attribute);
+    if (R_FAILED(account_result)) {
+        LOG_ERROR(Service_AM, "DataErase failed to create account save data: {:08X}",
+                  account_result.GetInnerValue());
+        Complete(account_result, 0, 0);
+        return;
+    }
+
+    u64 normal_size{};
+    u64 journal_size{};
+    const auto account_size =
+        save_controller->ReadSaveDataSize(FileSys::SaveDataType::Account, program_id,
+                                          user_id.AsU128());
+    normal_size = account_size.normal;
+    journal_size = account_size.journal;
+    if (normal_size == 0 && journal_size == 0) {
+        const FileSys::PatchManager pm{program_id, fsc, system.GetContentProvider()};
+        const auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            normal_size = metadata.first->GetDefaultNormalSaveSize();
+            journal_size = metadata.first->GetDefaultJournalSaveSize();
+            save_controller->WriteSaveDataSize(FileSys::SaveDataType::Account, program_id,
+                                               user_id.AsU128(), {normal_size, journal_size});
+        }
+    }
+
+    FileSys::SaveDataAttribute cache_attribute{};
+    cache_attribute.program_id = program_id;
+    cache_attribute.type = FileSys::SaveDataType::Cache;
+    cache_attribute.index = 0;
+
+    FileSys::VirtualDir cache_save{};
+    const Result cache_result = save_controller->CreateSaveData(
+        &cache_save, FileSys::SaveDataSpaceId::User, cache_attribute);
+    if (R_FAILED(cache_result)) {
+        LOG_WARNING(Service_AM, "DataErase failed to create cache save data: {:08X}",
+                    cache_result.GetInnerValue());
+    } else {
+        const FileSys::PatchManager pm{program_id, fsc, system.GetContentProvider()};
+        const auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            const FileSys::SaveDataSize cache_size{
+                metadata.first->GetCacheStorageSize(),
+                metadata.first->GetCacheStorageJournalSize(),
+            };
+            if (cache_size.normal != 0 || cache_size.journal != 0) {
+                save_controller->WriteSaveDataSize(FileSys::SaveDataType::Cache, program_id, {},
+                                                   cache_size);
+            }
+        }
+    }
+
+    const u64 required_size =
+        GetRequiredSaveDataSize(*save_controller, system, program_id, user_id.AsU128());
+    const u64 free_space_size = fsc.GetFreeSpaceSize(FileSys::StorageId::NandUser);
+
+    LOG_INFO(Service_AM,
+             "DataErase applet result: free_space={:#x}, required_size={:#x}, sufficient={}",
+             free_space_size, required_size, free_space_size >= required_size);
+
+    if (free_space_size < required_size) {
+        Complete(FileSys::ResultUsableSpaceNotEnough, free_space_size, required_size);
+        return;
+    }
+
+    Complete(ResultSuccess, free_space_size, required_size);
+}
+
+void DataErase::Complete(Result result, u64 free_space_size, u64 required_size) {
+    complete = true;
+    status = result;
+
+    if (const auto applet_locked = applet.lock()) {
+        applet_locked->terminate_result = result;
+    }
+
+    DataEraseAppletOutput output{
+        .free_space_size = free_space_size,
+        .required_size = required_size,
+    };
+
+    std::vector<u8> out(0x1000);
+    std::memcpy(out.data(), &output, sizeof(output));
+
+    LOG_INFO(Service_AM, "DataErase applet output: result={} free_space={:#x} required={:#x}",
+             result.GetInnerValue(), free_space_size, required_size);
+
+    PushOutData(std::make_shared<IStorage>(system, std::move(out)));
+    Exit();
+}
+
+Result DataErase::RequestExit() {
+    R_SUCCEED();
+}
+
+} // namespace Service::AM::Frontend

--- a/src/core/hle/service/am/frontend/applet_data_erase.h
+++ b/src/core/hle/service/am/frontend/applet_data_erase.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/uuid.h"
+#include "core/hle/service/am/frontend/applets.h"
+
+namespace Core {
+class System;
+}
+
+namespace Service::AM::Frontend {
+
+// Applet-specific input pushed after CommonArguments.
+struct DataEraseAppletInput {
+    Common::UUID user_id;
+    u32 mode;
+    INSERT_PADDING_BYTES(4);
+};
+static_assert(sizeof(DataEraseAppletInput) == 0x18, "DataEraseAppletInput has incorrect size.");
+
+// Output returned via PopOutData. Games read free/required space as u64 pair at offset 0.
+struct DataEraseAppletOutput {
+    u64 free_space_size;
+    u64 required_size;
+};
+static_assert(sizeof(DataEraseAppletOutput) == 0x10, "DataEraseAppletOutput has incorrect size.");
+
+class DataErase final : public FrontendApplet {
+public:
+    explicit DataErase(Core::System& system_, std::shared_ptr<Applet> applet_,
+                       LibraryAppletMode applet_mode_);
+    ~DataErase() override;
+
+    void Initialize() override;
+    Result GetStatus() const override;
+    void ExecuteInteractive() override;
+    void Execute() override;
+    Result RequestExit() override;
+
+private:
+    void Complete(Result result, u64 free_space_size, u64 required_size);
+
+    Common::UUID user_id{};
+    u32 mode{};
+    u64 program_id{};
+    bool complete{};
+    Result status{ResultSuccess};
+};
+
+} // namespace Service::AM::Frontend

--- a/src/core/hle/service/am/frontend/applets.cpp
+++ b/src/core/hle/service/am/frontend/applets.cpp
@@ -19,6 +19,7 @@
 #include "core/hle/service/am/applet_manager.h"
 #include "core/hle/service/am/frontend/applet_cabinet.h"
 #include "core/hle/service/am/frontend/applet_controller.h"
+#include "core/hle/service/am/frontend/applet_data_erase.h"
 #include "core/hle/service/am/frontend/applet_error.h"
 #include "core/hle/service/am/frontend/applet_general.h"
 #include "core/hle/service/am/frontend/applet_mii_edit.h"
@@ -213,6 +214,8 @@ std::shared_ptr<FrontendApplet> FrontendAppletHolder::GetApplet(std::shared_ptr<
         return std::make_shared<Cabinet>(system, applet, mode, *frontend.cabinet);
     case AppletId::Controller:
         return std::make_shared<Controller>(system, applet, mode, *frontend.controller);
+    case AppletId::DataErase:
+        return std::make_shared<DataErase>(system, applet, mode);
     case AppletId::Error:
         return std::make_shared<Error>(system, applet, mode, *frontend.error);
     case AppletId::ProfileSelect:

--- a/src/core/hle/service/am/service/application_functions.cpp
+++ b/src/core/hle/service/am/service/application_functions.cpp
@@ -341,7 +341,7 @@ Result IApplicationFunctions::CreateCacheStorage(Out<u32> out_target_media,
     FileSys::SaveDataAttribute attribute{};
     attribute.program_id = m_applet->program_id;
     attribute.type = FileSys::SaveDataType::Cache;
-    attribute.index = static_cast<u8>(index);
+    attribute.index = index;
 
     FileSys::VirtualDir save_data{};
     R_TRY(GetApplicationSaveDataController(system, *m_applet)->CreateSaveData(

--- a/src/core/hle/service/am/service/application_functions.cpp
+++ b/src/core/hle/service/am/service/application_functions.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/alignment.h"
 #include "common/settings.h"
 #include "common/uuid.h"
 #include "core/file_sys/control_metadata.h"
@@ -15,6 +16,7 @@
 #include "core/hle/service/am/service/storage.h"
 #include "core/hle/service/cmif_serialization.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/hle/service/filesystem/romfs_controller.h"
 #include "core/hle/service/filesystem/save_data_controller.h"
 #include "core/hle/service/glue/glue_manager.h"
 #include "core/hle/service/ns/application_manager_interface.h"
@@ -22,6 +24,33 @@
 #include "core/hle/service/sm/sm.h"
 
 namespace Service::AM {
+
+namespace {
+
+u64 CalculateSaveDataTotalSize(u64 normal_size, u64 journal_size) {
+    constexpr u64 block_size = 0x4000;
+    return Common::AlignUp(normal_size, block_size) + Common::AlignUp(journal_size, block_size) +
+           block_size;
+}
+
+std::shared_ptr<FileSystem::SaveDataController> GetApplicationSaveDataController(
+    Core::System& system, const Applet& applet) {
+    auto& fsc = system.GetFileSystemController();
+    ProgramId program_id{};
+    std::shared_ptr<FileSystem::SaveDataController> save_controller;
+    std::shared_ptr<FileSystem::RomFsController> romfs_controller;
+    if (applet.process != nullptr &&
+        fsc.OpenProcess(&program_id, &save_controller, &romfs_controller,
+                        applet.process->GetProcessId()) == ResultSuccess) {
+        return save_controller;
+    }
+    if (applet.program_id != 0) {
+        return fsc.OpenSaveDataControllerForProgram(applet.program_id);
+    }
+    return fsc.OpenSaveDataController();
+}
+
+} // Anonymous namespace
 
 IApplicationFunctions::IApplicationFunctions(Core::System& system_, std::shared_ptr<Applet> applet)
     : ServiceFramework{system_, "IApplicationFunctions"}, m_applet{std::move(applet)} {
@@ -153,16 +182,38 @@ Result IApplicationFunctions::PopLaunchParameter(Out<SharedPointer<IStorage>> ou
 Result IApplicationFunctions::EnsureSaveData(Out<u64> out_size, Common::UUID user_id) {
     LOG_INFO(Service_AM, "called, uid={}", user_id.FormattedString());
 
+    auto save_controller = GetApplicationSaveDataController(system, *m_applet);
+
     FileSys::SaveDataAttribute attribute{};
     attribute.program_id = m_applet->program_id;
     attribute.user_id = user_id.AsU128();
     attribute.type = FileSys::SaveDataType::Account;
 
     FileSys::VirtualDir save_data{};
-    R_TRY(system.GetFileSystemController().OpenSaveDataController()->CreateSaveData(
-        &save_data, FileSys::SaveDataSpaceId::User, attribute));
+    R_TRY(save_controller->CreateSaveData(&save_data, FileSys::SaveDataSpaceId::User, attribute));
 
-    *out_size = 0;
+    u64 normal_size{};
+    u64 journal_size{};
+    const auto size = save_controller->ReadSaveDataSize(FileSys::SaveDataType::Account,
+                                                          m_applet->program_id, user_id.AsU128());
+    normal_size = size.normal;
+    journal_size = size.journal;
+
+    if (normal_size == 0 && journal_size == 0) {
+        const FileSys::PatchManager pm{m_applet->program_id, system.GetFileSystemController(),
+                                       system.GetContentProvider()};
+        const auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            normal_size = metadata.first->GetDefaultNormalSaveSize();
+            journal_size = metadata.first->GetDefaultJournalSaveSize();
+            save_controller->WriteSaveDataSize(FileSys::SaveDataType::Account, m_applet->program_id,
+                                               user_id.AsU128(), {normal_size, journal_size});
+        }
+    }
+
+    *out_size = CalculateSaveDataTotalSize(normal_size, journal_size);
+
+    LOG_INFO(Service_AM, "returning save total size={:#x}", *out_size);
     R_SUCCEED();
 }
 
@@ -259,7 +310,7 @@ Result IApplicationFunctions::ExtendSaveData(Out<u64> out_required_size, FileSys
     LOG_DEBUG(Service_AM, "called with type={} user_id={} normal={:#x} journal={:#x}",
               static_cast<u8>(type), user_id.FormattedString(), normal_size, journal_size);
 
-    system.GetFileSystemController().OpenSaveDataController()->WriteSaveDataSize(
+    GetApplicationSaveDataController(system, *m_applet)->WriteSaveDataSize(
         type, m_applet->program_id, user_id.AsU128(), {normal_size, journal_size});
 
     // The following value is used to indicate the amount of space remaining on failure
@@ -273,7 +324,7 @@ Result IApplicationFunctions::GetSaveDataSize(Out<u64> out_normal_size, Out<u64>
                                               FileSys::SaveDataType type, Common::UUID user_id) {
     LOG_DEBUG(Service_AM, "called with type={} user_id={}", type, user_id.FormattedString());
 
-    const auto size = system.GetFileSystemController().OpenSaveDataController()->ReadSaveDataSize(
+    const auto size = GetApplicationSaveDataController(system, *m_applet)->ReadSaveDataSize(
         type, m_applet->program_id, user_id.AsU128());
 
     *out_normal_size = size.normal;
@@ -284,10 +335,22 @@ Result IApplicationFunctions::GetSaveDataSize(Out<u64> out_normal_size, Out<u64>
 Result IApplicationFunctions::CreateCacheStorage(Out<u32> out_target_media,
                                                  Out<u64> out_required_size, u16 index,
                                                  u64 normal_size, u64 journal_size) {
-    LOG_WARNING(Service_AM, "(STUBBED) called with index={} size={:#x} journal_size={:#x}", index,
-                normal_size, journal_size);
+    LOG_INFO(Service_AM, "called with index={} size={:#x} journal_size={:#x}", index, normal_size,
+             journal_size);
 
-    *out_target_media = 1; // Nand
+    FileSys::SaveDataAttribute attribute{};
+    attribute.program_id = m_applet->program_id;
+    attribute.type = FileSys::SaveDataType::Cache;
+    attribute.index = static_cast<u8>(index);
+
+    FileSys::VirtualDir save_data{};
+    R_TRY(GetApplicationSaveDataController(system, *m_applet)->CreateSaveData(
+        &save_data, FileSys::SaveDataSpaceId::User, attribute));
+
+    GetApplicationSaveDataController(system, *m_applet)->WriteSaveDataSize(
+        FileSys::SaveDataType::Cache, m_applet->program_id, {}, {normal_size, journal_size});
+
+    *out_target_media = 1;
     *out_required_size = 0;
 
     R_SUCCEED();

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -422,7 +422,12 @@ void FileSystemController::SetPackedUpdate(ProcessId process_id, FileSys::Virtua
 }
 
 std::shared_ptr<SaveDataController> FileSystemController::OpenSaveDataController() {
-    return std::make_shared<SaveDataController>(system, CreateSaveDataFactory(ProgramId{}));
+    return OpenSaveDataControllerForProgram(ProgramId{});
+}
+
+std::shared_ptr<SaveDataController> FileSystemController::OpenSaveDataControllerForProgram(
+    ProgramId program_id) {
+    return std::make_shared<SaveDataController>(system, CreateSaveDataFactory(program_id));
 }
 
 std::shared_ptr<FileSys::SaveDataFactory> FileSystemController::CreateSaveDataFactory(
@@ -801,6 +806,25 @@ FileSys::VirtualDir FileSystemController::GetBCATDirectory(u64 title_id) const {
         return nullptr;
 
     return bis_factory->GetBCATDirectory(title_id);
+}
+
+void FileSystemController::ReleaseVfsBackedCaches() {
+    Reset();
+    global_save_data_factory.reset();
+
+    system.ClearContentProvider(FileSys::ContentProviderUnionSlot::External);
+    external_provider.reset();
+
+    system.ClearContentProvider(FileSys::ContentProviderUnionSlot::SDMC);
+    sdmc_factory.reset();
+
+    system.ClearContentProvider(FileSys::ContentProviderUnionSlot::SysNAND);
+    system.ClearContentProvider(FileSys::ContentProviderUnionSlot::UserNAND);
+    bis_factory.reset();
+
+    gamecard_placeholder.reset();
+    gamecard_registered.reset();
+    gamecard.reset();
 }
 
 void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite) {

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -85,6 +85,7 @@ public:
     void SetPackedUpdate(ProcessId process_id, FileSys::VirtualFile update_raw);
 
     std::shared_ptr<SaveDataController> OpenSaveDataController();
+    std::shared_ptr<SaveDataController> OpenSaveDataControllerForProgram(ProgramId program_id);
 
     Result OpenSDMC(FileSys::VirtualDir* out_sdmc) const;
     Result OpenBISPartition(FileSys::VirtualDir* out_bis_partition,
@@ -133,6 +134,8 @@ public:
     // Creates the SaveData, SDMC, and BIS Factories. Should be called once and before any function
     // above is called.
     void CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite = true);
+
+    void ReleaseVfsBackedCaches();
 
     // getter for main.cpp to trigger the sync between custom game paths for separate emulators
     FileSys::SaveDataFactory& GetSaveDataFactory() {

--- a/src/core/hle/service/filesystem/fsp/fs_i_filesystem.cpp
+++ b/src/core/hle/service/filesystem/fsp/fs_i_filesystem.cpp
@@ -4,6 +4,7 @@
 
 #include "common/string_util.h"
 #include "common/settings.h"
+#include "core/file_sys/directory_save_data_filesystem.h"
 #include "core/file_sys/fssrv/fssrv_sf_path.h"
 #include "core/hle/service/cmif_serialization.h"
 #include "core/hle/service/filesystem/fsp/fs_i_directory.h"
@@ -23,11 +24,14 @@ namespace Service::FileSystem {
 
 IFileSystem::IFileSystem(Core::System& system_, FileSys::VirtualDir dir_, SizeGetter size_getter_,
                          std::shared_ptr<FileSys::SaveDataFactory> factory_,
-                         FileSys::SaveDataSpaceId space_id_, FileSys::SaveDataAttribute attribute_)
+                         FileSys::SaveDataSpaceId space_id_, FileSys::SaveDataAttribute attribute_,
+                         FileSys::VirtualDir save_content_dir_,
+                         std::unique_ptr<FileSys::DirectorySaveDataFileSystem> journal_fs_)
     : ServiceFramework{system_, "IFileSystem"},
       backend{std::make_unique<FileSys::Fsa::IFileSystem>(dir_)},
+      journal_fs{std::move(journal_fs_)},
       size_getter{std::move(size_getter_)},
-      content_dir{std::move(dir_)},
+      content_dir{save_content_dir_ != nullptr ? std::move(save_content_dir_) : dir_},
       save_factory{std::move(factory_)},
       save_space{space_id_},
       save_attr{attribute_} {
@@ -141,6 +145,25 @@ Result IFileSystem::GetEntryType(
 }
 
 Result IFileSystem::Commit() {
+    if (journal_fs) {
+        if (system.IsShuttingDown()) {
+            R_SUCCEED();
+        }
+
+        R_TRY(journal_fs->Commit());
+
+        if (save_factory) {
+            const u64 title_id = save_attr.program_id != 0 ? save_attr.program_id
+                                                           : system.GetApplicationProcessProgramID();
+            if (save_factory->GetMirrorDirectory(title_id) == nullptr &&
+                Settings::values.backup_saves_to_nand.GetValue()) {
+                save_factory->DoNandBackup(save_space, save_attr, content_dir);
+            }
+        }
+
+        R_SUCCEED();
+    }
+
     // 1. Standard Commit
     Result res = backend->Commit();
     if (res != ResultSuccess) return res;

--- a/src/core/hle/service/filesystem/fsp/fs_i_filesystem.h
+++ b/src/core/hle/service/filesystem/fsp/fs_i_filesystem.h
@@ -18,8 +18,11 @@ namespace FileSys::Sf {
 struct Path;
 }
 
-namespace Service::FileSystem {
+namespace FileSys {
+class DirectorySaveDataFileSystem;
+}
 
+namespace Service::FileSystem {
 
 // [UNITY-FIX] winbase.h A/W macros shadow C++ method names.
 #undef DeleteFile
@@ -34,10 +37,12 @@ class IDirectory;
 
 class IFileSystem final : public ServiceFramework<IFileSystem> {
 public:
-    explicit IFileSystem(Core::System& system_, FileSys::VirtualDir dir_, SizeGetter size_getter_,
-                         std::shared_ptr<FileSys::SaveDataFactory> factory_ = nullptr,
-                         FileSys::SaveDataSpaceId space_id_ = {},
-                         FileSys::SaveDataAttribute attribute_ = {});
+    explicit IFileSystem(
+        Core::System& system_, FileSys::VirtualDir dir_, SizeGetter size_getter_,
+        std::shared_ptr<FileSys::SaveDataFactory> factory_ = nullptr,
+        FileSys::SaveDataSpaceId space_id_ = {}, FileSys::SaveDataAttribute attribute_ = {},
+        FileSys::VirtualDir save_content_dir_ = nullptr,
+        std::unique_ptr<FileSys::DirectorySaveDataFileSystem> journal_fs_ = nullptr);
 
     Result CreateFile(const InLargeData<FileSys::Sf::Path, BufferAttr_HipcPointer> path, s32 option,
                       s64 size);
@@ -68,6 +73,7 @@ public:
 
 private:
     std::unique_ptr<FileSys::Fsa::IFileSystem> backend;
+    std::unique_ptr<FileSys::DirectorySaveDataFileSystem> journal_fs;
     SizeGetter size_getter;
     FileSys::VirtualDir content_dir;
     std::shared_ptr<FileSys::SaveDataFactory> save_factory;

--- a/src/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.cpp
+++ b/src/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.cpp
@@ -11,7 +11,7 @@ namespace Service::FileSystem {
 
 ISaveDataInfoReader::ISaveDataInfoReader(Core::System& system_,
                                          std::shared_ptr<SaveDataController> save_data_controller_,
-                                         FileSys::SaveDataSpaceId space)
+                                         FileSys::SaveDataSpaceId space, bool cache_only)
     : ServiceFramework{system_, "ISaveDataInfoReader"}, save_data_controller{
                                                             save_data_controller_} {
     static const FunctionInfo functions[] = {
@@ -19,7 +19,11 @@ ISaveDataInfoReader::ISaveDataInfoReader(Core::System& system_,
     };
     RegisterHandlers(functions);
 
-    FindAllSaves(space);
+    if (cache_only) {
+        FindCacheSaves();
+    } else {
+        FindAllSaves(space);
+    }
 }
 
 ISaveDataInfoReader::~ISaveDataInfoReader() = default;
@@ -58,6 +62,46 @@ Result ISaveDataInfoReader::ReadSaveDataInfo(
     *out_count = actual_entries;
 
     R_SUCCEED();
+}
+
+void ISaveDataInfoReader::FindCacheSaves() {
+    FileSys::VirtualDir save_root{};
+    const auto result =
+        save_data_controller->OpenSaveDataSpace(&save_root, FileSys::SaveDataSpaceId::User);
+
+    if (result != ResultSuccess || save_root == nullptr) {
+        LOG_ERROR(Service_FS, "The save root for cache storage was invalid!");
+        return;
+    }
+
+    const auto save_dir = save_root->GetSubdirectory("save");
+    if (save_dir == nullptr) {
+        return;
+    }
+
+    const auto cache_dir = save_dir->GetSubdirectory("cache");
+    if (cache_dir == nullptr) {
+        return;
+    }
+
+    for (const auto& title_id_dir : cache_dir->GetSubdirectories()) {
+        if (title_id_dir->GetName().size() != 16) {
+            continue;
+        }
+
+        info.emplace_back(SaveDataInfo{
+            0,
+            FileSys::SaveDataSpaceId::User,
+            FileSys::SaveDataType::Cache,
+            {},
+            {},
+            0,
+            stoull_be(title_id_dir->GetName()),
+            title_id_dir->GetSize(),
+            {},
+            {},
+        });
+    }
 }
 
 void ISaveDataInfoReader::FindAllSaves(FileSys::SaveDataSpaceId space) {

--- a/src/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.h
+++ b/src/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.h
@@ -16,7 +16,7 @@ class ISaveDataInfoReader final : public ServiceFramework<ISaveDataInfoReader> {
 public:
     explicit ISaveDataInfoReader(Core::System& system_,
                                  std::shared_ptr<SaveDataController> save_data_controller_,
-                                 FileSys::SaveDataSpaceId space);
+                                 FileSys::SaveDataSpaceId space, bool cache_only = false);
     ~ISaveDataInfoReader() override;
 
     struct SaveDataInfo {
@@ -38,6 +38,7 @@ public:
                             OutArray<SaveDataInfo, BufferAttr_HipcMapAlias> out_entries);
 
 private:
+    void FindCacheSaves();
     void FindAllSaves(FileSys::SaveDataSpaceId space);
     void FindNormalSaves(FileSys::SaveDataSpaceId space, const FileSys::VirtualDir& type);
     void FindTemporaryStorageSaves(FileSys::SaveDataSpaceId space, const FileSys::VirtualDir& type);

--- a/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -349,9 +350,10 @@ Result FSP_SRV::FindSaveDataWithFilter(Out<s64> out_count,
                                        FileSys::SaveDataFilter filter) {
     LOG_INFO(Service_FS, "called, space_id={}", space_id);
 
-    FileSys::SaveDataAttribute query = filter.attribute;
-    if (!filter.use_program_id || query.program_id == 0) {
-        query.program_id = program_id;
+    FileSys::SaveDataAttribute query{};
+    query.program_id = program_id;
+    if (filter.use_program_id && filter.attribute.program_id != 0) {
+        query.program_id = filter.attribute.program_id;
     }
     if (filter.use_save_data_type) {
         query.type = filter.attribute.type;
@@ -793,6 +795,10 @@ Result FSP_SRV::QuerySaveDataTotalSize(Out<u64> out_total_size, u64 save_data_si
     constexpr u64 block_size = 0x4000;
     const u64 aligned_data = Common::AlignUp(save_data_size, block_size);
     const u64 aligned_journal = Common::AlignUp(journal_size, block_size);
+
+    if (aligned_data > std::numeric_limits<u64>::max() - aligned_journal - block_size) {
+        R_THROW(FileSys::ResultInvalidSize);
+    }
 
     *out_total_size = aligned_data + aligned_journal + block_size;
 

--- a/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
@@ -4,11 +4,13 @@
 
 #include <cinttypes>
 #include <cstring>
+#include <functional>
 #include <iterator>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/hex_util.h"
@@ -17,6 +19,7 @@
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/content_archive.h"
+#include "core/file_sys/directory_save_data_filesystem.h"
 #include "core/file_sys/errors.h"
 #include "core/file_sys/fs_directory.h"
 #include "core/file_sys/fs_filesystem.h"
@@ -127,7 +130,7 @@ FSP_SRV::FSP_SRV(Core::System& system_)
         {511, nullptr, "NotifySystemDataUpdateEvent"},
         {520, nullptr, "SimulateGameCardDetectionEvent"},
         {600, nullptr, "SetCurrentPosixTime"},
-        {601, nullptr, "QuerySaveDataTotalSize"},
+        {601, D<&FSP_SRV::QuerySaveDataTotalSize>, "QuerySaveDataTotalSize"},
         {602, nullptr, "VerifySaveDataFileSystem"},
         {603, nullptr, "CorruptSaveDataFileSystem"},
         {604, nullptr, "CreatePaddingFile"},
@@ -138,7 +141,7 @@ FSP_SRV::FSP_SRV(Core::System& system_)
         {609, nullptr, "GetRightsIdByPath"},
         {610, nullptr, "GetRightsIdAndKeyGenerationByPath"},
         {611, nullptr, "SetCurrentPosixTimeWithTimeDifference"},
-        {612, nullptr, "GetFreeSpaceSizeForSaveData"},
+        {612, D<&FSP_SRV::GetFreeSpaceSizeForSaveData>, "GetFreeSpaceSizeForSaveData"},
         {613, nullptr, "VerifySaveDataFileSystemBySaveDataSpaceId"},
         {614, nullptr, "CorruptSaveDataFileSystemBySaveDataSpaceId"},
         {615, nullptr, "QuerySaveDataInternalStorageTotalSize"},
@@ -253,35 +256,56 @@ Result FSP_SRV::CreateSaveDataFileSystemBySystemSaveDataId(
 Result FSP_SRV::OpenSaveDataFileSystem(OutInterface<IFileSystem> out_interface,
                                        FileSys::SaveDataSpaceId space_id,
                                        FileSys::SaveDataAttribute attribute) {
-    LOG_INFO(Service_FS, "called, space_id={:02X}, program_id={:016X}", static_cast<u8>(space_id),
-             attribute.program_id);
+    LOG_INFO(Service_FS, "called, space_id={:02X}, {}", static_cast<u8>(space_id),
+             attribute.DebugInfo());
 
-    FileSys::VirtualDir dir{};
+    FileSys::VirtualDir save_root{};
     // This triggers the 'Smart Pull' (Ryujinx -> Citron) in savedata_factory.cpp
-    R_TRY(save_data_controller->OpenSaveData(&dir, space_id, attribute));
+    R_TRY(save_data_controller->OpenSaveData(&save_root, space_id, attribute));
 
-    FileSys::StorageId id{};
-    switch (space_id) {
-    case FileSys::SaveDataSpaceId::User:
-        id = FileSys::StorageId::NandUser;
-        break;
-    case FileSys::SaveDataSpaceId::SdSystem:
-    case FileSys::SaveDataSpaceId::SdUser:
-        id = FileSys::StorageId::SdCard;
-        break;
-    case FileSys::SaveDataSpaceId::System:
-    case FileSys::SaveDataSpaceId::Temporary:
-    case FileSys::SaveDataSpaceId::ProperSystem:
-    case FileSys::SaveDataSpaceId::SafeMode:
-        id = FileSys::StorageId::NandSystem;
-        break;
-    }
+    const u64 title_id = attribute.program_id != 0 ? attribute.program_id
+                                                   : system.GetApplicationProcessProgramID();
+    const auto mirror_dir = save_data_controller->GetFactory()->GetMirrorDirectory(title_id);
+
+    auto journal_fs =
+        std::make_unique<FileSys::DirectorySaveDataFileSystem>(save_root, nullptr, mirror_dir);
+    R_TRY(journal_fs->Initialize(true));
+
+    FileSys::VirtualDir working_dir = journal_fs->GetWorkingDirectory();
+
+    const FileSys::SaveDataSize save_sizes =
+        save_data_controller->ReadSaveDataSize(attribute.type, title_id, attribute.user_id);
+    const auto working_dir_for_size = working_dir;
+    SizeGetter size_getter{
+        [working_dir_for_size, save_sizes]() {
+            u64 used = 0;
+            std::function<void(const FileSys::VirtualDir&)> accumulate;
+            accumulate = [&](const FileSys::VirtualDir& dir) {
+                if (dir == nullptr) {
+                    return;
+                }
+                for (const auto& file : dir->GetFiles()) {
+                    used += static_cast<u64>(file->GetSize());
+                }
+                for (const auto& subdir : dir->GetSubdirectories()) {
+                    accumulate(subdir);
+                }
+            };
+            accumulate(working_dir_for_size);
+            if (used >= save_sizes.normal) {
+                return UINT64_C(0);
+            }
+            return save_sizes.normal - used;
+        },
+        [save_sizes]() { return save_sizes.normal + save_sizes.journal; },
+    };
 
     // Wrap the directory in the IFileSystem interface.
     // We pass 'save_data_controller->GetFactory()' so the Commit function can find the Mirror.
-    *out_interface =
-        std::make_shared<IFileSystem>(system, std::move(dir), SizeGetter::FromStorageId(fsc, id),
-                                      save_data_controller->GetFactory(), space_id, attribute);
+    *out_interface = std::make_shared<IFileSystem>(
+        system, std::move(working_dir), std::move(size_getter),
+        save_data_controller->GetFactory(), space_id, attribute, std::move(save_root),
+        std::move(journal_fs));
 
     R_SUCCEED();
 }
@@ -311,10 +335,10 @@ Result FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(
 
 Result FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage(
     OutInterface<ISaveDataInfoReader> out_interface) {
-    LOG_WARNING(Service_FS, "(STUBBED) called");
+    LOG_INFO(Service_FS, "called");
 
     *out_interface = std::make_shared<ISaveDataInfoReader>(system, save_data_controller,
-                                                           FileSys::SaveDataSpaceId::Temporary);
+                                                           FileSys::SaveDataSpaceId::User, true);
 
     R_SUCCEED();
 }
@@ -323,8 +347,36 @@ Result FSP_SRV::FindSaveDataWithFilter(Out<s64> out_count,
                                        OutBuffer<BufferAttr_HipcMapAlias> out_buffer,
                                        FileSys::SaveDataSpaceId space_id,
                                        FileSys::SaveDataFilter filter) {
-    LOG_WARNING(Service_FS, "(STUBBED) called");
-    R_THROW(FileSys::ResultTargetNotFound);
+    LOG_INFO(Service_FS, "called, space_id={}", space_id);
+
+    FileSys::SaveDataAttribute query = filter.attribute;
+    if (!filter.use_program_id || query.program_id == 0) {
+        query.program_id = program_id;
+    }
+    if (filter.use_save_data_type) {
+        query.type = filter.attribute.type;
+    }
+    if (filter.use_user_id) {
+        query.user_id = filter.attribute.user_id;
+    }
+    if (filter.use_save_data_id) {
+        query.system_save_data_id = filter.attribute.system_save_data_id;
+    }
+    if (filter.use_index) {
+        query.index = filter.attribute.index;
+    }
+    query.rank = filter.rank;
+
+    FileSys::VirtualDir save_dir{};
+    R_TRY(save_data_controller->OpenSaveData(&save_dir, space_id, query));
+
+    if (out_buffer.size() < sizeof(FileSys::SaveDataAttribute)) {
+        R_THROW(FileSys::ResultInvalidSize);
+    }
+
+    std::memcpy(out_buffer.data(), &query, sizeof(FileSys::SaveDataAttribute));
+    *out_count = 1;
+    R_SUCCEED();
 }
 
 Result FSP_SRV::WriteSaveDataFileSystemExtraData(InBuffer<BufferAttr_HipcMapAlias> buffer,
@@ -606,17 +658,35 @@ Result FSP_SRV::ExtendSaveDataFileSystem(FileSys::SaveDataSpaceId space_id, u64 
 }
 
 Result FSP_SRV::DeleteCacheStorage(u16 index) {
-    LOG_WARNING(Service_FS, "(STUBBED) called, index={}", index);
-    // Cache storage deletion is not implemented, but we return success to prevent crashes
-    R_SUCCEED();
+    LOG_INFO(Service_FS, "called, index={}", index);
+    R_RETURN(save_data_controller->GetFactory()->DeleteCacheStorage(index));
 }
 
 Result FSP_SRV::GetCacheStorageSize(s32 index, Out<s64> out_data_size, Out<s64> out_journal_size) {
-    LOG_WARNING(Service_FS, "(STUBBED) called with index={}", index);
+    LOG_INFO(Service_FS, "called with index={}", index);
 
-    *out_data_size = 0;
-    *out_journal_size = 0;
+    const auto size = save_data_controller->ReadSaveDataSize(FileSys::SaveDataType::Cache,
+                                                             program_id, {});
+    if (size.normal != 0 || size.journal != 0) {
+        *out_data_size = static_cast<s64>(size.normal);
+        *out_journal_size = static_cast<s64>(size.journal);
+        LOG_INFO(Service_FS, "returning data_size={:#x}, journal_size={:#x}", *out_data_size,
+                 *out_journal_size);
+        R_SUCCEED();
+    }
 
+    const FileSys::PatchManager pm{program_id, fsc, content_provider};
+    const auto metadata = pm.GetControlMetadata();
+    if (metadata.first != nullptr) {
+        *out_data_size = static_cast<s64>(metadata.first->GetCacheStorageSize());
+        *out_journal_size = static_cast<s64>(metadata.first->GetCacheStorageJournalSize());
+    } else {
+        *out_data_size = 0;
+        *out_journal_size = 0;
+    }
+
+    LOG_INFO(Service_FS, "returning default data_size={:#x}, journal_size={:#x}", *out_data_size,
+             *out_journal_size);
     R_SUCCEED();
 }
 
@@ -712,6 +782,52 @@ Result FSP_SRV::IsExFatSupported(Out<bool> out_is_supported) {
 
     *out_is_supported = true;
 
+    R_SUCCEED();
+}
+
+Result FSP_SRV::QuerySaveDataTotalSize(Out<u64> out_total_size, u64 save_data_size,
+                                       u64 journal_size) {
+    LOG_DEBUG(Service_FS, "called, save_data_size={:#x}, journal_size={:#x}", save_data_size,
+              journal_size);
+
+    constexpr u64 block_size = 0x4000;
+    const u64 aligned_data = Common::AlignUp(save_data_size, block_size);
+    const u64 aligned_journal = Common::AlignUp(journal_size, block_size);
+
+    *out_total_size = aligned_data + aligned_journal + block_size;
+
+    LOG_DEBUG(Service_FS, "returning total_size={:#x}", *out_total_size);
+    R_SUCCEED();
+}
+
+Result FSP_SRV::GetFreeSpaceSizeForSaveData(Out<u64> out_free_space,
+                                              FileSys::SaveDataSpaceId space_id) {
+    LOG_INFO(Service_FS, "called, space_id={}", space_id);
+
+    FileSys::StorageId storage_id{};
+    switch (space_id) {
+    case FileSys::SaveDataSpaceId::System:
+    case FileSys::SaveDataSpaceId::ProperSystem:
+    case FileSys::SaveDataSpaceId::SafeMode:
+        storage_id = FileSys::StorageId::NandSystem;
+        break;
+    case FileSys::SaveDataSpaceId::User:
+    case FileSys::SaveDataSpaceId::Temporary:
+        storage_id = FileSys::StorageId::NandUser;
+        break;
+    case FileSys::SaveDataSpaceId::SdSystem:
+    case FileSys::SaveDataSpaceId::SdUser:
+        storage_id = FileSys::StorageId::SdCard;
+        break;
+    default:
+        LOG_WARNING(Service_FS, "Unknown SaveDataSpaceId={}, defaulting to NandUser", space_id);
+        storage_id = FileSys::StorageId::NandUser;
+        break;
+    }
+
+    *out_free_space = fsc.GetFreeSpaceSize(storage_id);
+
+    LOG_INFO(Service_FS, "returning free_space={:#x}", *out_free_space);
     R_SUCCEED();
 }
 

--- a/src/core/hle/service/filesystem/fsp/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp/fsp_srv.h
@@ -125,6 +125,9 @@ private:
     Result OpenGameCardFileSystem(OutInterface<IFileSystem> out_interface, u32 handle,
                                   u32 partition_id);
     Result IsExFatSupported(Out<bool> out_is_supported);
+    Result QuerySaveDataTotalSize(Out<u64> out_total_size, u64 save_data_size, u64 journal_size);
+    Result GetFreeSpaceSizeForSaveData(Out<u64> out_free_space,
+                                       FileSys::SaveDataSpaceId space_id);
 
     FileSystemController& fsc;
     const FileSys::ContentProvider& content_provider;

--- a/src/core/hle/service/filesystem/save_data_controller.cpp
+++ b/src/core/hle/service/filesystem/save_data_controller.cpp
@@ -42,6 +42,11 @@ Result SaveDataController::CreateSaveData(FileSys::VirtualDir* out_save_data,
     LOG_TRACE(Service_FS, "Creating Save Data for space_id={:01X}, save_struct={}", space,
               attribute.DebugInfo());
 
+    if (auto save_data = factory->Open(space, attribute)) {
+        *out_save_data = save_data;
+        return ResultSuccess;
+    }
+
     auto save_data = factory->Create(space, attribute);
     if (save_data == nullptr) {
         return FileSys::ResultTargetNotFound;
@@ -56,9 +61,13 @@ Result SaveDataController::OpenSaveData(FileSys::VirtualDir* out_save_data,
                                         const FileSys::SaveDataAttribute& attribute) {
     auto save_data = factory->Open(space, attribute);
     if (save_data == nullptr) {
+        LOG_INFO(Service_FS, "OpenSaveData failed for space_id={:02X}, {}", static_cast<u8>(space),
+                 attribute.DebugInfo());
         return FileSys::ResultTargetNotFound;
     }
 
+    LOG_INFO(Service_FS, "OpenSaveData succeeded for space_id={:02X}, {}", static_cast<u8>(space),
+             attribute.DebugInfo());
     *out_save_data = save_data;
     return ResultSuccess;
 }


### PR DESCRIPTION
## Summary
Save data factory, FSP, VFS, control metadata, kernel transfer memory, and DataErase applet. Adds `CITRON_SAVE_SEED_ROOT` and data_erase to core CMakeLists (no DNA gateway).

Split from `moltenvk-xfb` via file-group checkout.

## Test plan
- [ ] Save create/open for affected titles
- [ ] Data erase applet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “DataErase” applet flow that prepares erase capacity, creates the required save data, and returns completion output.
  * Implemented real cache storage listing/creation/deletion and improved save-data total/free space queries, including automatic extra-data size synchronization.
  * Added journaling-based save-data filesystem support with conditional recovery and optional mirroring/backup behavior.

* **Bug Fixes**
  * Fixed VFS directory rename/caching behavior during moves.
  * Improved save-data recovery rules and cache path handling for consistent layouts.
  * Enhanced memory-transfer validation and error logging, plus additional stale-state repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->