### PR TITLE
fix: Bedrock account, dauth, and related services

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <filesystem>
+#include <atomic>
 #include <mutex>
 #include <string_view>
 #include <unordered_map>
@@ -1048,7 +1049,7 @@ public:
     explicit IGuestLoginRequest(Core::System& system_, Common::UUID user_id_,
                                 ProfileManager& profile_manager_)
         : ServiceFramework{system_, "IGuestLoginRequest"}, user_id{user_id_},
-          profile_manager{profile_manager_} {
+          profile_manager{profile_manager_}, session_id{Common::UUID::MakeRandom()} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IGuestLoginRequest::GetSessionId, "GetSessionId"},
@@ -1067,8 +1068,9 @@ public:
 private:
     void GetSessionId(HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "IGuestLoginRequest::GetSessionId called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(ResultSuccess);
+        rb.PushRaw(session_id);
     }
 
     void GetAccountId(HLERequestContext& ctx) {
@@ -1132,6 +1134,7 @@ private:
 
     Common::UUID user_id;
     ProfileManager& profile_manager;
+    Common::UUID session_id;
 };
 
 class EnsureTokenIdCacheAsyncInterface final : public IAsyncContext {
@@ -1281,7 +1284,7 @@ public:
     }
 
     void SignalCompletion() {
-        is_complete = true;
+        is_complete.store(true);
         completion_event->Signal();
     }
 
@@ -1289,7 +1292,7 @@ private:
     void GetSystemEvent(HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "IAsyncNetworkServiceLicenseKindContext::GetSystemEvent called");
 
-        if (is_complete) {
+        if (is_complete.load()) {
             completion_event->Signal();
         }
 
@@ -1299,7 +1302,7 @@ private:
     }
 
     void Cancel(HLERequestContext& ctx) {
-        is_complete = true;
+        is_complete.store(true);
         completion_event->Signal();
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -1308,11 +1311,11 @@ private:
 
     void HasDone(HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "IAsyncNetworkServiceLicenseKindContext::HasDone called, done={}",
-                 is_complete);
+                 is_complete.load());
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.Push(is_complete);
+        rb.Push(is_complete.load());
     }
 
     void GetResult(HLERequestContext& ctx) {
@@ -1331,7 +1334,7 @@ private:
 
     KernelHelpers::ServiceContext service_context;
     Kernel::KEvent* completion_event{};
-    bool is_complete{};
+    std::atomic<bool> is_complete{false};
 };
 
 class IAsyncContextForLoginForOnlinePlay final
@@ -1361,7 +1364,7 @@ public:
     }
 
     void SignalCompletion() {
-        is_complete = true;
+        is_complete.store(true);
         completion_event->Signal();
     }
 
@@ -1369,7 +1372,7 @@ private:
     void GetSystemEvent(HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::GetSystemEvent called");
 
-        if (is_complete) {
+        if (is_complete.load()) {
             completion_event->Signal();
         }
 
@@ -1379,7 +1382,7 @@ private:
     }
 
     void Cancel(HLERequestContext& ctx) {
-        is_complete = true;
+        is_complete.store(true);
         completion_event->Signal();
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -1388,11 +1391,11 @@ private:
 
     void HasDone(HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::HasDone called, done={}",
-                 is_complete);
+                 is_complete.load());
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.Push(is_complete);
+        rb.Push(is_complete.load());
     }
 
     void GetResult(HLERequestContext& ctx) {
@@ -1420,7 +1423,7 @@ private:
 
     KernelHelpers::ServiceContext service_context;
     Kernel::KEvent* completion_event{};
-    bool is_complete{};
+    std::atomic<bool> is_complete{false};
     Common::UUID user_id;
 };
 

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -2,8 +2,11 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <algorithm>
-#include <array>
+#include <filesystem>
+#include <mutex>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include "common/common_types.h"
 #include "common/fs/file.h"
@@ -15,7 +18,9 @@
 #include "common/swap.h"
 #include "core/constants.h"
 #include "core/core.h"
+#include "core/hle/api_version.h"
 #include "core/core_timing.h"
+#include "core/hle/kernel/k_event.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/hle/service/acc/acc.h"
@@ -40,6 +45,9 @@ namespace Service::Account {
 
 // Thumbnails are hard coded to be at least this size
 constexpr std::size_t THUMBNAIL_SIZE = 0x24000;
+
+// Forward declaration — full definition appears later in this file after the async interfaces.
+class EnsureTokenIdCacheAsyncInterface;
 
 static std::filesystem::path GetImagePath(const Common::UUID& uuid) {
     return Common::FS::GetCitronPath(Common::FS::CitronPath::NANDDir) /
@@ -78,6 +86,334 @@ static void SanitizeJPEGImageSize(std::vector<u8>& image) {
     image.resize(std::min(image.size(), max_jpeg_image_size));
 }
 
+namespace {
+
+// Bedrock treats license kind 0 as "no license" and shows "Something went wrong".
+// Ryujinx stubs NSO as Subscribed (2), not Personal (1).
+constexpr u32 NETWORK_SERVICE_LICENSE_KIND_SUBSCRIBED = 2;
+constexpr u32 NETWORK_SERVICE_LICENSE_KIND_BEDROCK = NETWORK_SERVICE_LICENSE_KIND_SUBSCRIBED;
+constexpr u64 STUB_NETWORK_SERVICE_ACCOUNT_ID = 0x000000000000CAFEULL;
+constexpr s64 NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION = 0x7FFFFFFFFFFFFFFFLL;
+
+std::string Base64UrlEncode(std::string_view input) {
+    static constexpr char table[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve(((input.size() + 2) / 3) * 4);
+
+    for (std::size_t i = 0; i < input.size(); i += 3) {
+        const u32 block = (static_cast<u8>(input[i]) << 16) |
+                          ((i + 1 < input.size() ? static_cast<u8>(input[i + 1]) : 0) << 8) |
+                          (i + 2 < input.size() ? static_cast<u8>(input[i + 2]) : 0);
+        out.push_back(table[(block >> 18) & 0x3F]);
+        out.push_back(table[(block >> 12) & 0x3F]);
+        out.push_back(i + 1 < input.size() ? table[(block >> 6) & 0x3F] : '=');
+        out.push_back(i + 2 < input.size() ? table[block & 0x3F] : '=');
+    }
+
+    for (char& c : out) {
+        if (c == '+') {
+            c = '-';
+        } else if (c == '/') {
+            c = '_';
+        }
+    }
+    while (!out.empty() && out.back() == '=') {
+        out.pop_back();
+    }
+    return out;
+}
+
+std::filesystem::path GetAccountSaveBasePath() {
+    return Common::FS::GetCitronPath(Common::FS::CitronPath::NANDDir) /
+           "system/save/8000000000000010";
+}
+
+std::filesystem::path GetBaasAccountCachePath(const Common::UUID& uuid) {
+    return GetAccountSaveBasePath() / "su/baas" / fmt::format("{}.dat", uuid.FormattedString());
+}
+
+std::filesystem::path GetSuIdTokenCachePath(const Common::UUID& uuid) {
+    return GetAccountSaveBasePath() / "su/cache" / fmt::format("{}.dat", uuid.FormattedString());
+}
+
+std::filesystem::path GetNasUserResourceCachePath(const Common::UUID& uuid) {
+    return GetAccountSaveBasePath() / "su/nas" / fmt::format("{}.dat", uuid.FormattedString());
+}
+
+std::filesystem::path GetNetworkServiceLicenseCachePath(const Common::UUID& uuid) {
+    return GetAccountSaveBasePath() / "su/license" /
+           fmt::format("{}.dat", uuid.FormattedString());
+}
+
+bool WriteBinaryFile(const std::filesystem::path& path, std::span<const u8> data) {
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+        LOG_WARNING(Service_ACC, "Failed to create directory {}: {}", path.parent_path().string(),
+                    ec.message());
+        return false;
+    }
+
+    Common::FS::IOFile file(path, Common::FS::FileAccessMode::Write, Common::FS::FileType::BinaryFile);
+    if (!file.IsOpen()) {
+        LOG_WARNING(Service_ACC, "Failed to open {}", path.string());
+        return false;
+    }
+
+    if (file.Write(data) != data.size()) {
+        LOG_WARNING(Service_ACC, "Failed to write {}", path.string());
+        return false;
+    }
+
+    return true;
+}
+
+constexpr std::size_t NAS_USER_BASE_SIZE = 0x68;
+constexpr u64 STUB_NINTENDO_ACCOUNT_ID = 0x0123456789ABCDEFULL;
+
+u64 GetStubNintendoAccountId(const Common::UUID& account_id) {
+    const u64 derived = account_id.Hash();
+    return derived != 0 ? derived : STUB_NINTENDO_ACCOUNT_ID;
+}
+
+std::string GetStubDeviceIdHex(const Common::UUID& user_id) {
+    const u64 derived = user_id.IsInvalid() ? 0x0123456789ABCDEFULL : user_id.Hash();
+    const u64 device_account = GetStubNintendoAccountId(user_id);
+    return fmt::format("{:016x}{:016x}", derived, device_account);
+}
+
+std::vector<u8> GenerateStubIdToken(const Common::UUID& user_id) {
+    // Bedrock validates Nintendo id_token JWT fields (iss/exp/aud/sub/di/bs:did). sub must match user.
+    constexpr std::string_view header{R"({"alg":"none","typ":"JWT"})"};
+    const std::string subject =
+        user_id.IsInvalid() ? "00000000000000000000000000000001" : user_id.RawString();
+    const std::string device_id = GetStubDeviceIdHex(user_id);
+    const std::string payload = fmt::format(
+        R"({{"sub":"{}","aud":"ed9e2f05d286f7b8","di":"{}","sn":"XAW10000000000","bs:did":"{}","iss":"https://e0d67c509fb203858ebcbcf2fe3f88c2aa.baas.nintendo.com","typ":"id_token","exp":2000000000,"iat":1700000000}})",
+        subject, device_id, device_id);
+    const std::string token =
+        fmt::format("{}.{}.", Base64UrlEncode(header), Base64UrlEncode(payload));
+    return std::vector<u8>(token.begin(), token.end());
+}
+
+void PopulateNasUserBaseForApplication(std::vector<u8>& out, u64 nintendo_account_id) {
+    out.assign(NAS_USER_BASE_SIZE, 0);
+    std::memcpy(out.data(), &nintendo_account_id, sizeof(nintendo_account_id));
+    out[0x08] = 1; // is_nintendo_account_linked
+    out[0x09] = 1; // is_network_service_account_registered
+    if (out.size() >= 0x0C + sizeof(u32)) {
+        const u32 license_kind = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+        std::memcpy(out.data() + 0x0C, &license_kind, sizeof(license_kind));
+    }
+}
+
+void WriteAccountServiceCachesOnDisk(const Common::UUID& user_id, u64 title_id) {
+    // su/baas: CheckAvailability / GetAccountId read NetworkServiceAccountId from here.
+    std::vector<u8> baas_data(0x40, 0);
+    const u64 network_service_account_id = STUB_NETWORK_SERVICE_ACCOUNT_ID;
+    std::memcpy(baas_data.data(), &network_service_account_id, sizeof(network_service_account_id));
+    baas_data[0x08] = 1; // is_nintendo_account_linked
+    baas_data[0x09] = 1; // is_network_service_account_registered
+    const u32 license_kind = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+    std::memcpy(baas_data.data() + 0x0C, &license_kind, sizeof(license_kind));
+
+    const auto baas_path = GetBaasAccountCachePath(user_id);
+    if (WriteBinaryFile(baas_path, baas_data)) {
+        LOG_INFO(Service_ACC, "Wrote baas account cache to {}", baas_path.string());
+    }
+
+    // su/cache: LoadIdTokenCache reads the JWT id token from here (not su/baas).
+    const auto token = GenerateStubIdToken(user_id);
+    const auto cache_path = GetSuIdTokenCachePath(user_id);
+    if (WriteBinaryFile(cache_path, token)) {
+        LOG_INFO(Service_ACC, "Wrote id token cache to {}", cache_path.string());
+    }
+
+    const u64 nintendo_account_id = GetStubNintendoAccountId(user_id);
+    std::vector<u8> nas_user_base;
+    PopulateNasUserBaseForApplication(nas_user_base, nintendo_account_id);
+    const auto nas_path = GetNasUserResourceCachePath(user_id);
+    if (WriteBinaryFile(nas_path, nas_user_base)) {
+        LOG_INFO(Service_ACC, "Wrote NAS user resource cache to {}", nas_path.string());
+    }
+
+    std::vector<u8> license_cache(sizeof(u32) + sizeof(s64), 0);
+    std::memcpy(license_cache.data(), &license_kind, sizeof(license_kind));
+    const s64 expiration = NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION;
+    std::memcpy(license_cache.data() + sizeof(u32), &expiration, sizeof(expiration));
+    const auto license_path = GetNetworkServiceLicenseCachePath(user_id);
+    if (WriteBinaryFile(license_path, license_cache)) {
+        LOG_INFO(Service_ACC, "Wrote network service license cache to {}", license_path.string());
+    }
+
+    if (title_id != 0) {
+        WriteDauthApplicationAuthCacheOnDisk(title_id);
+    }
+}
+
+struct BaasStubSessionState {
+    bool id_token_cache_ready{};
+    u32 network_service_license_kind{};
+};
+
+std::mutex baas_stub_session_mutex;
+std::unordered_map<Common::UUID, BaasStubSessionState> baas_stub_session_cache;
+
+BaasStubSessionState& GetOrCreateBaasStubSessionState(const Common::UUID& user_id) {
+    return baas_stub_session_cache[user_id];
+}
+
+void PopulateBaasStubSessionCache(Core::System& system, const Common::UUID& user_id) {
+    std::scoped_lock lock{baas_stub_session_mutex};
+    auto& state = GetOrCreateBaasStubSessionState(user_id);
+    state.id_token_cache_ready = true;
+    state.network_service_license_kind = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+    WriteAccountServiceCachesOnDisk(user_id, system.GetApplicationProcessProgramID());
+}
+
+void EnsureDefaultAvatarExists(const Common::UUID& uuid) {
+    const auto image_path = GetImagePath(uuid);
+    if (std::filesystem::exists(image_path)) {
+        return;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(image_path.parent_path(), ec);
+    if (ec) {
+        LOG_WARNING(Service_ACC, "Failed to create avatar directory for {}: {}", image_path.string(),
+                    ec.message());
+        return;
+    }
+
+    Common::FS::IOFile image(image_path, Common::FS::FileAccessMode::Write,
+                             Common::FS::FileType::BinaryFile);
+    if (!image.IsOpen()) {
+        LOG_WARNING(Service_ACC, "Failed to create default avatar at {}", image_path.string());
+        return;
+    }
+
+    if (image.Write(Core::Constants::ACCOUNT_BACKUP_JPEG) !=
+        Core::Constants::ACCOUNT_BACKUP_JPEG.size()) {
+        LOG_WARNING(Service_ACC, "Failed to write default avatar at {}", image_path.string());
+        return;
+    }
+
+    LOG_INFO(Service_ACC, "Created default avatar at {}", image_path.string());
+}
+
+void PushLoadIdTokenCacheResponse(HLERequestContext& ctx, const Common::UUID& user_id = {}) {
+    std::vector<u8> token = GenerateStubIdToken(user_id);
+    if (!user_id.IsInvalid()) {
+        const auto cache_path = GetSuIdTokenCachePath(user_id);
+        Common::FS::IOFile cache_file(cache_path, Common::FS::FileAccessMode::Read,
+                                      Common::FS::FileType::BinaryFile);
+        if (cache_file.IsOpen()) {
+            token.resize(static_cast<std::size_t>(cache_file.GetSize()));
+            if (cache_file.Read(token) != token.size()) {
+                token = GenerateStubIdToken(user_id);
+            }
+        }
+    }
+
+    const u32 token_size = static_cast<u32>(token.size());
+    if (ctx.CanWriteBuffer(0)) {
+        ctx.WriteBuffer(token, 0);
+    }
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(token_size);
+}
+
+void PushAuthorizationCodeResponse(HLERequestContext& ctx) {
+    constexpr std::string_view stub_code{"citron_stub_authorization_code"};
+    const u32 code_size = static_cast<u32>(stub_code.size());
+
+    if (ctx.CanWriteBuffer(0)) {
+        std::vector<u8> buffer(ctx.GetWriteBufferSize(0), 0);
+        if (code_size <= buffer.size()) {
+            std::memcpy(buffer.data(), stub_code.data(), stub_code.size());
+        }
+        ctx.WriteBuffer(buffer, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(code_size);
+}
+
+void PushNasAuthorizationStateResponse(HLERequestContext& ctx, bool authorized) {
+    if (ctx.CanWriteBuffer(0)) {
+        std::vector<u8> state(ctx.GetWriteBufferSize(0), 0);
+        if (state.size() >= sizeof(u32)) {
+            const u32 value = authorized ? 1U : 0U;
+            std::memcpy(state.data(), &value, sizeof(value));
+        } else if (!state.empty()) {
+            state[0] = authorized ? 1 : 0;
+        }
+        ctx.WriteBuffer(state, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ResultSuccess);
+}
+
+void WriteNetworkServiceLicenseCacheBuffer(HLERequestContext& ctx) {
+    if (!ctx.CanWriteBuffer(0)) {
+        return;
+    }
+
+    std::vector<u8> cache(ctx.GetWriteBufferSize(0), 0);
+    if (cache.size() >= sizeof(u32)) {
+        const u32 license_kind = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+        std::memcpy(cache.data(), &license_kind, sizeof(license_kind));
+    }
+    if (cache.size() >= sizeof(u32) + sizeof(s64)) {
+        const s64 expiration = NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION;
+        std::memcpy(cache.data() + sizeof(u32), &expiration, sizeof(expiration));
+    }
+    ctx.WriteBuffer(cache, 0);
+}
+
+void WriteNasUserResourceCacheBuffers(HLERequestContext& ctx, u64 nintendo_account_id) {
+    std::vector<u8> nas_user_base;
+    PopulateNasUserBaseForApplication(nas_user_base, nintendo_account_id);
+    ctx.WriteBuffer(nas_user_base, 0);
+
+    if (ctx.CanWriteBuffer(1)) {
+        std::vector<u8> unknown_out_buffer(ctx.GetWriteBufferSize(1));
+        ctx.WriteBuffer(unknown_out_buffer, 1);
+    }
+}
+
+class CompletedIAsyncContextInterface final : public IAsyncContext {
+public:
+    explicit CompletedIAsyncContextInterface(Core::System& system_) : IAsyncContext{system_} {
+        MarkComplete();
+    }
+
+protected:
+    bool IsComplete() const override {
+        return true;
+    }
+
+    void Cancel() override {}
+
+    Result GetResult() const override {
+        return ResultSuccess;
+    }
+};
+
+void PushCompletedIAsyncContextResponse(Core::System& system, HLERequestContext& ctx) {
+    auto async = std::make_shared<CompletedIAsyncContextInterface>(system);
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(ResultSuccess);
+    rb.PushIpcInterface(async);
+}
+
+} // Anonymous namespace
+
 class IManagerForSystemService final : public ServiceFramework<IManagerForSystemService> {
 public:
     explicit IManagerForSystemService(Core::System& system_, Common::UUID uuid)
@@ -86,28 +422,36 @@ public:
         static const FunctionInfo functions[] = {
             {0, D<&IManagerForSystemService::CheckAvailability>, "CheckAvailability"},
             {1, D<&IManagerForSystemService::GetAccountId>, "GetAccountId"},
-            {2, nullptr, "EnsureIdTokenCacheAsync"},
-            {3, D<&IManagerForSystemService::LoadIdTokenCacheDeprecated>, "LoadIdTokenCacheDeprecated"}, // 19.0.0+
-            {4, D<&IManagerForSystemService::LoadIdTokenCache>, "LoadIdTokenCache"}, // 19.0.0+
+            {2, &IManagerForSystemService::EnsureIdTokenCacheAsync, "EnsureIdTokenCacheAsync"},
+            {3, &IManagerForSystemService::LoadIdTokenCacheDeprecated, "LoadIdTokenCacheDeprecated"},
+            {4, &IManagerForSystemService::LoadIdTokenCache, "LoadIdTokenCache"},
             {100, nullptr, "SetSystemProgramIdentification"},
             {101, nullptr, "RefreshNotificationTokenAsync"}, // 7.0.0+
             {110, nullptr, "GetServiceEntryRequirementCache"}, // 4.0.0+
             {111, nullptr, "InvalidateServiceEntryRequirementCache"}, // 4.0.0+
             {112, nullptr, "InvalidateTokenCache"}, // 4.0.0 - 6.2.0
-            {113, nullptr, "GetServiceEntryRequirementCacheForOnlinePlay"}, // 6.1.0+
+            {113, D<&IManagerForSystemService::GetServiceEntryRequirementCacheForOnlinePlay>,
+             "GetServiceEntryRequirementCacheForOnlinePlay"}, // 6.1.0+
             {120, nullptr, "GetNintendoAccountId"},
             {121, nullptr, "CalculateNintendoAccountAuthenticationFingerprint"}, // 9.0.0+
-            {130, nullptr, "GetNintendoAccountUserResourceCache"},
-            {131, nullptr, "RefreshNintendoAccountUserResourceCacheAsync"},
-            {132, nullptr, "RefreshNintendoAccountUserResourceCacheAsyncIfSecondsElapsed"},
+            {130, &IManagerForSystemService::GetNintendoAccountUserResourceCache,
+             "GetNintendoAccountUserResourceCache"},
+            {131, &IManagerForSystemService::RefreshNintendoAccountUserResourceCacheAsync,
+             "RefreshNintendoAccountUserResourceCacheAsync"},
+            {132, &IManagerForSystemService::RefreshNintendoAccountUserResourceCacheAsyncIfSecondsElapsed,
+             "RefreshNintendoAccountUserResourceCacheAsyncIfSecondsElapsed"},
             {133, nullptr, "GetNintendoAccountVerificationUrlCache"}, // 9.0.0+
             {134, nullptr, "RefreshNintendoAccountVerificationUrlCache"}, // 9.0.0+
             {135, nullptr, "RefreshNintendoAccountVerificationUrlCacheAsyncIfSecondsElapsed"}, // 9.0.0+
-            {140, nullptr, "GetNetworkServiceLicenseCache"}, // 5.0.0+
-            {141, nullptr, "RefreshNetworkServiceLicenseCacheAsync"}, // 5.0.0+
-            {142, nullptr, "RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed"}, // 5.0.0+
+            {140, &IManagerForSystemService::GetNetworkServiceLicenseCache,
+             "GetNetworkServiceLicenseCache"}, // 5.0.0+
+            {141, &IManagerForSystemService::RefreshNetworkServiceLicenseCacheAsync,
+             "RefreshNetworkServiceLicenseCacheAsync"}, // 5.0.0+
+            {142, &IManagerForSystemService::RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed,
+             "RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed"}, // 5.0.0+
             {150, nullptr, "CreateAuthorizationRequest"},
-            {160, nullptr, "RequiresUpdateNetworkServiceAccountIdTokenCache"},
+            {160, D<&IManagerForSystemService::RequiresUpdateNetworkServiceAccountIdTokenCache>,
+             "RequiresUpdateNetworkServiceAccountIdTokenCache"},
             {161, nullptr, "RequireReauthenticationOfNetworkServiceAccount"},
             {143, D<&IManagerForSystemService::GetNetworkServiceLicenseCacheEx>, "GetNetworkServiceLicenseCacheEx"}, // 15.0.0+
         };
@@ -117,33 +461,110 @@ public:
     }
 
 private:
-    Result CheckAvailability() {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+    Result CheckAvailability(Out<bool> out_available) {
+        LOG_DEBUG(Service_ACC, "called");
+        *out_available = true;
         R_SUCCEED();
     }
 
     Result GetAccountId(Out<u64> out_account_id) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-        *out_account_id = account_id.Hash();
+        LOG_INFO(Service_ACC, "IManagerForSystemService::GetAccountId called");
+        *out_account_id = STUB_NETWORK_SERVICE_ACCOUNT_ID;
         R_SUCCEED();
     }
 
-    Result LoadIdTokenCacheDeprecated() {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-        R_SUCCEED();
+    // Defined out-of-class below, after EnsureTokenIdCacheAsyncInterface is fully defined.
+    void EnsureIdTokenCacheAsync(HLERequestContext& ctx);
+
+    void LoadIdTokenCacheDeprecated(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+        PushLoadIdTokenCacheResponse(ctx, account_id);
     }
 
-    Result LoadIdTokenCache() {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-        R_SUCCEED();
+    void LoadIdTokenCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+        PushLoadIdTokenCacheResponse(ctx, account_id);
     }
 
     Result GetNetworkServiceLicenseCacheEx(Out<u32> out_license, Out<s64> out_expiration) {
         LOG_INFO(Service_ACC, "called");
 
-        *out_license = 0;
-        *out_expiration = 0;
+        *out_license = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+        *out_expiration = NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION;
 
+        R_SUCCEED();
+    }
+
+    Result GetServiceEntryRequirementCacheForOnlinePlay(Out<u32> out_requirement) {
+        LOG_INFO(Service_ACC, "called");
+        // Non-zero indicates the title may proceed with online/local play gating.
+        *out_requirement = 1;
+        R_SUCCEED();
+    }
+
+    void GetNetworkServiceLicenseCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IManagerForSystemService::GetNetworkServiceLicenseCache called");
+        WriteNetworkServiceLicenseCacheBuffer(ctx);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void GetNintendoAccountUserResourceCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+
+        const u64 nintendo_account_id = GetStubNintendoAccountId(account_id);
+        WriteNasUserResourceCacheBuffers(ctx, nintendo_account_id);
+
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(ResultSuccess);
+        rb.PushRaw<u64>(nintendo_account_id);
+    }
+
+    void RefreshNintendoAccountUserResourceCacheAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+        PushCompletedIAsyncContextResponse(system, ctx);
+    }
+
+    void RefreshNintendoAccountUserResourceCacheAsyncIfSecondsElapsed(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+
+        IPC::RequestParser rp{ctx};
+        [[maybe_unused]] const auto seconds = rp.Pop<u32>();
+
+        auto async = std::make_shared<CompletedIAsyncContextInterface>(system);
+
+        IPC::ResponseBuilder rb{ctx, 3, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.Push<u8>(1);
+        rb.PushIpcInterface(async);
+    }
+
+    void RefreshNetworkServiceLicenseCacheAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+        PopulateBaasStubSessionCache(system,account_id);
+        PushCompletedIAsyncContextResponse(system, ctx);
+    }
+
+    void RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+
+        IPC::RequestParser rp{ctx};
+        [[maybe_unused]] const auto seconds = rp.Pop<u32>();
+
+        PopulateBaasStubSessionCache(system,account_id);
+
+        auto async = std::make_shared<CompletedIAsyncContextInterface>(system);
+
+        IPC::ResponseBuilder rb{ctx, 3, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.Push<u8>(1);
+        rb.PushIpcInterface(async);
+    }
+
+    Result RequiresUpdateNetworkServiceAccountIdTokenCache(Out<u8> out_requires_update) {
+        LOG_INFO(Service_ACC, "called");
+        *out_requires_update = 0;
         R_SUCCEED();
     }
 
@@ -239,21 +660,66 @@ public:
 
 class IAuthorizationRequest final : public ServiceFramework<IAuthorizationRequest> {
 public:
-    explicit IAuthorizationRequest(Core::System& system_, Common::UUID)
-        : ServiceFramework{system_, "IAuthorizationRequest"} {
+    explicit IAuthorizationRequest(Core::System& system_, Common::UUID user_id_)
+        : ServiceFramework{system_, "IAuthorizationRequest"}, user_id{user_id_},
+          session_id{Common::UUID::MakeRandom()} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetSessionId"},
-            {10, nullptr, "InvokeWithoutInteractionAsync"},
-            {19, nullptr, "IsAuthorized"},
-            {20, nullptr, "GetAuthorizationCode"},
-            {21, nullptr, "GetIdToken"},
-            {22, nullptr, "GetState"},
+            {0, &IAuthorizationRequest::GetSessionId, "GetSessionId"},
+            {10, &IAuthorizationRequest::InvokeWithoutInteractionAsync, "InvokeWithoutInteractionAsync"},
+            {19, &IAuthorizationRequest::IsAuthorized, "IsAuthorized"},
+            {20, &IAuthorizationRequest::GetAuthorizationCode, "GetAuthorizationCode"},
+            {21, &IAuthorizationRequest::GetIdToken, "GetIdToken"},
+            {22, &IAuthorizationRequest::GetState, "GetState"},
         };
         // clang-format on
 
         RegisterHandlers(functions);
     }
+
+private:
+    void GetSessionId(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::GetSessionId called");
+
+        IPC::ResponseBuilder rb{ctx, 6};
+        rb.Push(ResultSuccess);
+        rb.PushRaw(session_id);
+    }
+
+    void InvokeWithoutInteractionAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::InvokeWithoutInteractionAsync called");
+        authorized = true;
+        PushCompletedIAsyncContextResponse(system, ctx);
+    }
+
+    void IsAuthorized(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::IsAuthorized called, authorized={}",
+                 authorized);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<u8>(authorized ? 1 : 0);
+    }
+
+    void GetAuthorizationCode(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::GetAuthorizationCode called");
+        PushAuthorizationCodeResponse(ctx);
+    }
+
+    void GetIdToken(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::GetIdToken called");
+        PopulateBaasStubSessionCache(system, user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
+    }
+
+    void GetState(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAuthorizationRequest::GetState called, authorized={}", authorized);
+        PushNasAuthorizationStateResponse(ctx, authorized);
+    }
+
+    Common::UUID user_id;
+    Common::UUID session_id;
+    bool authorized{};
 };
 
 class IOAuthProcedure final : public ServiceFramework<IOAuthProcedure> {
@@ -579,42 +1045,108 @@ public:
 
 class IGuestLoginRequest final : public ServiceFramework<IGuestLoginRequest> {
 public:
-    explicit IGuestLoginRequest(Core::System& system_, Common::UUID)
-        : ServiceFramework{system_, "IGuestLoginRequest"} {
+    explicit IGuestLoginRequest(Core::System& system_, Common::UUID user_id_,
+                                ProfileManager& profile_manager_)
+        : ServiceFramework{system_, "IGuestLoginRequest"}, user_id{user_id_},
+          profile_manager{profile_manager_} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetSessionId"},
+            {0, &IGuestLoginRequest::GetSessionId, "GetSessionId"},
             {11, nullptr, "Unknown"}, // 1.0.0 - 2.3.0 (the name is blank on Switchbrew)
-            {12, nullptr, "GetAccountId"},
-            {13, nullptr, "GetLinkedNintendoAccountId"},
-            {14, nullptr, "GetNickname"},
-            {15, nullptr, "GetProfileImage"},
-            {21, nullptr, "LoadIdTokenCache"}, // 3.0.0+
+            {12, &IGuestLoginRequest::GetAccountId, "GetAccountId"},
+            {13, &IGuestLoginRequest::GetLinkedNintendoAccountId, "GetLinkedNintendoAccountId"},
+            {14, &IGuestLoginRequest::GetNickname, "GetNickname"},
+            {15, &IGuestLoginRequest::GetProfileImage, "GetProfileImage"},
+            {21, &IGuestLoginRequest::LoadIdTokenCache, "LoadIdTokenCache"}, // 3.0.0+
         };
         // clang-format on
 
         RegisterHandlers(functions);
     }
+
+private:
+    void GetSessionId(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::GetSessionId called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void GetAccountId(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::GetAccountId called");
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(ResultSuccess);
+        rb.PushRaw<u64>(STUB_NETWORK_SERVICE_ACCOUNT_ID);
+    }
+
+    void GetLinkedNintendoAccountId(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::GetLinkedNintendoAccountId called");
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(ResultSuccess);
+        rb.PushRaw<u64>(GetStubNintendoAccountId(user_id));
+    }
+
+    void GetNickname(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::GetNickname called");
+
+        ProfileBase profile_base{};
+        if (profile_manager.GetProfileBase(user_id, profile_base)) {
+            ctx.WriteBuffer(profile_base.username);
+        }
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void GetProfileImage(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::GetProfileImage called");
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+
+        EnsureDefaultAvatarExists(user_id);
+        const Common::FS::IOFile image(GetImagePath(user_id), Common::FS::FileAccessMode::Read,
+                                       Common::FS::FileType::BinaryFile);
+        if (!image.IsOpen()) {
+            ctx.WriteBuffer(Core::Constants::ACCOUNT_BACKUP_JPEG);
+            rb.Push(static_cast<u32>(Core::Constants::ACCOUNT_BACKUP_JPEG.size()));
+            return;
+        }
+
+        std::vector<u8> buffer(static_cast<std::size_t>(image.GetSize()));
+        if (image.Read(buffer) != buffer.size()) {
+            buffer = std::vector<u8>(Core::Constants::ACCOUNT_BACKUP_JPEG.begin(),
+                                     Core::Constants::ACCOUNT_BACKUP_JPEG.end());
+        } else {
+            SanitizeJPEGImageSize(buffer);
+        }
+
+        ctx.WriteBuffer(buffer);
+        rb.Push(static_cast<u32>(buffer.size()));
+    }
+
+    void LoadIdTokenCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IGuestLoginRequest::LoadIdTokenCache called");
+        PopulateBaasStubSessionCache(system,user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
+    }
+
+    Common::UUID user_id;
+    ProfileManager& profile_manager;
 };
 
 class EnsureTokenIdCacheAsyncInterface final : public IAsyncContext {
 public:
-    explicit EnsureTokenIdCacheAsyncInterface(Core::System& system_) : IAsyncContext{system_} {
-        MarkComplete();
-    }
+    explicit EnsureTokenIdCacheAsyncInterface(Core::System& system_, const Common::UUID& user_id_)
+        : IAsyncContext{system_}, user_id{user_id_} {}
     ~EnsureTokenIdCacheAsyncInterface() = default;
 
     void LoadIdTokenCache(HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-
-        IPC::ResponseBuilder rb{ctx, 3};
-        rb.Push(ResultSuccess);
-        rb.Push(0);
+        LOG_INFO(Service_ACC, "EnsureTokenIdCacheAsyncInterface::LoadIdTokenCache called");
+        PopulateBaasStubSessionCache(system, user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
     }
-
-protected:
     bool IsComplete() const override {
-        return true;
+        return is_complete.load();
     }
 
     void Cancel() override {}
@@ -622,6 +1154,8 @@ protected:
     Result GetResult() const override {
         return ResultSuccess;
     }
+
+    Common::UUID user_id;
 };
 
 class AuthenticateApplicationAsyncInterface final : public IAsyncContext {
@@ -722,13 +1256,200 @@ protected:
     }
 };
 
+class IAsyncNetworkServiceLicenseKindContext final
+    : public ServiceFramework<IAsyncNetworkServiceLicenseKindContext> {
+public:
+    explicit IAsyncNetworkServiceLicenseKindContext(Core::System& system_)
+        : ServiceFramework{system_, "IAsyncNetworkServiceLicenseKindContext"},
+          service_context{system_, "IAsyncNetworkServiceLicenseKindContext"} {
+        static const FunctionInfo functions[] = {
+            {0, &IAsyncNetworkServiceLicenseKindContext::GetSystemEvent, "GetSystemEvent"},
+            {1, &IAsyncNetworkServiceLicenseKindContext::Cancel, "Cancel"},
+            {2, &IAsyncNetworkServiceLicenseKindContext::HasDone, "HasDone"},
+            {3, &IAsyncNetworkServiceLicenseKindContext::GetResult, "GetResult"},
+            {100, &IAsyncNetworkServiceLicenseKindContext::GetNetworkServiceLicenseKind,
+             "GetNetworkServiceLicenseKind"},
+        };
+        RegisterHandlers(functions);
+
+        completion_event =
+            service_context.CreateEvent("IAsyncNetworkServiceLicenseKindContext:CompletionEvent");
+    }
+
+    ~IAsyncNetworkServiceLicenseKindContext() override {
+        service_context.CloseEvent(completion_event);
+    }
+
+    void SignalCompletion() {
+        is_complete = true;
+        completion_event->Signal();
+    }
+
+private:
+    void GetSystemEvent(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncNetworkServiceLicenseKindContext::GetSystemEvent called");
+
+        if (is_complete) {
+            completion_event->Signal();
+        }
+
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(ResultSuccess);
+        rb.PushCopyObjects(completion_event->GetReadableEvent());
+    }
+
+    void Cancel(HLERequestContext& ctx) {
+        is_complete = true;
+        completion_event->Signal();
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void HasDone(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncNetworkServiceLicenseKindContext::HasDone called, done={}",
+                 is_complete);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push(is_complete);
+    }
+
+    void GetResult(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncNetworkServiceLicenseKindContext::GetResult called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void GetNetworkServiceLicenseKind(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "called");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<u32>(NETWORK_SERVICE_LICENSE_KIND_BEDROCK);
+    }
+
+    KernelHelpers::ServiceContext service_context;
+    Kernel::KEvent* completion_event{};
+    bool is_complete{};
+};
+
+class IAsyncContextForLoginForOnlinePlay final
+    : public ServiceFramework<IAsyncContextForLoginForOnlinePlay> {
+public:
+    explicit IAsyncContextForLoginForOnlinePlay(Core::System& system_,
+                                                const Common::UUID& user_id_)
+        : ServiceFramework{system_, "IAsyncContextForLoginForOnlinePlay"},
+          service_context{system_, "IAsyncContextForLoginForOnlinePlay"}, user_id{user_id_} {
+        static const FunctionInfo functions[] = {
+            {0, &IAsyncContextForLoginForOnlinePlay::GetSystemEvent, "GetSystemEvent"},
+            {1, &IAsyncContextForLoginForOnlinePlay::Cancel, "Cancel"},
+            {2, &IAsyncContextForLoginForOnlinePlay::HasDone, "HasDone"},
+            {3, &IAsyncContextForLoginForOnlinePlay::GetResult, "GetResult"},
+            {21, &IAsyncContextForLoginForOnlinePlay::LoadIdTokenCache, "LoadIdTokenCache"},
+            {100, &IAsyncContextForLoginForOnlinePlay::GetNetworkServiceLicenseInfoForOnlinePlay,
+             "GetNetworkServiceLicenseInfoForOnlinePlay"},
+        };
+        RegisterHandlers(functions);
+
+        completion_event =
+            service_context.CreateEvent("IAsyncContextForLoginForOnlinePlay:CompletionEvent");
+    }
+
+    ~IAsyncContextForLoginForOnlinePlay() override {
+        service_context.CloseEvent(completion_event);
+    }
+
+    void SignalCompletion() {
+        is_complete = true;
+        completion_event->Signal();
+    }
+
+private:
+    void GetSystemEvent(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::GetSystemEvent called");
+
+        if (is_complete) {
+            completion_event->Signal();
+        }
+
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(ResultSuccess);
+        rb.PushCopyObjects(completion_event->GetReadableEvent());
+    }
+
+    void Cancel(HLERequestContext& ctx) {
+        is_complete = true;
+        completion_event->Signal();
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void HasDone(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::HasDone called, done={}",
+                 is_complete);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push(is_complete);
+    }
+
+    void GetResult(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::GetResult called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void LoadIdTokenCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IAsyncContextForLoginForOnlinePlay::LoadIdTokenCache called");
+        PopulateBaasStubSessionCache(system,user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
+    }
+
+    void GetNetworkServiceLicenseInfoForOnlinePlay(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC,
+                 "IAsyncContextForLoginForOnlinePlay::GetNetworkServiceLicenseInfoForOnlinePlay "
+                 "called");
+        IPC::ResponseBuilder rb{ctx, 5};
+        rb.Push(ResultSuccess);
+        rb.Push<u32>(NETWORK_SERVICE_LICENSE_KIND_BEDROCK);
+        rb.PushRaw<s64>(NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION);
+    }
+
+    KernelHelpers::ServiceContext service_context;
+    Kernel::KEvent* completion_event{};
+    bool is_complete{};
+    Common::UUID user_id;
+};
+
+// cmd 2 EnsureIdTokenCacheAsync returns IAsyncContext; cmd 170 returns
+// IAsyncContextForLoginForOnlinePlay (Switchbrew).
+void PushEnsureIdTokenCacheAsyncResponse(Core::System& system, HLERequestContext& ctx,
+                                         const Common::UUID& user_id) {
+    auto async = std::make_shared<EnsureTokenIdCacheAsyncInterface>(system, user_id);
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(ResultSuccess);
+    rb.PushIpcInterface(async);
+    async->SignalCompletion();
+}
+
+// Out-of-class definition — needs IAsyncContextForLoginForOnlinePlay to be fully defined first.
+void IManagerForSystemService::EnsureIdTokenCacheAsync(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "called");
+
+    PopulateBaasStubSessionCache(system,account_id);
+    EnsureDefaultAvatarExists(account_id);
+    PushEnsureIdTokenCacheAsyncResponse(system, ctx, account_id);
+}
+
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {
 public:
     explicit IManagerForApplication(Core::System& system_,
                                     const std::shared_ptr<ProfileManager>& profile_manager_)
-        : ServiceFramework{system_, "IManagerForApplication"},
-          ensure_token_id{std::make_shared<EnsureTokenIdCacheAsyncInterface>(system)},
-          profile_manager{profile_manager_} {
+        : ServiceFramework{system_, "IManagerForApplication"}, profile_manager{profile_manager_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IManagerForApplication::CheckAvailability, "CheckAvailability"},
@@ -738,9 +1459,16 @@ public:
             {4, &IManagerForApplication::LoadIdTokenCache, "LoadIdTokenCache"},
             {130, &IManagerForApplication::GetNintendoAccountUserResourceCacheForApplication, "GetNintendoAccountUserResourceCacheForApplication"},
             {136, &IManagerForApplication::GetNintendoAccountUserResourceCacheForApplication, "GetNintendoAccountUserResourceCache"}, // 19.0.0+
-            {150, nullptr, "CreateAuthorizationRequest"},
+            {140, &IManagerForApplication::GetNetworkServiceLicenseCache, "GetNetworkServiceLicenseCache"}, // 5.0.0+
+            {141, &IManagerForApplication::RefreshNetworkServiceLicenseCacheAsync,
+             "RefreshNetworkServiceLicenseCacheAsync"}, // 5.0.0+
+            {142, &IManagerForApplication::RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed,
+             "RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed"}, // 5.0.0+
+            {143, D<&IManagerForApplication::GetNetworkServiceLicenseCacheEx>, "GetNetworkServiceLicenseCacheEx"}, // 15.0.0+
+            {150, &IManagerForApplication::CreateAuthorizationRequest, "CreateAuthorizationRequest"},
             {160, &IManagerForApplication::StoreOpenContext, "StoreOpenContext"},
-            {170, nullptr, "LoadNetworkServiceLicenseKindAsync"},
+            {170, &IManagerForApplication::EnsureIdTokenCacheForOnlinePlayOrLicenseKindAsync,
+             "EnsureIdTokenCacheForOnlinePlayOrLicenseKindAsync"},
         };
         // clang-format on
 
@@ -749,9 +1477,10 @@ public:
 
 private:
     void CheckAvailability(HLERequestContext& ctx) {
-        LOG_DEBUG(Service_ACC, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        LOG_DEBUG(Service_ACC, "called");
+        IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
+        rb.Push<u8>(1);
     }
 
     void GetAccountId(HLERequestContext& ctx) {
@@ -759,46 +1488,59 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(ResultSuccess);
-        rb.PushRaw<u64>(profile_manager->GetLastOpenedUser().Hash());
+        rb.PushRaw<u64>(STUB_NETWORK_SERVICE_ACCOUNT_ID);
     }
 
     void EnsureIdTokenCacheAsync(HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_INFO(Service_ACC, "IManagerForApplication::EnsureIdTokenCacheAsync called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
-        rb.Push(ResultSuccess);
-        rb.PushIpcInterface(ensure_token_id);
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        if (!user_id.IsInvalid()) {
+            profile_manager->OpenUser(user_id);
+            profile_manager->StoreOpenedUsers();
+        }
+        PopulateBaasStubSessionCache(system,user_id);
+        EnsureDefaultAvatarExists(user_id);
+        PushEnsureIdTokenCacheAsyncResponse(system, ctx, user_id);
     }
 
     void LoadIdTokenCacheDeprecated(HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-
-        ensure_token_id->LoadIdTokenCache(ctx);
+        LOG_INFO(Service_ACC, "IManagerForApplication::LoadIdTokenCacheDeprecated called");
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
     }
 
     void LoadIdTokenCache(HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-
-        IPC::ResponseBuilder rb{ctx, 4};
-        rb.Push(ResultSuccess);
-        rb.Push(0); // token size
-        rb.Push(0); // unknown
+        LOG_INFO(Service_ACC, "IManagerForApplication::LoadIdTokenCache called");
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+        PushLoadIdTokenCacheResponse(ctx, user_id);
     }
 
     void GetNintendoAccountUserResourceCacheForApplication(HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_INFO(Service_ACC, "called");
 
-        std::vector<u8> nas_user_base_for_application(0x68);
-        ctx.WriteBuffer(nas_user_base_for_application, 0);
-
-        if (ctx.CanWriteBuffer(1)) {
-            std::vector<u8> unknown_out_buffer(ctx.GetWriteBufferSize(1));
-            ctx.WriteBuffer(unknown_out_buffer, 1);
-        }
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        const u64 nintendo_account_id = GetStubNintendoAccountId(user_id);
+        WriteNasUserResourceCacheBuffers(ctx, nintendo_account_id);
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(ResultSuccess);
-        rb.PushRaw<u64>(profile_manager->GetLastOpenedUser().Hash());
+        rb.PushRaw<u64>(nintendo_account_id);
+    }
+
+    void CreateAuthorizationRequest(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IManagerForApplication::CreateAuthorizationRequest called");
+
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system, user_id);
+
+        auto request = std::make_shared<IAuthorizationRequest>(system, user_id);
+
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.PushIpcInterface(request);
     }
 
     void StoreOpenContext(HLERequestContext& ctx) {
@@ -810,28 +1552,89 @@ private:
         rb.Push(ResultSuccess);
     }
 
-    std::shared_ptr<EnsureTokenIdCacheAsyncInterface> ensure_token_id{};
-    std::shared_ptr<ProfileManager> profile_manager;
-};
+    void GetNetworkServiceLicenseCache(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IManagerForApplication::GetNetworkServiceLicenseCache called");
+        WriteNetworkServiceLicenseCacheBuffer(ctx);
 
-// 6.0.0+
-class IAsyncNetworkServiceLicenseKindContext final
-    : public ServiceFramework<IAsyncNetworkServiceLicenseKindContext> {
-public:
-    explicit IAsyncNetworkServiceLicenseKindContext(Core::System& system_, Common::UUID)
-        : ServiceFramework{system_, "IAsyncNetworkServiceLicenseKindContext"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {0, nullptr, "GetSystemEvent"},
-            {1, nullptr, "Cancel"},
-            {2, nullptr, "HasDone"},
-            {3, nullptr, "GetResult"},
-            {4, nullptr, "GetNetworkServiceLicenseKind"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
     }
+
+    void RefreshNetworkServiceLicenseCacheAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IManagerForApplication::RefreshNetworkServiceLicenseCacheAsync called");
+
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+        PushCompletedIAsyncContextResponse(system, ctx);
+    }
+
+    void RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC,
+                 "IManagerForApplication::RefreshNetworkServiceLicenseCacheAsyncIfSecondsElapsed "
+                 "called");
+
+        IPC::RequestParser rp{ctx};
+        [[maybe_unused]] const auto seconds = rp.Pop<u32>();
+
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+
+        auto async = std::make_shared<CompletedIAsyncContextInterface>(system);
+
+        IPC::ResponseBuilder rb{ctx, 3, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.Push<u8>(1);
+        rb.PushIpcInterface(async);
+    }
+
+    Result GetNetworkServiceLicenseCacheEx(Out<u32> out_license, Out<s64> out_expiration) {
+        LOG_INFO(Service_ACC, "IManagerForApplication::GetNetworkServiceLicenseCacheEx called");
+
+        *out_license = NETWORK_SERVICE_LICENSE_KIND_BEDROCK;
+        *out_expiration = NETWORK_SERVICE_LICENSE_FAR_FUTURE_EXPIRATION;
+
+        R_SUCCEED();
+    }
+
+    void LoadNetworkServiceLicenseKindAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "LoadNetworkServiceLicenseKindAsync called");
+
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+
+        auto async = std::make_shared<IAsyncNetworkServiceLicenseKindContext>(system);
+
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.PushIpcInterface(async);
+        async->SignalCompletion();
+    }
+
+    void EnsureIdTokenCacheForOnlinePlayAsync(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "IManagerForApplication::EnsureIdTokenCacheForOnlinePlayAsync (cmd 170) called");
+
+        const auto user_id = profile_manager->GetLastOpenedUser();
+        PopulateBaasStubSessionCache(system,user_id);
+        EnsureDefaultAvatarExists(user_id);
+
+        auto async = std::make_shared<IAsyncContextForLoginForOnlinePlay>(system, user_id);
+
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(ResultSuccess);
+        rb.PushIpcInterface(async);
+        async->SignalCompletion();
+    }
+
+    void EnsureIdTokenCacheForOnlinePlayOrLicenseKindAsync(HLERequestContext& ctx) {
+        if (HLE::ApiVersion::HOS_VERSION_MAJOR >= 19) {
+            EnsureIdTokenCacheForOnlinePlayAsync(ctx);
+            return;
+        }
+
+        LoadNetworkServiceLicenseKindAsync(ctx);
+    }
+
+    std::shared_ptr<ProfileManager> profile_manager;
 };
 
 // 8.0.0+
@@ -1007,6 +1810,8 @@ Result Module::Interface::InitializeApplicationInfoBase() {
         return Account::ResultInvalidApplication;
     }
 
+    application_info.launch_property = launch_property;
+    application_info.application_type = ApplicationType::Digital;
     switch (launch_property.base_game_storage_id) {
     case FileSys::StorageId::GameCard:
         application_info.application_type = ApplicationType::GameCard;
@@ -1023,21 +1828,21 @@ Result Module::Interface::InitializeApplicationInfoBase() {
         return Account::ResultInvalidApplication;
     }
 
-    LOG_WARNING(Service_ACC, "ApplicationInfo init required");
-    // TODO(ogniK): Actual initialization here
+    LOG_INFO(Service_ACC, "ApplicationInfo initialized for title_id={:016X}",
+             application_info.launch_property.title_id);
 
     return ResultSuccess;
 }
 
 void Module::Interface::GetBaasAccountManagerForApplication(HLERequestContext& ctx) {
-    LOG_DEBUG(Service_ACC, "called");
+    LOG_INFO(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IManagerForApplication>(system, profile_manager);
 }
 
 void Module::Interface::AuthenticateApplicationAsync(HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    LOG_INFO(Service_ACC, "called");
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
@@ -1045,7 +1850,7 @@ void Module::Interface::AuthenticateApplicationAsync(HLERequestContext& ctx) {
 }
 
 void Module::Interface::CheckNetworkServiceAvailabilityAsync(HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    LOG_INFO(Service_ACC, "called");
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
@@ -1080,10 +1885,9 @@ void Module::Interface::IsUserAccountSwitchLocked(HLERequestContext& ctx) {
 }
 
 void Module::Interface::InitializeApplicationInfoV2(HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
-
+    LOG_INFO(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(ResultSuccess);
+    rb.Push(InitializeApplicationInfoBase());
 }
 
 void Module::Interface::BeginUserRegistration(HLERequestContext& ctx) {
@@ -1160,18 +1964,28 @@ void Module::Interface::ClearSaveDataThumbnail(HLERequestContext& ctx) {
 }
 
 void Module::Interface::CreateGuestLoginRequest(HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    LOG_INFO(Service_ACC, "CreateGuestLoginRequest called");
 
-    // Create a dummy UUID for the guest login request
-    const Common::UUID dummy_uuid{};
+    const auto user_id = profile_manager->GetLastOpenedUser();
+    if (!user_id.IsInvalid()) {
+        profile_manager->OpenUser(user_id);
+        profile_manager->StoreOpenedUsers();
+    }
+    PopulateBaasStubSessionCache(system,user_id);
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
-    rb.PushIpcInterface<IGuestLoginRequest>(system, dummy_uuid);
+    rb.PushIpcInterface<IGuestLoginRequest>(system, user_id, *profile_manager);
 }
 
 void Module::Interface::LoadOpenContext(HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    LOG_INFO(Service_ACC, "LoadOpenContext called");
+
+    for (const auto& uuid : profile_manager->GetStoredOpenedUsers()) {
+        if (!uuid.IsInvalid()) {
+            profile_manager->OpenUser(uuid);
+        }
+    }
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
@@ -1658,8 +2472,7 @@ void LoopProcess(Core::System& system) {
     auto profile_manager = std::make_shared<ProfileManager>();
     auto server_manager = std::make_unique<ServerManager>(system);
 
-    server_manager->RegisterNamedService("acc:aa",
-                                         std::make_shared<ACC_AA>(module, profile_manager, system));
+    server_manager->RegisterNamedService("acc:aa", std::make_shared<ACC_AA>(system));
     server_manager->RegisterNamedService("acc:e",
                                          std::make_shared<ACC_E>(module, profile_manager, system));
     server_manager->RegisterNamedService(

--- a/src/core/hle/service/acc/acc_aa.cpp
+++ b/src/core/hle/service/acc/acc_aa.cpp
@@ -3,17 +3,41 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/hle/service/acc/acc_aa.h"
+#include "core/hle/service/acc/async_context.h"
+#include "core/hle/service/ipc_helpers.h"
+#include "common/logging.h"
+#include <cstring>
 
 namespace Service::Account {
 
-ACC_AA::ACC_AA(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> profile_manager_,
-               Core::System& system_)
-    : Interface(std::move(module_), std::move(profile_manager_), system_, "acc:aa") {
+namespace {
+
+class CompletedBaasCacheAsync final : public IAsyncContext {
+public:
+    explicit CompletedBaasCacheAsync(Core::System& system_) : IAsyncContext{system_} {
+        MarkComplete();
+    }
+
+protected:
+    bool IsComplete() const override {
+        return true;
+    }
+
+    void Cancel() override {}
+
+    Result GetResult() const override {
+        return ResultSuccess;
+    }
+};
+
+} // Anonymous namespace
+
+ACC_AA::ACC_AA(Core::System& system_) : ServiceFramework{system_, "acc:aa"} {
     // clang-format off
     static const FunctionInfo functions[] = {
-        {0, nullptr, "EnsureCacheAsync"},
-        {1, nullptr, "LoadCache"},
-        {2, nullptr, "GetDeviceAccountId"},
+        {0, &ACC_AA::EnsureCacheAsync, "EnsureCacheAsync"},
+        {1, &ACC_AA::LoadCache, "LoadCache"},
+        {2, &ACC_AA::GetDeviceAccountId, "GetDeviceAccountId"},
         {50, nullptr, "RegisterNotificationTokenAsync"},   // 1.0.0 - 6.2.0
         {51, nullptr, "UnregisterNotificationTokenAsync"}, // 1.0.0 - 6.2.0
     };
@@ -22,5 +46,43 @@ ACC_AA::ACC_AA(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> 
 }
 
 ACC_AA::~ACC_AA() = default;
+
+void ACC_AA::EnsureCacheAsync(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "acc:aa EnsureCacheAsync called");
+
+    auto async = std::make_shared<CompletedBaasCacheAsync>(system);
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(ResultSuccess);
+    rb.PushIpcInterface(async);
+}
+
+void ACC_AA::LoadCache(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "acc:aa LoadCache called");
+
+    // Baas device-account cache: network service account id + linked/registered flags.
+    std::vector<u8> cache(0x40, 0);
+    const u64 network_service_account_id = 0x000000000000CAFEULL;
+    std::memcpy(cache.data(), &network_service_account_id, sizeof(network_service_account_id));
+    cache[0x08] = 1;
+    cache[0x09] = 1;
+    const u32 license_kind = 2;
+    std::memcpy(cache.data() + 0x0C, &license_kind, sizeof(license_kind));
+
+    if (ctx.CanWriteBuffer(0)) {
+        ctx.WriteBuffer(cache, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ResultSuccess);
+}
+
+void ACC_AA::GetDeviceAccountId(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "acc:aa GetDeviceAccountId called");
+
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(ResultSuccess);
+    rb.PushRaw<u64>(0x0123456789ABCDEFULL);
+}
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_aa.h
+++ b/src/core/hle/service/acc/acc_aa.h
@@ -1,17 +1,26 @@
 // SPDX-FileCopyrightText: Copyright 2018 yuzu Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
-#include "core/hle/service/acc/acc.h"
+#include "core/hle/service/service.h"
+
+namespace Core {
+class System;
+}
 
 namespace Service::Account {
 
-class ACC_AA final : public Module::Interface {
+class ACC_AA final : public ServiceFramework<ACC_AA> {
 public:
-    explicit ACC_AA(std::shared_ptr<Module> module_,
-                    std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_);
+    explicit ACC_AA(Core::System& system_);
     ~ACC_AA() override;
+
+private:
+    void EnsureCacheAsync(HLERequestContext& ctx);
+    void LoadCache(HLERequestContext& ctx);
+    void GetDeviceAccountId(HLERequestContext& ctx);
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/async_context.cpp
+++ b/src/core/hle/service/acc/async_context.cpp
@@ -33,7 +33,11 @@ IAsyncContext::~IAsyncContext() {
 }
 
 void IAsyncContext::GetSystemEvent(HLERequestContext& ctx) {
-    LOG_DEBUG(Service_ACC, "called");
+    LOG_INFO(Service_ACC, "called, complete={}", IsComplete());
+
+    if (IsComplete()) {
+        completion_event->Signal();
+    }
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(ResultSuccess);
@@ -51,9 +55,8 @@ void IAsyncContext::Cancel(HLERequestContext& ctx) {
 }
 
 void IAsyncContext::HasDone(HLERequestContext& ctx) {
-    LOG_DEBUG(Service_ACC, "called");
-
     is_complete.store(IsComplete());
+    LOG_INFO(Service_ACC, "called, done={}", is_complete.load());
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
@@ -61,10 +64,15 @@ void IAsyncContext::HasDone(HLERequestContext& ctx) {
 }
 
 void IAsyncContext::GetResult(HLERequestContext& ctx) {
-    LOG_DEBUG(Service_ACC, "called");
+    const Result result = GetResult();
+    LOG_INFO(Service_ACC, "called, result=0x{:08X}", result.raw);
 
-    IPC::ResponseBuilder rb{ctx, 3};
-    rb.Push(GetResult());
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void IAsyncContext::SignalCompletion() {
+    MarkComplete();
 }
 
 void IAsyncContext::MarkComplete() {

--- a/src/core/hle/service/acc/async_context.h
+++ b/src/core/hle/service/acc/async_context.h
@@ -23,6 +23,8 @@ public:
     void HasDone(HLERequestContext& ctx);
     void GetResult(HLERequestContext& ctx);
 
+    void SignalCompletion();
+
 protected:
     virtual bool IsComplete() const = 0;
     virtual void Cancel() = 0;

--- a/src/core/hle/service/acc/dauth_0.cpp
+++ b/src/core/hle/service/acc/dauth_0.cpp
@@ -1,17 +1,163 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "common/fs/file.h"
+#include "common/fs/path_util.h"
+#include "common/logging.h"
+#include "core/core.h"
 #include "core/hle/service/acc/dauth_0.h"
+#include "core/hle/service/ipc_helpers.h"
+#include "core/hle/service/kernel_helpers.h"
+
+// [UNITY-FIX] undef Win32 macros shadowing ServiceContext methods.
+#undef CreateEvent
+#undef CreateMutex
+#undef CreateSemaphore
 
 namespace Service::Account {
+
+namespace {
+
+constexpr std::string_view STUB_APPLICATION_AUTH_TOKEN{
+    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0."
+    "eyJzdWIiOiIwMTAwZDcxMDA0Njk0MDAwIiwiYXVkIjoiYWF1dGgiLCJleHAiOjIwMDAwMDAwMDAsImlhdCI6"
+    "MTcwMDAwMDAwMH0."
+    ""};
+
+std::filesystem::path GetDauthApplicationAuthCachePath(u64 title_id) {
+    return Common::FS::GetCitronPath(Common::FS::CitronPath::NANDDir) /
+           fmt::format("system/save/8000000000000010/su/dauth/application/{:016X}.dat", title_id);
+}
+
+bool WriteBinaryFile(const std::filesystem::path& path, std::span<const u8> data) {
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+        LOG_WARNING(Service_ACC, "dauth: failed to create directory {}: {}",
+                    path.parent_path().string(), ec.message());
+        return false;
+    }
+
+    Common::FS::IOFile file(path, Common::FS::FileAccessMode::Write, Common::FS::FileType::BinaryFile);
+    if (!file.IsOpen()) {
+        LOG_WARNING(Service_ACC, "dauth: failed to open {}", path.string());
+        return false;
+    }
+
+    if (file.Write(data) != data.size()) {
+        LOG_WARNING(Service_ACC, "dauth: failed to write {}", path.string());
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<u8> ReadApplicationAuthTokenFromDisk(u64 title_id) {
+    const auto path = GetDauthApplicationAuthCachePath(title_id);
+    Common::FS::IOFile file(path, Common::FS::FileAccessMode::Read, Common::FS::FileType::BinaryFile);
+    if (!file.IsOpen()) {
+        return std::vector<u8>(STUB_APPLICATION_AUTH_TOKEN.begin(), STUB_APPLICATION_AUTH_TOKEN.end());
+    }
+
+    std::vector<u8> data(static_cast<std::size_t>(file.GetSize()));
+    if (file.Read(data) != data.size() || data.empty()) {
+        return std::vector<u8>(STUB_APPLICATION_AUTH_TOKEN.begin(), STUB_APPLICATION_AUTH_TOKEN.end());
+    }
+
+    return data;
+}
+
+class DauthAsyncResult final : public ServiceFramework<DauthAsyncResult> {
+public:
+    explicit DauthAsyncResult(Core::System& system_)
+        : ServiceFramework{system_, "IAsyncResult"},
+          service_context{system_, "Dauth:IAsyncResult"} {
+        static const FunctionInfo functions[] = {
+            {0, &DauthAsyncResult::GetResult, "GetResult"},
+            {1, &DauthAsyncResult::Cancel, "Cancel"},
+            {2, &DauthAsyncResult::IsAvailable, "IsAvailable"},
+            {3, &DauthAsyncResult::GetSystemEvent, "GetSystemEvent"},
+        };
+        RegisterHandlers(functions);
+
+        completion_event = service_context.CreateEvent("Dauth:IAsyncResult:CompletionEvent");
+        completion_event->Signal();
+    }
+
+    ~DauthAsyncResult() override {
+        service_context.CloseEvent(completion_event);
+    }
+
+private:
+    void GetResult(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "dauth: IAsyncResult::GetResult called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void Cancel(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "dauth: IAsyncResult::Cancel called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void IsAvailable(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "dauth: IAsyncResult::IsAvailable called, available=true");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<u8>(1);
+    }
+
+    void GetSystemEvent(HLERequestContext& ctx) {
+        LOG_INFO(Service_ACC, "dauth: IAsyncResult::GetSystemEvent called");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(ResultSuccess);
+        rb.PushCopyObjects(completion_event->GetReadableEvent());
+    }
+
+    KernelHelpers::ServiceContext service_context;
+    Kernel::KEvent* completion_event{};
+};
+
+void PushDauthAsyncResult(Core::System& system, HLERequestContext& ctx) {
+    auto async = std::make_shared<DauthAsyncResult>(system);
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(ResultSuccess);
+    rb.PushIpcInterface(async);
+}
+
+} // Anonymous namespace
+
+void WriteDauthApplicationAuthCacheOnDisk(u64 title_id) {
+    const std::vector<u8> token(STUB_APPLICATION_AUTH_TOKEN.begin(), STUB_APPLICATION_AUTH_TOKEN.end());
+    const auto path = GetDauthApplicationAuthCachePath(title_id);
+    if (WriteBinaryFile(path, token)) {
+        LOG_INFO(Service_ACC, "dauth: wrote application auth cache to {}", path.string());
+    }
+}
 
 DAUTH_0::DAUTH_0(Core::System& system_) : ServiceFramework{system_, "dauth:0"} {
     // clang-format off
     static const FunctionInfo functions[] = {
-        {0, nullptr, "GetSystemEvent"}, // IAsyncResult interface
-        {1, nullptr, "Cancel"},         // IAsyncResult interface
-        {2, nullptr, "IsAvailable"},    // IAsyncResult interface
-        {3, nullptr, "GetResult"},      // IAsyncResult interface
+        {0, &DAUTH_0::EnsureAuthenticationTokenCacheAsync, "EnsureAuthenticationTokenCacheAsync"},
+        {1, &DAUTH_0::LoadAuthenticationTokenCache, "LoadAuthenticationTokenCache"},
+        {2, nullptr, "InvalidateAuthenticationTokenCache"},
+        {3, &DAUTH_0::IsDeviceAuthenticationTokenCacheAvailable, "IsDeviceAuthenticationTokenCacheAvailable"},
+        {10, nullptr, "EnsureEdgeTokenCacheAsync"},
+        {11, nullptr, "LoadEdgeTokenCache"},
+        {12, nullptr, "InvalidateEdgeTokenCache"},
+        {13, nullptr, "IsEdgeTokenCacheAvailable"},
+        {20, &DAUTH_0::EnsureApplicationAuthenticationCacheAsync, "EnsureApplicationAuthenticationCacheAsync"},
+        {21, &DAUTH_0::LoadApplicationAuthenticationTokenCache, "LoadApplicationAuthenticationTokenCache"},
+        {22, nullptr, "LoadApplicationNetworkServiceClientConfigCache"},
+        {23, &DAUTH_0::IsApplicationAuthenticationCacheAvailable, "IsApplicationAuthenticationCacheAvailable"},
+        {24, nullptr, "InvalidateApplicationAuthenticationCache"},
     };
     // clang-format on
 
@@ -19,5 +165,66 @@ DAUTH_0::DAUTH_0(Core::System& system_) : ServiceFramework{system_, "dauth:0"} {
 }
 
 DAUTH_0::~DAUTH_0() = default;
+
+void DAUTH_0::EnsureAuthenticationTokenCacheAsync(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "dauth:0 EnsureAuthenticationTokenCacheAsync called");
+    PushDauthAsyncResult(system, ctx);
+}
+
+void DAUTH_0::LoadAuthenticationTokenCache(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "dauth:0 LoadAuthenticationTokenCache called");
+
+    constexpr std::string_view stub_device_token{"stub-device-auth-token"};
+    const std::vector<u8> token(stub_device_token.begin(), stub_device_token.end());
+    if (ctx.CanWriteBuffer(0)) {
+        ctx.WriteBuffer(token, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(static_cast<u32>(token.size()));
+}
+
+void DAUTH_0::IsDeviceAuthenticationTokenCacheAvailable(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "dauth:0 IsDeviceAuthenticationTokenCacheAvailable called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push<u8>(1);
+}
+
+void DAUTH_0::EnsureApplicationAuthenticationCacheAsync(HLERequestContext& ctx) {
+    LOG_INFO(Service_ACC, "dauth:0 EnsureApplicationAuthenticationCacheAsync called");
+    WriteDauthApplicationAuthCacheOnDisk(system.GetApplicationProcessProgramID());
+    PushDauthAsyncResult(system, ctx);
+}
+
+void DAUTH_0::LoadApplicationAuthenticationTokenCache(HLERequestContext& ctx) {
+    const u64 title_id = system.GetApplicationProcessProgramID();
+    LOG_INFO(Service_ACC, "dauth:0 LoadApplicationAuthenticationTokenCache called, title_id={:016X}",
+             title_id);
+
+    auto token = ReadApplicationAuthTokenFromDisk(title_id);
+    if (ctx.CanWriteBuffer(0)) {
+        ctx.WriteBuffer(token, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(static_cast<u32>(token.size()));
+}
+
+void DAUTH_0::IsApplicationAuthenticationCacheAvailable(HLERequestContext& ctx) {
+    const u64 title_id = system.GetApplicationProcessProgramID();
+    const auto path = GetDauthApplicationAuthCachePath(title_id);
+    const bool available = std::filesystem::exists(path);
+
+    LOG_INFO(Service_ACC,
+             "dauth:0 IsApplicationAuthenticationCacheAvailable called, available={}",
+             available);
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push<u8>(available ? 1 : 0);
+}
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/dauth_0.h
+++ b/src/core/hle/service/acc/dauth_0.h
@@ -7,10 +7,20 @@
 
 namespace Service::Account {
 
+void WriteDauthApplicationAuthCacheOnDisk(u64 title_id);
+
 class DAUTH_0 final : public ServiceFramework<DAUTH_0> {
 public:
     explicit DAUTH_0(Core::System& system_);
     ~DAUTH_0() override;
+
+private:
+    void EnsureAuthenticationTokenCacheAsync(HLERequestContext& ctx);
+    void LoadAuthenticationTokenCache(HLERequestContext& ctx);
+    void IsDeviceAuthenticationTokenCacheAvailable(HLERequestContext& ctx);
+    void EnsureApplicationAuthenticationCacheAsync(HLERequestContext& ctx);
+    void LoadApplicationAuthenticationTokenCache(HLERequestContext& ctx);
+    void IsApplicationAuthenticationCacheAvailable(HLERequestContext& ctx);
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/am/frontend/applet_web_browser.cpp
+++ b/src/core/hle/service/am/frontend/applet_web_browser.cpp
@@ -3,6 +3,7 @@
 
 #include "common/assert.h"
 #include "common/fs/file.h"
+#include <algorithm>
 #include "common/fs/fs.h"
 #include "common/fs/path_util.h"
 #include "common/logging.h"
@@ -362,8 +363,10 @@ void WebBrowser::WebBrowserExit(WebExitReason exit_reason, std::string last_url)
     WebCommonReturnValue web_common_return_value;
 
     web_common_return_value.exit_reason = exit_reason;
-    std::memcpy(&web_common_return_value.last_url, last_url.data(), last_url.size());
-    web_common_return_value.last_url_size = last_url.size();
+    const auto copy_size =
+        std::min(last_url.size(), sizeof(web_common_return_value.last_url));
+    std::memcpy(&web_common_return_value.last_url, last_url.data(), copy_size);
+    web_common_return_value.last_url_size = copy_size;
 
     LOG_DEBUG(Service_AM, "WebCommonReturnValue: exit_reason={}, last_url={}, last_url_size={}",
               exit_reason, last_url, last_url.size());

--- a/src/core/hle/service/am/frontend/applet_web_browser.cpp
+++ b/src/core/hle/service/am/frontend/applet_web_browser.cpp
@@ -457,8 +457,17 @@ void WebBrowser::ExecuteShop() {
 }
 
 void WebBrowser::ExecuteLogin() {
-    LOG_WARNING(Service_AM, "(STUBBED) called, Login Applet is not implemented");
-    WebBrowserExit(WebExitReason::EndButtonPressed);
+    LOG_INFO(Service_AM, "called (HLE auto-success for offline/guest login)");
+
+    std::string callback_url;
+    if (const auto data = GetInputTLVData(WebArgInputTLVType::CallbackURL)) {
+        callback_url = ParseStringValue(*data);
+    }
+    if (callback_url.empty()) {
+        callback_url = "https://localhost/auth/callback?success=1";
+    }
+
+    WebBrowserExit(WebExitReason::CallbackURL, callback_url);
 }
 
 void WebBrowser::ExecuteOffline() {

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -23,6 +23,18 @@ namespace {
 
 #include "core/internal_network/network.h"
 #include "core/internal_network/network_interface.h"
+#include "common/settings.h"
+
+namespace {
+
+constexpr u64 Lego2KDriveProgramId = 0x0100739018020000ULL;
+
+bool IsLego2KDriveOfflineLocalMode(const Core::System& system_) {
+    return Settings::values.airplane_mode.GetValue() &&
+           system_.GetApplicationProcessProgramID() == Lego2KDriveProgramId;
+}
+
+} // Anonymous namespace
 
 // [UNITY-FIX] undef Win32 macros shadowing ServiceContext methods.
 #undef CreateEvent
@@ -318,6 +330,13 @@ private:
         LOG_DEBUG(Service_NIFM, "(STUBBED) called");
 
         const auto result = [this] {
+            if (IsLego2KDriveOfflineLocalMode(system)) {
+                if (state == RequestState::OnHold) {
+                    UpdateState(RequestState::Accepted);
+                }
+                return ResultSuccess;
+            }
+
             const auto has_connection = Network::GetHostIPv4Address().has_value();
             switch (state) {
             case RequestState::Free:
@@ -525,12 +544,34 @@ public:
 };
 
 void IGeneralService::GetClientId(HLERequestContext& ctx) {
-    static constexpr u32 client_id = 1;
-    LOG_WARNING(Service_NIFM, "(STUBBED) called");
+    static u32 next_client_id = 1;
+    const u32 client_id = next_client_id++;
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    LOG_INFO(Service_NIFM, "called, client_id={}", client_id);
+
+    if (ctx.CanWriteBuffer(0)) {
+        ctx.WriteBuffer(std::span{reinterpret_cast<const u8*>(&client_id), sizeof(client_id)}, 0);
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
-    rb.Push<u64>(client_id); // Client ID needs to be non zero otherwise it's considered invalid
+}
+
+void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
+    u32 client_id{};
+    if (ctx.CanReadBuffer(0)) {
+        const auto buffer = ctx.ReadBuffer(0);
+        if (buffer.size() >= sizeof(client_id)) {
+            std::memcpy(&client_id, buffer.data(), sizeof(client_id));
+        }
+    }
+
+    const bool accepted = client_id != 0 && Network::GetHostIPv4Address().has_value();
+    LOG_INFO(Service_NIFM, "called, client_id={}, accepted={}", client_id, accepted);
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push<u8>(accepted ? 1 : 0);
 }
 
 void IGeneralService::CreateScanRequest(HLERequestContext& ctx) {
@@ -653,8 +694,6 @@ void IGeneralService::RemoveNetworkProfile(HLERequestContext& ctx) {
 }
 
 void IGeneralService::GetCurrentIpAddress(HLERequestContext& ctx) {
-    LOG_WARNING(Service_NIFM, "(STUBBED) called");
-
     auto ipv4 = Network::GetHostIPv4Address();
     if (!ipv4) {
         LOG_ERROR(Service_NIFM, "Couldn't get host IPv4 address, defaulting to 0.0.0.0");
@@ -667,6 +706,9 @@ void IGeneralService::GetCurrentIpAddress(HLERequestContext& ctx) {
             ipv4 = room_member->GetFakeIpAddress();
         }
     }
+
+    LOG_INFO(Service_NIFM, "GetCurrentIpAddress returning {}",
+             Network::IPv4AddressToString(*ipv4));
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
@@ -758,15 +800,30 @@ void IGeneralService::SetBackgroundRequestEnabled(HLERequestContext& ctx) {
 }
 
 void IGeneralService::IsWirelessCommunicationEnabled(HLERequestContext& ctx) {
-    LOG_WARNING(Service_NIFM, "(STUBBED) called");
+    const bool enabled = !Settings::values.airplane_mode.GetValue() &&
+                         Network::GetHostIPv4Address().has_value();
+
+    LOG_DEBUG(Service_NIFM, "called, enabled={}", enabled);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
-    rb.Push<u8>(1);
+    rb.Push<u8>(enabled ? 1 : 0);
 }
 
 void IGeneralService::GetInternetConnectionStatus(HLERequestContext& ctx) {
-    LOG_WARNING(Service_NIFM, "(STUBBED) called");
+    const bool lego2k_offline_local = IsLego2KDriveOfflineLocalMode(system);
+    const bool has_internet = lego2k_offline_local ||
+                              (!Settings::values.airplane_mode.GetValue() &&
+                               Network::GetHostIPv4Address().has_value());
+
+    if (!has_internet) {
+        LOG_INFO(Service_NIFM, "called, internet unavailable (airplane_mode={}, has_ip={})",
+                 Settings::values.airplane_mode.GetValue(),
+                 Network::GetHostIPv4Address().has_value());
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultNetworkCommunicationDisabled);
+        return;
+    }
 
     struct Output {
         u8 type{static_cast<u8>(NetworkInterfaceType::WiFi_Ieee80211)};
@@ -777,6 +834,8 @@ void IGeneralService::GetInternetConnectionStatus(HLERequestContext& ctx) {
 
     constexpr Output out{};
 
+    LOG_DEBUG(Service_NIFM, "called, internet connected");
+
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
     rb.PushRaw(out);
@@ -784,18 +843,6 @@ void IGeneralService::GetInternetConnectionStatus(HLERequestContext& ctx) {
 
 void IGeneralService::IsEthernetCommunicationEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_NIFM, "(STUBBED) called");
-
-    IPC::ResponseBuilder rb{ctx, 3};
-    rb.Push(ResultSuccess);
-    if (Network::GetHostIPv4Address().has_value()) {
-        rb.Push<u8>(1);
-    } else {
-        rb.Push<u8>(0);
-    }
-}
-
-void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
-    LOG_ERROR(Service_NIFM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cstring>
+#include <mutex>
+#include <unordered_set>
 #include "core/core.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/service/ipc_helpers.h"
@@ -18,6 +20,9 @@ namespace {
                                            std::string&& name) {
     return service_context.CreateEvent(std::move(name));
 }
+
+std::mutex g_nifm_client_id_mutex;
+std::unordered_set<u32> g_nifm_issued_client_ids;
 
 } // Anonymous namespace
 
@@ -547,6 +552,11 @@ void IGeneralService::GetClientId(HLERequestContext& ctx) {
     static u32 next_client_id = 1;
     const u32 client_id = next_client_id++;
 
+    {
+        std::scoped_lock lock{g_nifm_client_id_mutex};
+        g_nifm_issued_client_ids.insert(client_id);
+    }
+
     LOG_INFO(Service_NIFM, "called, client_id={}", client_id);
 
     if (ctx.CanWriteBuffer(0)) {
@@ -566,7 +576,12 @@ void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
         }
     }
 
-    const bool accepted = client_id != 0 && Network::GetHostIPv4Address().has_value();
+    bool accepted = false;
+    if (client_id != 0) {
+        std::scoped_lock lock{g_nifm_client_id_mutex};
+        accepted = g_nifm_issued_client_ids.contains(client_id);
+    }
+    accepted = accepted && Network::GetHostIPv4Address().has_value();
     LOG_INFO(Service_NIFM, "called, client_id={}, accepted={}", client_id, accepted);
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -800,8 +815,7 @@ void IGeneralService::SetBackgroundRequestEnabled(HLERequestContext& ctx) {
 }
 
 void IGeneralService::IsWirelessCommunicationEnabled(HLERequestContext& ctx) {
-    const bool enabled = !Settings::values.airplane_mode.GetValue() &&
-                         Network::GetHostIPv4Address().has_value();
+    const bool enabled = !Settings::values.airplane_mode.GetValue();
 
     LOG_DEBUG(Service_NIFM, "called, enabled={}", enabled);
 

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -23,6 +23,8 @@ namespace {
 
 std::mutex g_nifm_client_id_mutex;
 std::unordered_set<u32> g_nifm_issued_client_ids;
+std::unordered_set<u32> g_nifm_accepted_client_ids;
+u32 g_nifm_current_client_id = 0;
 
 } // Anonymous namespace
 
@@ -260,8 +262,9 @@ private:
 
 class IRequest final : public ServiceFramework<IRequest> {
 public:
-    explicit IRequest(Core::System& system_)
-        : ServiceFramework{system_, "IRequest"}, service_context{system_, "IRequest"} {
+    explicit IRequest(Core::System& system_, u32 client_id_)
+        : ServiceFramework{system_, "IRequest"}, service_context{system_, "IRequest"},
+          client_id{client_id_} {
         static const FunctionInfo functions[] = {
             {0, &IRequest::GetRequestState, "GetRequestState"},
             {1, &IRequest::GetResult, "GetResult"},
@@ -404,6 +407,10 @@ private:
 
     void UpdateState(RequestState new_state) {
         state = new_state;
+        if (new_state == RequestState::Accepted && client_id != 0) {
+            std::scoped_lock lock{g_nifm_client_id_mutex};
+            g_nifm_accepted_client_ids.insert(client_id);
+        }
         event1->Signal();
     }
 
@@ -531,6 +538,7 @@ private:
     KernelHelpers::ServiceContext service_context;
 
     RequestState state;
+    u32 client_id = 0;
 
     Kernel::KEvent* event1;
     Kernel::KEvent* event2;
@@ -555,6 +563,7 @@ void IGeneralService::GetClientId(HLERequestContext& ctx) {
     {
         std::scoped_lock lock{g_nifm_client_id_mutex};
         g_nifm_issued_client_ids.insert(client_id);
+        g_nifm_current_client_id = client_id;
     }
 
     LOG_INFO(Service_NIFM, "called, client_id={}", client_id);
@@ -579,9 +588,12 @@ void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
     bool accepted = false;
     if (client_id != 0) {
         std::scoped_lock lock{g_nifm_client_id_mutex};
-        accepted = g_nifm_issued_client_ids.contains(client_id);
+        accepted = g_nifm_issued_client_ids.contains(client_id) &&
+                   g_nifm_accepted_client_ids.contains(client_id);
     }
-    accepted = accepted && Network::GetHostIPv4Address().has_value();
+    const bool connectivity_ok = IsLego2KDriveOfflineLocalMode(system) ||
+                                 Network::GetHostIPv4Address().has_value();
+    accepted = accepted && connectivity_ok;
     LOG_INFO(Service_NIFM, "called, client_id={}, accepted={}", client_id, accepted);
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -601,10 +613,16 @@ void IGeneralService::CreateScanRequest(HLERequestContext& ctx) {
 void IGeneralService::CreateRequest(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NIFM, "called");
 
+    u32 client_id = 0;
+    {
+        std::scoped_lock lock{g_nifm_client_id_mutex};
+        client_id = g_nifm_current_client_id;
+    }
+
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 
     rb.Push(ResultSuccess);
-    rb.PushIpcInterface<IRequest>(system);
+    rb.PushIpcInterface<IRequest>(system, client_id);
 }
 
 void IGeneralService::GetCurrentNetworkProfile(HLERequestContext& ctx) {
@@ -1132,7 +1150,12 @@ IGeneralService::IGeneralService(Core::System& system_)
     RegisterHandlers(functions);
 }
 
-IGeneralService::~IGeneralService() = default;
+IGeneralService::~IGeneralService() {
+    std::scoped_lock lock{g_nifm_client_id_mutex};
+    g_nifm_issued_client_ids.clear();
+    g_nifm_accepted_client_ids.clear();
+    g_nifm_current_client_id = 0;
+}
 
 class NetworkInterface final : public ServiceFramework<NetworkInterface> {
 public:

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cstring>
-#include <mutex>
 #include <unordered_set>
 #include "core/core.h"
 #include "core/hle/kernel/k_event.h"
@@ -20,11 +19,6 @@ namespace {
                                            std::string&& name) {
     return service_context.CreateEvent(std::move(name));
 }
-
-std::mutex g_nifm_client_id_mutex;
-std::unordered_set<u32> g_nifm_issued_client_ids;
-std::unordered_set<u32> g_nifm_accepted_client_ids;
-u32 g_nifm_current_client_id = 0;
 
 } // Anonymous namespace
 
@@ -262,9 +256,10 @@ private:
 
 class IRequest final : public ServiceFramework<IRequest> {
 public:
-    explicit IRequest(Core::System& system_, u32 client_id_)
+    explicit IRequest(Core::System& system_, std::shared_ptr<ClientIdState> client_id_state_,
+                      u32 client_id_)
         : ServiceFramework{system_, "IRequest"}, service_context{system_, "IRequest"},
-          client_id{client_id_} {
+          client_id_state{std::move(client_id_state_)}, client_id{client_id_} {
         static const FunctionInfo functions[] = {
             {0, &IRequest::GetRequestState, "GetRequestState"},
             {1, &IRequest::GetResult, "GetResult"},
@@ -407,9 +402,9 @@ private:
 
     void UpdateState(RequestState new_state) {
         state = new_state;
-        if (new_state == RequestState::Accepted && client_id != 0) {
-            std::scoped_lock lock{g_nifm_client_id_mutex};
-            g_nifm_accepted_client_ids.insert(client_id);
+        if (new_state == RequestState::Accepted && client_id != 0 && client_id_state != nullptr &&
+            client_id_state->issued_client_ids.contains(client_id)) {
+            client_id_state->accepted_client_ids.insert(client_id);
         }
         event1->Signal();
     }
@@ -538,6 +533,7 @@ private:
     KernelHelpers::ServiceContext service_context;
 
     RequestState state;
+    std::shared_ptr<ClientIdState> client_id_state;
     u32 client_id = 0;
 
     Kernel::KEvent* event1;
@@ -557,14 +553,9 @@ public:
 };
 
 void IGeneralService::GetClientId(HLERequestContext& ctx) {
-    static u32 next_client_id = 1;
-    const u32 client_id = next_client_id++;
-
-    {
-        std::scoped_lock lock{g_nifm_client_id_mutex};
-        g_nifm_issued_client_ids.insert(client_id);
-        g_nifm_current_client_id = client_id;
-    }
+    const u32 client_id = client_id_state->next_client_id++;
+    client_id_state->issued_client_ids.insert(client_id);
+    client_id_state->current_client_id = client_id;
 
     LOG_INFO(Service_NIFM, "called, client_id={}", client_id);
 
@@ -587,9 +578,8 @@ void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
 
     bool accepted = false;
     if (client_id != 0) {
-        std::scoped_lock lock{g_nifm_client_id_mutex};
-        accepted = g_nifm_issued_client_ids.contains(client_id) &&
-                   g_nifm_accepted_client_ids.contains(client_id);
+        accepted = client_id_state->issued_client_ids.contains(client_id) &&
+                   client_id_state->accepted_client_ids.contains(client_id);
     }
     const bool connectivity_ok = IsLego2KDriveOfflineLocalMode(system) ||
                                  Network::GetHostIPv4Address().has_value();
@@ -613,16 +603,10 @@ void IGeneralService::CreateScanRequest(HLERequestContext& ctx) {
 void IGeneralService::CreateRequest(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NIFM, "called");
 
-    u32 client_id = 0;
-    {
-        std::scoped_lock lock{g_nifm_client_id_mutex};
-        client_id = g_nifm_current_client_id;
-    }
-
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 
     rb.Push(ResultSuccess);
-    rb.PushIpcInterface<IRequest>(system, client_id);
+    rb.PushIpcInterface<IRequest>(system, client_id_state, client_id_state->current_client_id);
 }
 
 void IGeneralService::GetCurrentNetworkProfile(HLERequestContext& ctx) {
@@ -1085,7 +1069,8 @@ void IGeneralService::GetNetworkEmulationProfile(HLERequestContext& ctx) {
 }
 
 IGeneralService::IGeneralService(Core::System& system_)
-    : ServiceFramework{system_, "IGeneralService"}, network{system_.GetRoomNetwork()} {
+    : ServiceFramework{system_, "IGeneralService"}, network{system_.GetRoomNetwork()},
+      client_id_state{std::make_shared<ClientIdState>()} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, &IGeneralService::GetClientId, "GetClientId"},
@@ -1150,12 +1135,7 @@ IGeneralService::IGeneralService(Core::System& system_)
     RegisterHandlers(functions);
 }
 
-IGeneralService::~IGeneralService() {
-    std::scoped_lock lock{g_nifm_client_id_mutex};
-    g_nifm_issued_client_ids.clear();
-    g_nifm_accepted_client_ids.clear();
-    g_nifm_current_client_id = 0;
-}
+IGeneralService::~IGeneralService() = default;
 
 class NetworkInterface final : public ServiceFramework<NetworkInterface> {
 public:

--- a/src/core/hle/service/nifm/nifm.h
+++ b/src/core/hle/service/nifm/nifm.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <memory>
+#include <unordered_set>
+
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -17,6 +20,13 @@ class RoomNetwork;
 namespace Service::NIFM {
 
 void LoopProcess(Core::System& system);
+
+struct ClientIdState {
+    std::unordered_set<u32> issued_client_ids;
+    std::unordered_set<u32> accepted_client_ids;
+    u32 current_client_id = 0;
+    u32 next_client_id = 1;
+};
 
 class IGeneralService final : public ServiceFramework<IGeneralService> {
 public:
@@ -68,6 +78,7 @@ private:
     void GetNetworkEmulationProfile(HLERequestContext& ctx);
 
     Network::RoomNetwork& network;
+    std::shared_ptr<ClientIdState> client_id_state;
 };
 
 } // namespace Service::NIFM

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -90,16 +90,52 @@ public:
         : ServiceFramework{system_, "IShopServiceAsync"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "Cancel"},
-            {1, nullptr, "GetSize"},
-            {2, nullptr, "Read"},
-            {3, nullptr, "GetErrorCode"},
-            {4, nullptr, "Request"},
-            {5, nullptr, "Prepare"},
+            {0, &IShopServiceAsync::Cancel, "Cancel"},
+            {1, &IShopServiceAsync::GetSize, "GetSize"},
+            {2, &IShopServiceAsync::Read, "Read"},
+            {3, &IShopServiceAsync::GetErrorCode, "GetErrorCode"},
+            {4, &IShopServiceAsync::Request, "Request"},
+            {5, &IShopServiceAsync::Prepare, "Prepare"},
         };
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+private:
+    void Cancel(HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void GetSize(HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(ResultSuccess);
+        rb.Push<s64>(0);
+    }
+
+    void Read(HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<s32>(0);
+    }
+
+    void GetErrorCode(HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<u32>(0);
+    }
+
+    void Request(HLERequestContext& ctx) {
+        LOG_DEBUG(Service_NIM, "IShopServiceAsync::Request (stubbed)");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
+    }
+
+    void Prepare(HLERequestContext& ctx) {
+        LOG_DEBUG(Service_NIM, "IShopServiceAsync::Prepare (stubbed)");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
     }
 };
 
@@ -596,13 +632,13 @@ private:
 
     void CreateServerInterface2(HLERequestContext& ctx)
     {
-        // [17.0.0+] CreateServerInterface2
-        // Use the same logic as CreateServerInterface
-        LOG_WARNING(Service_NIM, "(STUBBED) called");
-        // Signal To IPC For A Response
+        // [17.0.0+] CreateServerInterface2 — still returns IShopServiceAccessServer; cmd 0 must be
+        // CreateAccessorInterface. Returning IShopServiceAccessor here made cmd 0 run
+        // CreateAsyncInterface instead, breaking the guest IPC contract.
+        LOG_WARNING(Service_NIM, "(STUBBED) CreateServerInterface2 called");
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(ResultSuccess);
-        rb.PushIpcInterface<IShopServiceAccessor>(system);
+        rb.PushIpcInterface<IShopServiceAccessServer>(system);
     }
 
     void IsLargeResourceAvailable(HLERequestContext& ctx) {
@@ -610,11 +646,12 @@ private:
 
         const auto unknown{rp.Pop<u64>()};
 
-        LOG_INFO(Service_NIM, "(STUBBED) called, unknown={}", unknown);
+        // Stub previously returned false; some apps exit then fault if "large resource" is unavailable.
+        LOG_DEBUG(Service_NIM, "called, unknown={}, out_available=true", unknown);
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.Push(false);
+        rb.Push(true);
     }
 };
 


### PR DESCRIPTION
## Summary
ACC/dauth/async context, NIFM, NIM, web browser applet for Bedrock-style account flows.

Split from `moltenvk-xfb`.

## Test plan
- [ ] Account sign-in for affected titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More complete account/authentication flows, including id-token cache, authorization state, guest profile retrieval, and automatic default avatar creation with sanitization.
  * Added deterministic async network-license and online-play login flows driven by cache/state.
  * Implemented ACC_AA service handling and persistent device/application authentication token cache ensure/load behavior.
* **Bug Fixes**
  * Web login now reliably returns a safe default callback URL and limits copied URL length.
  * Internet availability logic now better reflects airplane mode and offline-local behavior; client acceptance is consistent.
  * NIM shop async endpoints now return consistent placeholder results instead of unhandled commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->