### PR TITLE
fix: MoltenVK transform feedback and Vulkan pipeline core

### DIFF
--- a/src/core/device_memory_manager.inc
+++ b/src/core/device_memory_manager.inc
@@ -217,14 +217,15 @@ void DeviceMemoryManager<Traits>::Map(DAddr address, VAddr virtual_address, size
     std::scoped_lock lk(mapping_guard);
     for (size_t i = 0; i < num_pages; i++) {
         const VAddr new_vaddress = virtual_address + i * Memory::CITRON_PAGESIZE;
-        auto* ptr = process_memory->GetPointerSilent(Common::ProcessAddress(new_vaddress));
+        InsertCPUBacking(start_page_d + i, new_vaddress, asid);
+        auto* ptr = process_memory->GetHostPointerForSmmuMapping(
+            Common::ProcessAddress(new_vaddress));
         if (ptr == nullptr) [[unlikely]] {
             entries[start_page_d + i].compressed_physical_ptr = 0;
             continue;
         }
         auto phys_addr = static_cast<u32>(GetRawPhysicalAddr(ptr) >> Memory::CITRON_PAGEBITS) + 1U;
         entries[start_page_d + i].compressed_physical_ptr = phys_addr;
-        InsertCPUBacking(start_page_d + i, new_vaddress, asid);
         const u32 base_dev = compressed_device_addr[phys_addr - 1U];
         const u32 new_dev = static_cast<u32>(start_page_d + i);
         if (base_dev == 0) [[likely]] {
@@ -285,7 +286,7 @@ void DeviceMemoryManager<Traits>::TrackContinuityImpl(DAddr address, VAddr virtu
         size_t index = i - 1;
         const VAddr new_vaddress = virtual_address + index * Memory::CITRON_PAGESIZE;
         const uintptr_t new_ptr = reinterpret_cast<uintptr_t>(
-            process_memory->GetPointerSilent(Common::ProcessAddress(new_vaddress)));
+            process_memory->GetHostPointerForSmmuMapping(Common::ProcessAddress(new_vaddress)));
         if (new_ptr + page_size == last_ptr) {
             page_count++;
         } else {
@@ -399,6 +400,32 @@ void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto o
 
         auto phys_addr = entries[page_index].compressed_physical_ptr;
         if (phys_addr == 0) {
+            const auto [asid, cpu_backing] = ExtractCPUBacking(page_index);
+            if (cpu_backing != 0 && asid.id < registered_processes.size()) {
+                if (auto* process_memory = registered_processes[asid.id]; process_memory != nullptr) {
+                    auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
+                        Common::ProcessAddress(cpu_backing + page_offset));
+                    if (mem_ptr != nullptr) {
+                        on_memory(copy_amount, mem_ptr);
+                        continue;
+                    }
+                }
+            }
+            // Some nvmap-backed regions can still be physically contiguous by device address even if
+            // page-by-page host pointer resolution failed during map setup. In that case, treat
+            // device address as a direct physical offset as a last-resort fallback to avoid
+            // zero-filling large GPU reads (black screen).
+            const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
+                                               Settings::MemoryLayout::Memory_4Gb
+                                           ? physical_min_bits
+                                           : physical_max_bits;
+            const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
+            const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
+            if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
+                auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
+                on_memory(copy_amount, mem_ptr);
+                continue;
+            }
             on_unmapped(copy_amount, current_vaddr);
             continue;
         }
@@ -458,6 +485,9 @@ void DeviceMemoryManager<Traits>::WriteBlock(DAddr address, const void* src_poin
 
 template <typename Traits>
 void DeviceMemoryManager<Traits>::ReadBlockUnsafe(DAddr address, void* dest_pointer, size_t size) {
+    if (device_inter) {
+        device_inter->FlushRegion(address, size);
+    }
     static std::atomic<u64> unmapped_read_unsafe_count{0};
     WalkBlock(
         address, size,

--- a/src/core/device_memory_manager.inc
+++ b/src/core/device_memory_manager.inc
@@ -403,28 +403,27 @@ void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto o
             const auto [asid, cpu_backing] = ExtractCPUBacking(page_index);
             if (cpu_backing != 0 && asid.id < registered_processes.size()) {
                 if (auto* process_memory = registered_processes[asid.id]; process_memory != nullptr) {
-                    auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
-                        Common::ProcessAddress(cpu_backing + page_offset));
-                    if (mem_ptr != nullptr) {
+                    if (auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
+                            Common::ProcessAddress(cpu_backing + page_offset));
+                        mem_ptr != nullptr) {
                         on_memory(copy_amount, mem_ptr);
                         continue;
                     }
                 }
-            }
-            // Some nvmap-backed regions can still be physically contiguous by device address even if
-            // page-by-page host pointer resolution failed during map setup. In that case, treat
-            // device address as a direct physical offset as a last-resort fallback to avoid
-            // zero-filling large GPU reads (black screen).
-            const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
-                                               Settings::MemoryLayout::Memory_4Gb
-                                           ? physical_min_bits
-                                           : physical_max_bits;
-            const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
-            const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
-            if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
-                auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
-                on_memory(copy_amount, mem_ptr);
-                continue;
+                // Some nvmap-backed regions can still be physically contiguous by device address
+                // even if page-by-page host pointer resolution failed during map setup. Only apply
+                // this fallback when CPU backing was recorded; unmapped pages leave cpu_backing at 0.
+                const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
+                                                   Settings::MemoryLayout::Memory_4Gb
+                                               ? physical_min_bits
+                                               : physical_max_bits;
+                const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
+                const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
+                if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
+                    auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
+                    on_memory(copy_amount, mem_ptr);
+                    continue;
+                }
             }
             on_unmapped(copy_amount, current_vaddr);
             continue;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -937,6 +937,26 @@ u8* Memory::GetPointerSilent(Common::ProcessAddress vaddr) {
     return impl->GetPointerSilent(vaddr);
 }
 
+u8* Memory::GetHostPointerForSmmuMapping(Common::ProcessAddress vaddr) {
+    const u64 addr = GetInteger(vaddr) & 0xffffffffffffULL;
+    Common::PageTable* table = impl->current_page_table;
+    if (!table || !AddressSpaceContains(*table, addr, 1)) {
+        return nullptr;
+    }
+    if (u8* const direct = impl->GetPointerSilent(Common::ProcessAddress(addr))) {
+        return direct;
+    }
+    const auto& entry = table->entries[addr >> CITRON_PAGEBITS];
+    if (entry.pointer.Type() == Common::PageType::Unmapped) {
+        return nullptr;
+    }
+    if (!entry.backing_addr) {
+        return nullptr;
+    }
+    return system.DeviceMemory().GetPointer<u8>(
+        Common::PhysicalAddress{entry.backing_addr + addr});
+}
+
 const u8* Memory::GetPointer(Common::ProcessAddress vaddr) const {
     return impl->GetPointer(vaddr);
 }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -143,6 +143,8 @@ public:
     u8* GetPointer(Common::ProcessAddress vaddr);
     u8* GetPointerSilent(Common::ProcessAddress vaddr);
 
+    [[nodiscard]] u8* GetHostPointerForSmmuMapping(Common::ProcessAddress vaddr);
+
     template <typename T>
     T* GetPointer(Common::ProcessAddress vaddr) {
         return reinterpret_cast<T*>(GetPointer(vaddr));

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -17,6 +17,7 @@
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 #include "shader_recompiler/frontend/ir/basic_block.h"
 #include "shader_recompiler/frontend/ir/program.h"
+#include "shader_recompiler/frontend/ir/type.h"
 
 namespace Shader::Backend::SPIRV {
 namespace {
@@ -395,7 +396,7 @@ void SetupSignedNanCapabilities(const Profile& profile, const IR::Program& progr
 }
 
 void SetupTransformFeedbackCapabilities(EmitContext& ctx, Id main_func) {
-    if (ctx.runtime_info.xfb_count == 0) {
+    if (ctx.runtime_info.xfb_count == 0 || ctx.runtime_info.emulate_transform_feedback) {
         return;
     }
     ctx.AddCapability(spv::Capability::TransformFeedback);
@@ -487,7 +488,29 @@ void PatchPhiNodes(IR::Program& program, EmitContext& ctx) {
 } // Anonymous namespace
 
 std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_info, IR::Program& program, Bindings& bindings) {
-    EmitContext ctx{profile, runtime_info, program, bindings};
+    RuntimeInfo runtime_info_work = runtime_info;
+    if (runtime_info_work.emulate_transform_feedback && runtime_info_work.xfb_count > 0) {
+        static constexpr u32 kXfbEmuBuffers = 5;
+        static constexpr u32 kMaxwellMaxConstBuffers = 18;
+        if (program.info.storage_buffers_descriptors.size() + kXfbEmuBuffers >
+            Shader::Info::MAX_SSBOS) {
+            throw NotImplementedException(
+                "Transform-feedback emulation requires {} free SSBO slots", kXfbEmuBuffers);
+        }
+        program.info.used_storage_buffer_types |= IR::Type::F32 | IR::Type::U32;
+        runtime_info_work.xfb_emulation_ssbo_base =
+            static_cast<u32>(program.info.storage_buffers_descriptors.size());
+        for (u32 b = 0; b < kXfbEmuBuffers; ++b) {
+            program.info.storage_buffers_descriptors.push_back({
+                .cbuf_index = kMaxwellMaxConstBuffers + b,
+                .cbuf_offset = 0,
+                .count = 1,
+                .is_written = true,
+            });
+        }
+    }
+
+    EmitContext ctx{profile, runtime_info_work, program, bindings};
     const Id main{DefineMain(ctx, program)};
     DefineEntryPoint(program, ctx, main);
     if (profile.support_float_controls) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -490,6 +490,10 @@ void PatchPhiNodes(IR::Program& program, EmitContext& ctx) {
 std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_info, IR::Program& program, Bindings& bindings) {
     RuntimeInfo runtime_info_work = runtime_info;
     if (runtime_info_work.emulate_transform_feedback && runtime_info_work.xfb_count > 0) {
+        if (!profile.support_descriptor_aliasing) {
+            throw NotImplementedException(
+                "Transform-feedback emulation requires descriptor aliasing support");
+        }
         static constexpr u32 kXfbEmuBuffers = 5;
         static constexpr u32 kMaxwellMaxConstBuffers = 18;
         if (program.info.storage_buffers_descriptors.size() + kXfbEmuBuffers >

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -198,17 +198,27 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
         return;
     }
     const u32 counter_ssbo = base + 4;
-    Id record_index{};
     if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
         ctx.AddCapability(spv::Capability::AtomicStorage);
         const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
                                                ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
                                                ctx.u32_zero_value)};
-        record_index = ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr,
-                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
-                                        ctx.u32_zero_value, ctx.Const(1U));
-    } else {
+        // Atomic increment is for query byte-count emulation only; record placement uses a
+        // deterministic per-invocation index so captured stream data stays in draw order.
+        ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr, ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                         ctx.u32_zero_value, ctx.Const(1U));
+    }
+    Id record_index{};
+    if (Sirit::ValidId(ctx.vertex_index)) {
         record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
+    } else if (Sirit::ValidId(ctx.vertex_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_id);
+    } else if (Sirit::ValidId(ctx.invocation_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
+    } else if (Sirit::ValidId(ctx.primitive_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.primitive_id);
+    } else {
+        record_index = ctx.u32_zero_value;
     }
     const Id element_ptr{ctx.storage_types.F32.element};
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <bit>
+#include <limits>
 #include <tuple>
 #include <utility>
 
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
+#include "shader_recompiler/exception.h"
 
 namespace Shader::Backend::SPIRV {
 namespace {
@@ -168,6 +170,101 @@ Id GetCbufElement(EmitContext& ctx, Id vector, const IR::Value& offset, u32 inde
         element = ctx.OpIAdd(ctx.U32[1], element, ctx.Const(index_offset));
     }
     return ctx.OpVectorExtractDynamic(ctx.U32[1], vector, element);
+}
+
+void ConditionalStore(EmitContext& ctx, Id condition, Id pointer, Id value) {
+    const Id merge_label = ctx.OpLabel();
+    const Id store_label = ctx.OpLabel();
+    const Id skip_label = ctx.OpLabel();
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(condition, store_label, skip_label);
+    ctx.AddLabel(store_label);
+    ctx.OpStore(pointer, value);
+    ctx.OpBranch(merge_label);
+    ctx.AddLabel(skip_label);
+    ctx.OpBranch(merge_label);
+    ctx.AddLabel(merge_label);
+}
+
+void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
+    if (!ctx.runtime_info.emulate_transform_feedback || ctx.runtime_info.xfb_count == 0) {
+        return;
+    }
+    const u32 base = ctx.runtime_info.xfb_emulation_ssbo_base;
+    if (base == std::numeric_limits<u32>::max()) {
+        return;
+    }
+    const u32 counter_ssbo = base + 4;
+    Id record_index{};
+    if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
+        ctx.AddCapability(spv::Capability::AtomicStorage);
+        const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                               ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
+                                               ctx.u32_zero_value)};
+        record_index = ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr,
+                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                                        ctx.u32_zero_value, ctx.Const(1U));
+    } else {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
+    }
+    const Id element_ptr{ctx.storage_types.F32.element};
+
+    for (u32 attr_u32 = static_cast<u32>(IR::Attribute::PositionX); attr_u32 < 256; ++attr_u32) {
+        const auto& xv = ctx.runtime_info.xfb_varyings[attr_u32];
+        if (xv.components == 0) {
+            continue;
+        }
+        if (xv.buffer >= 4) {
+            continue;
+        }
+        const u32 ssbo_idx = base + xv.buffer;
+        if (ssbo_idx >= ctx.ssbos.size()) {
+            continue;
+        }
+        const Id ssbo_array_id = ctx.ssbos[ssbo_idx].F32;
+        if (!Sirit::ValidId(ssbo_array_id)) {
+            continue;
+        }
+        const Id stride_bytes{ctx.Const(xv.stride)};
+        const Id base_byte{ctx.OpIMul(ctx.U32[1], record_index, stride_bytes)};
+        for (u32 c = 0; c < xv.components; ++c) {
+            const u32 comp_attr = attr_u32 + c;
+            if (comp_attr >= 256) {
+                break;
+            }
+            const IR::Attribute attr = static_cast<IR::Attribute>(comp_attr);
+            std::optional<OutAttr> output;
+            try {
+                output = OutputAttrPointer(ctx, attr);
+            } catch (const NotImplementedException&) {
+                continue;
+            }
+            if (!output) {
+                continue;
+            }
+            Id value{};
+            if (Sirit::ValidId(output->type)) {
+                const Id raw{ctx.OpLoad(output->type, output->pointer)};
+                value = ctx.OpBitcast(ctx.F32[1], raw);
+            } else {
+                value = ctx.OpLoad(ctx.F32[1], output->pointer);
+            }
+            const Id byte_off{ctx.Const(xv.offset + c * 4)};
+            const Id abs_byte{ctx.OpIAdd(ctx.U32[1], base_byte, byte_off)};
+            const Id word_idx{ctx.OpShiftRightLogical(ctx.U32[1], abs_byte, ctx.Const(2u))};
+            const Id dst_ptr{
+                ctx.OpAccessChain(element_ptr, ssbo_array_id, ctx.u32_zero_value, word_idx)};
+            const u32 buffer_bytes = ctx.runtime_info.xfb_buffer_bytes[xv.buffer];
+            if (buffer_bytes == 0) {
+                ctx.OpStore(dst_ptr, value);
+                continue;
+            }
+            const Id size_bytes{ctx.Const(buffer_bytes)};
+            const Id end_byte{ctx.OpIAdd(ctx.U32[1], abs_byte, ctx.Const(4u))};
+            const Id in_bounds{ctx.OpULessThanEqual(ctx.U1, end_byte, size_bytes)};
+            ConditionalStore(ctx, in_bounds, dst_ptr, value);
+        }
+    }
 }
 } // Anonymous namespace
 
@@ -616,6 +713,10 @@ Id EmitLoadLocal(EmitContext& ctx, Id word_offset) {
 void EmitWriteLocal(EmitContext& ctx, Id word_offset, Id value) {
     const Id pointer{ctx.OpAccessChain(ctx.private_u32, ctx.local_memory, word_offset)};
     ctx.OpStore(pointer, value);
+}
+
+void EmitTransformFeedbackEmulationStores(EmitContext& ctx) {
+    EmitTransformFeedbackEmulationStoresImpl(ctx);
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -47,6 +47,9 @@ std::optional<OutAttr> OutputAttrPointer(EmitContext& ctx, IR::Attribute attr) {
         const u32 index{IR::GenericAttributeIndex(attr)};
         const u32 element{IR::GenericAttributeElement(attr)};
         const GenericElementInfo& info{ctx.output_generics.at(index).at(element)};
+        if (info.num_components == 0) {
+            return std::nullopt;
+        }
         if (info.num_components == 1) {
             return info.id;
         } else {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -197,28 +197,25 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
     if (base == std::numeric_limits<u32>::max()) {
         return;
     }
+    static constexpr u32 kXfbQueryCounterWord = 0;
+    static constexpr u32 kXfbRecordOrdinalWord = 4;
     const u32 counter_ssbo = base + 4;
+    Id record_index{ctx.u32_zero_value};
     if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
         ctx.AddCapability(spv::Capability::AtomicStorage);
-        const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
-                                               ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
-                                               ctx.u32_zero_value)};
-        // Atomic increment is for query byte-count emulation only; record placement uses a
-        // deterministic per-invocation index so captured stream data stays in draw order.
-        ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr, ctx.Const(static_cast<u32>(spv::Scope::Device)),
-                         ctx.u32_zero_value, ctx.Const(1U));
-    }
-    Id record_index{};
-    if (Sirit::ValidId(ctx.vertex_index)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
-    } else if (Sirit::ValidId(ctx.vertex_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_id);
-    } else if (Sirit::ValidId(ctx.invocation_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
-    } else if (Sirit::ValidId(ctx.primitive_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.primitive_id);
-    } else {
-        record_index = ctx.u32_zero_value;
+        const Id query_counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                                     ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
+                                                     ctx.Const(kXfbQueryCounterWord))};
+        ctx.OpAtomicIAdd(ctx.U32[1], query_counter_ptr,
+                         ctx.Const(static_cast<u32>(spv::Scope::Device)), ctx.u32_zero_value,
+                         ctx.Const(1U));
+        const Id record_counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                                      ctx.ssbos[counter_ssbo].U32,
+                                                      ctx.u32_zero_value,
+                                                      ctx.Const(kXfbRecordOrdinalWord))};
+        record_index = ctx.OpAtomicIAdd(ctx.U32[1], record_counter_ptr,
+                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                                        ctx.u32_zero_value, ctx.Const(1U));
     }
     const Id element_ptr{ctx.storage_types.F32.element};
 
@@ -272,9 +269,11 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
                 ctx.OpStore(dst_ptr, value);
                 continue;
             }
-            const Id size_bytes{ctx.Const(buffer_bytes)};
-            const Id end_byte{ctx.OpIAdd(ctx.U32[1], abs_byte, ctx.Const(4u))};
-            const Id in_bounds{ctx.OpULessThanEqual(ctx.U1, end_byte, size_bytes)};
+            const u32 max_records = xv.stride > 0 ? buffer_bytes / xv.stride : 0;
+            if (max_records == 0) {
+                continue;
+            }
+            const Id in_bounds{ctx.OpULessThan(ctx.U1, record_index, ctx.Const(max_records))};
             ConditionalStore(ctx, in_bounds, dst_ptr, value);
         }
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -36,10 +36,7 @@ public:
 
     explicit ImageOperands(EmitContext& ctx, const IR::Value& offset, const IR::Value& offset2) {
         if (offset2.IsEmpty()) {
-            if (offset.IsEmpty()) {
-                return;
-            }
-            Add(spv::ImageOperandsMask::Offset, ctx.Def(offset));
+            AddOffset(ctx, offset, ImageGatherOffsetAllowed);
             return;
         }
         const std::array values{offset.InstRecursive(), offset2.InstRecursive()};
@@ -53,10 +50,18 @@ public:
         }
         auto read{[&](unsigned int a, unsigned int b) { return values[a]->Arg(b).U32(); }};
 
+        const auto make_offset_pair = [&](u32 x, u32 y) {
+            if (ctx.profile.has_broken_unsigned_image_offsets) {
+                return ctx.SConst(static_cast<s32>(x), static_cast<s32>(y));
+            }
+            return ctx.Const(x, y);
+        };
+
         const Id offsets{ctx.ConstantComposite(
-            ctx.TypeArray(ctx.U32[2], ctx.Const(4U)), ctx.Const(read(0, 0), read(0, 1)),
-            ctx.Const(read(0, 2), read(0, 3)), ctx.Const(read(1, 0), read(1, 1)),
-            ctx.Const(read(1, 2), read(1, 3)))};
+            ctx.TypeArray(ctx.profile.has_broken_unsigned_image_offsets ? ctx.S32[2] : ctx.U32[2],
+                          ctx.Const(4U)),
+            make_offset_pair(read(0, 0), read(0, 1)), make_offset_pair(read(0, 2), read(0, 3)),
+            make_offset_pair(read(1, 0), read(1, 1)), make_offset_pair(read(1, 2), read(1, 3)))};
         Add(spv::ImageOperandsMask::ConstOffsets, offsets);
     }
 
@@ -164,7 +169,23 @@ private:
             }
         }
         if (runtime_offset_allowed) {
-            Add(spv::ImageOperandsMask::Offset, ctx.Def(offset));
+            Id offset_id{ctx.Def(offset)};
+            if (ctx.profile.has_broken_unsigned_image_offsets) {
+                const u32 num_components = [&] {
+                    switch (inst->GetOpcode()) {
+                    case IR::Opcode::CompositeConstructU32x2:
+                        return 2U;
+                    case IR::Opcode::CompositeConstructU32x3:
+                        return 3U;
+                    case IR::Opcode::CompositeConstructU32x4:
+                        return 4U;
+                    default:
+                        return 1U;
+                    }
+                }();
+                offset_id = ctx.OpBitcast(ctx.S32[num_components], offset_id);
+            }
+            Add(spv::ImageOperandsMask::Offset, offset_id);
         }
     }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -34,6 +34,7 @@ void EmitWorkgroupMemoryBarrier(EmitContext& ctx);
 void EmitDeviceMemoryBarrier(EmitContext& ctx);
 void EmitPrologue(EmitContext& ctx);
 void EmitEpilogue(EmitContext& ctx);
+void EmitTransformFeedbackEmulationStores(EmitContext& ctx);
 void EmitEmitVertex(EmitContext& ctx, const IR::Value& stream);
 void EmitEndPrimitive(EmitContext& ctx, const IR::Value& stream);
 void EmitGetRegister(EmitContext& ctx);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -140,10 +140,11 @@ void EmitPrologue(EmitContext& ctx) {
 }
 
 void EmitEpilogue(EmitContext& ctx) {
-    if (ctx.stage == Stage::VertexB && ctx.runtime_info.convert_depth_mode &&
-        !ctx.profile.support_native_ndc) {
+    if ((ctx.stage == Stage::VertexB || ctx.stage == Stage::TessellationEval) &&
+        ctx.runtime_info.convert_depth_mode && !ctx.profile.support_native_ndc) {
         ConvertDepthMode(ctx);
     }
+    EmitTransformFeedbackEmulationStores(ctx);
     if (ctx.stage == Stage::Fragment) {
         InitializeAlphaToCoverage(ctx);
         AlphaTest(ctx);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -196,7 +196,7 @@ void DefineGenericOutput(EmitContext& ctx, size_t index, std::optional<u32> invo
         if (element > 0) {
             ctx.Decorate(id, spv::Decoration::Component, element);
         }
-        if (xfb_varying) {
+        if (xfb_varying && !ctx.runtime_info.emulate_transform_feedback) {
             ctx.Decorate(id, spv::Decoration::XfbBuffer, xfb_varying->buffer);
             ctx.Decorate(id, spv::Decoration::XfbStride, xfb_varying->stride);
             ctx.Decorate(id, spv::Decoration::Offset, xfb_varying->offset);
@@ -1578,7 +1578,10 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         }
         const Id type{GetAttributeType(*this, input_type)};
         const Id id{DefineInput(*this, type, true)};
-        Decorate(id, spv::Decoration::Location, static_cast<u32>(index));
+        const u32 location = runtime_info.remapped_vertex_locations
+                                 ? runtime_info.vertex_locations[index]
+                                 : static_cast<u32>(index);
+        Decorate(id, spv::Decoration::Location, location);
         Name(id, fmt::format("in_attr{}", index));
         input_generics[index] = GetAttributeInfo(*this, input_type, id);
 

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <map>
 #include <optional>
 #include <vector>
@@ -13,6 +14,9 @@
 #include "shader_recompiler/varying_state.h"
 
 namespace Shader {
+
+/// Guest vertex input slot that could not be mapped into the host limit (see PopulateVertexLocationRemap).
+constexpr u8 VERTEX_INPUT_DROPPED = 0xFF;
 
 enum class AttributeType : u8 {
     Float,
@@ -85,6 +89,12 @@ struct TransformFeedbackVarying {
 
 struct RuntimeInfo {
     std::array<AttributeType, 32> generic_input_types{};
+    /// Maps guest attribute index to SPIR-V/VkVertexInput location when MoltenVK caps at 16.
+    bool remapped_vertex_locations{};
+    std::array<u8, 32> vertex_locations{};
+    /// Maps guest vertex stream/binding index to Vulkan binding when MoltenVK caps at 16.
+    bool remapped_vertex_bindings{};
+    std::array<u8, 32> vertex_bindings{};
     VaryingState previous_stage_stores;
     std::map<IR::Attribute, IR::Attribute> previous_stage_legacy_stores_mapping;
 
@@ -111,6 +121,12 @@ struct RuntimeInfo {
     /// Transform feedback state for each varying
     std::array<TransformFeedbackVarying, 256> xfb_varyings{};
     u32 xfb_count{0};
+    /// Guest transform-feedback buffer sizes captured in pipeline state (bytes).
+    std::array<u32, 4> xfb_buffer_bytes{};
+    /// Stream-out is implemented with storage-buffer writes (MoltenVK / no VK_EXT_transform_feedback).
+    bool emulate_transform_feedback{};
+    /// First SSBO index of the four transform-feedback buffers; UINT_MAX if unused.
+    u32 xfb_emulation_ssbo_base{std::numeric_limits<u32>::max()};
 };
 
 } // namespace Shader

--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -25,6 +25,9 @@ DECLARE_ENUM_FLAG_OPERATORS(BufferFlagBits)
 /// Tag for creating null buffers with no storage or size
 struct NullBufferParams {};
 
+/// Tag for the Vulkan transform-feedback emulation atomic stream-index buffer (host-only)
+struct XfbStreamCounterBufferParams {};
+
 /**
  * Range tracking buffer container.
  *

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -23,6 +23,14 @@ BufferCache<P>::BufferCache(Tegra::MaxwellDeviceMemoryManager& device_memory_, R
     : runtime{runtime_}, device_memory{device_memory_}, memory_tracker{device_memory} {
     // Ensure the first slot is used for the null buffer
     void(slot_buffers.insert(runtime, NullBufferParams{}));
+    if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+        xfb_stream_counter_buffer_id =
+            slot_buffers.insert(runtime, XfbStreamCounterBufferParams{});
+        Register(xfb_stream_counter_buffer_id);
+        slot_buffers[xfb_stream_counter_buffer_id].Pick();
+        runtime.RegisterXfbEmulationCounterBuffer(
+            slot_buffers[xfb_stream_counter_buffer_id].Handle());
+    }
     gpu_modified_ranges.Clear();
     inline_buffer_id = NULL_BUFFER_ID;
 
@@ -441,8 +449,59 @@ void BufferCache<P>::BindGraphicsStorageBuffer(size_t stage, size_t ssbo_index, 
     channel_state->enabled_storage_buffers[stage] |= 1U << ssbo_index;
     channel_state->written_storage_buffers[stage] |= (is_written ? 1U : 0U) << ssbo_index;
 
+    GPUVAddr ssbo_addr{};
+    if (cbuf_index >= Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers) {
+        const u32 slot = cbuf_index - Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers;
+        if (slot == Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers) {
+            if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+                if (xfb_stream_counter_buffer_id == NULL_BUFFER_ID) {
+                    return;
+                }
+                channel_state->storage_buffers[stage][ssbo_index] = Binding{
+                    .device_addr = XFB_EMULATION_COUNTER_DEVICE_ADDR,
+                    .size = XFB_EMULATION_COUNTER_BUFFER_BYTES,
+                    .buffer_id = xfb_stream_counter_buffer_id,
+                };
+            }
+            return;
+        }
+        if (slot > Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers) [[unlikely]] {
+            LOG_ERROR(HW_GPU, "Invalid transform-feedback emulation storage cbuf slot {}", slot);
+            return;
+        }
+        const auto& tf = maxwell3d->regs.transform_feedback.buffers[slot];
+        const GPUVAddr gpu_addr = tf.Address() + static_cast<GPUVAddr>(tf.start_offset);
+        const s32 tf_size = tf.size;
+        u32 size = 0;
+        if (tf_size > 0) {
+            size = static_cast<u32>(tf_size);
+        } else {
+            size = static_cast<u32>(gpu_memory->GetMemoryLayoutSize(gpu_addr));
+        }
+        if (size == 0) [[unlikely]] {
+            LOG_WARNING(HW_GPU, "Transform-feedback emulation buffer has zero size (slot {})", slot);
+            return;
+        }
+        const u32 alignment = runtime.GetStorageBufferAlignment();
+        const GPUVAddr aligned_gpu_addr = Common::AlignDown(gpu_addr, alignment);
+        const u32 aligned_size = static_cast<u32>(gpu_addr - aligned_gpu_addr) + size;
+        const std::optional<DAddr> aligned_device_addr = gpu_memory->GpuToCpuAddress(aligned_gpu_addr);
+        const std::optional<DAddr> device_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
+        if (!aligned_device_addr || !device_addr) [[unlikely]] {
+            LOG_WARNING(HW_GPU, "Transform-feedback emulation buffer not mapped (slot {})", slot);
+            return;
+        }
+        const DAddr cpu_end = Common::AlignUp(*device_addr + size, Core::DEVICE_PAGESIZE);
+        channel_state->storage_buffers[stage][ssbo_index] = Binding{
+            .device_addr = *aligned_device_addr,
+            .size = is_written ? aligned_size : static_cast<u32>(cpu_end - *aligned_device_addr),
+            .buffer_id = BufferId{},
+        };
+        return;
+    }
+
     const auto& cbufs = maxwell3d->state.shader_stages[stage];
-    const GPUVAddr ssbo_addr = cbufs.const_buffers[cbuf_index].address + cbuf_offset;
+    ssbo_addr = cbufs.const_buffers[cbuf_index].address + cbuf_offset;
     channel_state->storage_buffers[stage][ssbo_index] =
         StorageBufferBinding(ssbo_addr, cbuf_index, is_written);
 }
@@ -666,6 +725,18 @@ void BufferCache<P>::PopAsyncBuffers() {
     async_buffers_death_ring.emplace_back(*async_buffer);
     async_buffers.pop_front();
     pending_downloads.pop_front();
+}
+
+template <class P>
+void BufferCache<P>::ClearXfbStreamCounterForDraw() {
+    if constexpr (!BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+        return;
+    }
+    if (xfb_stream_counter_buffer_id == NULL_BUFFER_ID) [[unlikely]] {
+        return;
+    }
+    Buffer& buf = slot_buffers[xfb_stream_counter_buffer_id];
+    runtime.ClearBuffer(buf.Handle(), 0, XFB_EMULATION_COUNTER_BUFFER_BYTES, 0);
 }
 
 template <class P>
@@ -893,7 +964,13 @@ void BufferCache<P>::BindHostGraphicsStorageBuffers(size_t stage) {
         const bool is_written = ((channel_state->written_storage_buffers[stage] >> index) & 1) != 0;
 
         if (is_written) {
-            MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+            if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+                if (binding.device_addr != XFB_EMULATION_COUNTER_DEVICE_ADDR) {
+                    MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+                }
+            } else {
+                MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+            }
         }
 
         if constexpr (NEEDS_BIND_STORAGE_INDEX) {
@@ -1206,6 +1283,12 @@ void BufferCache<P>::UpdateStorageBuffers(size_t stage) {
     ForEachEnabledBit(channel_state->enabled_storage_buffers[stage], [&](u32 index) {
         // Resolve buffer
         Binding& binding = channel_state->storage_buffers[stage][index];
+        if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+            if (binding.device_addr == XFB_EMULATION_COUNTER_DEVICE_ADDR) {
+                binding.buffer_id = xfb_stream_counter_buffer_id;
+                return;
+            }
+        }
         const BufferId buffer_id = FindBuffer(binding.device_addr, binding.size);
         binding.buffer_id = buffer_id;
     });

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -40,11 +40,7 @@ using BufferId = Common::SlotId;
 using VideoCore::Surface::PixelFormat;
 using namespace Common::Literals;
 
-#ifdef __APPLE__
-constexpr u32 NUM_VERTEX_BUFFERS = 16;
-#else
 constexpr u32 NUM_VERTEX_BUFFERS = 32;
-#endif
 constexpr u32 NUM_TRANSFORM_FEEDBACK_BUFFERS = 4;
 constexpr u32 NUM_GRAPHICS_UNIFORM_BUFFERS = 18;
 constexpr u32 NUM_COMPUTE_UNIFORM_BUFFERS = 8;
@@ -52,8 +48,21 @@ constexpr u32 NUM_STORAGE_BUFFERS = 16;
 constexpr u32 NUM_TEXTURE_BUFFERS = 32;
 constexpr u32 NUM_STAGES = 5;
 
+/// Device-address placeholder for TF stream-index counter binding (not guest memory).
+inline constexpr DAddr XFB_EMULATION_COUNTER_DEVICE_ADDR = 0x3F0000000ULL;
+inline constexpr u32 XFB_EMULATION_COUNTER_BUFFER_BYTES = 64;
+
 using UniformBufferSizes = std::array<std::array<u32, NUM_GRAPHICS_UNIFORM_BUFFERS>, NUM_STAGES>;
 using ComputeUniformBufferSizes = std::array<u32, NUM_COMPUTE_UNIFORM_BUFFERS>;
+
+template <typename P>
+constexpr bool BufferCacheHasXfbStreamCounterHostBuffer() {
+    if constexpr (requires { P::HAS_XFB_STREAM_COUNTER_HOST_BUFFER; }) {
+        return P::HAS_XFB_STREAM_COUNTER_HOST_BUFFER;
+    } else {
+        return false;
+    }
+}
 
 enum class ObtainBufferSynchronize : u32 {
     NoSynchronize = 0,
@@ -276,6 +285,8 @@ public:
     /// Pop asynchronous downloads
     void PopAsyncFlushes();
     void PopAsyncBuffers();
+
+    void ClearXfbStreamCounterForDraw();
 
     bool DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount);
 
@@ -530,6 +541,8 @@ public:
     u64 last_emergency_gc_log_frame = 0;
     u64 last_emergency_gc_log_usage = 0;
     u32 emergency_gc_logs_suppressed = 0;
+
+    BufferId xfb_stream_counter_buffer_id{NULL_BUFFER_ID};
 
     std::array<BufferId, ((1ULL << 34) >> CACHING_PAGEBITS)> page_table;
     Common::ScratchBuffer<u8> tmp_buffer;

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -24,6 +24,8 @@ void RefreshXfbState(VideoCommon::TransformFeedbackState& state, const Tegra::En
                                    .stride = layout.stride,
                                };
                            });
+    std::ranges::transform(regs.transform_feedback.buffers, state.buffer_sizes.begin(),
+                           [](const auto& buffer) { return buffer.size; });
     state.varyings = regs.stream_out_layout;
 }
 } // Anonymous namespace
@@ -39,7 +41,9 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d, DynamicFe
     extended_dynamic_state_3_blend.Assign(features.has_extended_dynamic_state_3_blend ? 1 : 0);
     extended_dynamic_state_3_enables.Assign(features.has_extended_dynamic_state_3_enables ? 1 : 0);
     dynamic_vertex_input.Assign(features.has_dynamic_vertex_input ? 1 : 0);
-    xfb_enabled.Assign(features.has_transform_feedback && regs.transform_feedback_enabled != 0);
+    xfb_enabled.Assign((features.has_transform_feedback || features.emulate_transform_feedback) &&
+                       regs.transform_feedback_enabled != 0);
+    xfb_emulated.Assign(features.emulate_transform_feedback && regs.transform_feedback_enabled != 0);
     ndc_minus_one_to_one.Assign(regs.depth_mode == Tegra::Engines::Maxwell3D::Regs::DepthMode::MinusOneToOne ? 1 : 0);
     polygon_mode.Assign(PackPolygonMode(regs.polygon_mode_front));
     tessellation_primitive.Assign(static_cast<u32>(regs.tessellation.params.domain_type.Value()));

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -23,6 +23,8 @@ struct DynamicFeatures {
     bool has_extended_dynamic_state_3_enables;
     bool has_dynamic_vertex_input;
     bool has_transform_feedback;
+    /// Software stream-out when the host lacks VK_EXT_transform_feedback (e.g. MoltenVK).
+    bool emulate_transform_feedback;
 };
 
 struct FixedPipelineState {
@@ -201,6 +203,7 @@ struct FixedPipelineState {
     };
     union {
         u32 raw2;
+        BitField<0, 1, u32> xfb_emulated;
         BitField<1, 3, u32> alpha_test_func;
         BitField<4, 1, u32> early_z;
         BitField<5, 1, u32> depth_enabled;

--- a/src/video_core/renderer_vulkan/vertex_location_remap.h
+++ b/src/video_core/renderer_vulkan/vertex_location_remap.h
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "common/common_types.h"
+#include "shader_recompiler/program_header.h"
+#include "shader_recompiler/runtime_info.h"
+#include "video_core/renderer_vulkan/fixed_pipeline_state.h"
+
+namespace Vulkan {
+
+[[nodiscard]] inline bool IsVertexAttributeActive(const FixedPipelineState& state, size_t index,
+                                                  const Shader::Info& info) {
+    if (!info.loads.Generic(index)) {
+        return false;
+    }
+    if (state.dynamic_vertex_input != 0) {
+        return state.DynamicAttributeType(index) != 0;
+    }
+    return state.attributes[index].enabled != 0;
+}
+
+[[nodiscard]] inline bool IsVertexBindingUsedByMappedAttributes(
+    u32 binding, const FixedPipelineState& state, const Shader::Info& info,
+    const Shader::RuntimeInfo& runtime_info) {
+    for (size_t index = 0; index < state.attributes.size(); ++index) {
+        if (!IsVertexAttributeActive(state, index, info)) {
+            continue;
+        }
+        if (runtime_info.remapped_vertex_locations &&
+            runtime_info.vertex_locations[index] == Shader::VERTEX_INPUT_DROPPED) {
+            continue;
+        }
+        if (state.attributes[index].buffer == binding) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline void PopulateVertexLocationRemap(Shader::RuntimeInfo& runtime_info, u32 max_locations,
+                                        u32 max_bindings, const FixedPipelineState& state,
+                                        const Shader::Info& vertex_info) {
+    for (size_t i = 0; i < runtime_info.vertex_locations.size(); ++i) {
+        runtime_info.vertex_locations[i] = static_cast<u8>(i);
+        runtime_info.vertex_bindings[i] = static_cast<u8>(i);
+    }
+    runtime_info.remapped_vertex_locations = false;
+    runtime_info.remapped_vertex_bindings = false;
+
+    const bool needs_location_remap = max_locations < runtime_info.vertex_locations.size();
+    const bool needs_binding_remap = max_bindings < runtime_info.vertex_bindings.size();
+    if (!needs_location_remap && !needs_binding_remap) {
+        return;
+    }
+
+    if (needs_location_remap) {
+        u32 location_slot = 0;
+        for (size_t guest = 0; guest < runtime_info.vertex_locations.size(); ++guest) {
+            if (!IsVertexAttributeActive(state, guest, vertex_info)) {
+                continue;
+            }
+            if (location_slot >= max_locations) {
+                runtime_info.vertex_locations[guest] = Shader::VERTEX_INPUT_DROPPED;
+                runtime_info.remapped_vertex_locations = true;
+                continue;
+            }
+            const u8 vulkan_location = static_cast<u8>(location_slot);
+            runtime_info.vertex_locations[guest] = vulkan_location;
+            if (vulkan_location != guest) {
+                runtime_info.remapped_vertex_locations = true;
+            }
+            ++location_slot;
+        }
+    }
+
+    if (needs_binding_remap) {
+        u32 binding_slot = 0;
+        for (size_t guest = 0; guest < runtime_info.vertex_bindings.size(); ++guest) {
+            if (!IsVertexBindingUsedByMappedAttributes(static_cast<u32>(guest), state, vertex_info,
+                                                       runtime_info)) {
+                continue;
+            }
+            if (binding_slot >= max_bindings) {
+                runtime_info.vertex_bindings[guest] = Shader::VERTEX_INPUT_DROPPED;
+                runtime_info.remapped_vertex_bindings = true;
+                continue;
+            }
+            const u8 vulkan_binding = static_cast<u8>(binding_slot);
+            runtime_info.vertex_bindings[guest] = vulkan_binding;
+            if (vulkan_binding != guest) {
+                runtime_info.remapped_vertex_bindings = true;
+            }
+            ++binding_slot;
+        }
+    }
+}
+
+[[nodiscard]] inline u32 VulkanVertexLocation(const Shader::RuntimeInfo& runtime_info,
+                                              size_t guest_index) {
+    if (runtime_info.remapped_vertex_locations) {
+        return runtime_info.vertex_locations[guest_index];
+    }
+    return static_cast<u32>(guest_index);
+}
+
+[[nodiscard]] inline u32 VulkanVertexBinding(const Shader::RuntimeInfo& runtime_info,
+                                             u32 guest_binding) {
+    if (runtime_info.remapped_vertex_bindings) {
+        return runtime_info.vertex_bindings[guest_binding];
+    }
+    return guest_binding;
+}
+
+[[nodiscard]] inline bool IsVertexAttributeMapped(const Shader::RuntimeInfo& runtime_info,
+                                                  size_t guest_index) {
+    return !runtime_info.remapped_vertex_locations ||
+           runtime_info.vertex_locations[guest_index] != Shader::VERTEX_INPUT_DROPPED;
+}
+
+[[nodiscard]] inline bool IsVertexBindingMapped(const Shader::RuntimeInfo& runtime_info,
+                                               u32 guest_binding) {
+    return !runtime_info.remapped_vertex_bindings ||
+           runtime_info.vertex_bindings[guest_binding] != Shader::VERTEX_INPUT_DROPPED;
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -313,7 +313,7 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
         .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
         .dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
     };
-    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.RequestOutsideRenderPassOperationContext();
     scheduler.Record([counter_buffer, draw_buffer = *xfb_byte_count_draw_buffer, draw_staging,
                       guest_counter_buffer, guest_counter_offset](vk::CommandBuffer cmdbuf) {
         cmdbuf.PipelineBarrier(XfbEmulationWriteStages() | VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -336,6 +336,9 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
                                VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
                                    VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
                                0, DRAW_BARRIER);
+    });
+    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.Record([draw_buffer = *xfb_byte_count_draw_buffer](vk::CommandBuffer cmdbuf) {
         cmdbuf.DrawIndirect(draw_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     });
     StagingBufferRef draw_staging_ref = draw_staging;

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -10,6 +10,7 @@
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "common/literals.h"
+#include "common/logging.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 
 
@@ -84,7 +85,262 @@ vk::Buffer CreateBuffer(const Device& device, const MemoryAllocator& memory_allo
     return memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
 }
 
+constexpr VkPipelineStageFlags XfbEmulationWriteStages() {
+    return VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+           VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT |
+           VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+}
+
+vk::Buffer CreateXfbByteCountDrawBuffer(const Device& device, MemoryAllocator& memory_allocator,
+                                        StagingBufferPool& staging_pool, Scheduler& scheduler) {
+    static constexpr std::array<u32, 4> kDrawTemplate{0U, 1U, 0U, 0U};
+    const VkBufferCreateInfo buffer_ci{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = sizeof(kDrawTemplate),
+        .usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer draw_buffer = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        draw_buffer.SetObjectNameEXT("XFB byte-count draw indirect");
+    }
+    const StagingBufferRef staging =
+        staging_pool.Request(sizeof(kDrawTemplate), MemoryUsage::Upload, true);
+    std::memcpy(staging.mapped_span.data(), kDrawTemplate.data(), sizeof(kDrawTemplate));
+    const VkBuffer draw_buffer_handle = *draw_buffer;
+    scheduler.RequestOutsideRenderPassOperationContext();
+    scheduler.Record([draw_buffer_handle, staging](vk::CommandBuffer cmdbuf) {
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = staging.offset,
+            .dstOffset = 0,
+            .size = sizeof(kDrawTemplate),
+        }};
+        cmdbuf.CopyBuffer(staging.buffer, draw_buffer_handle, copy);
+    });
+    StagingBufferRef staging_ref = staging;
+    staging_pool.FreeDeferred(staging_ref);
+    return draw_buffer;
+}
+
 } // Anonymous namespace
+
+vk::Buffer CreateXfbStreamCounterBuffer(const Device& device, MemoryAllocator& memory_allocator) {
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                 VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer ret = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        ret.SetObjectNameEXT("XFB stream counter");
+    }
+    return ret;
+}
+
+vk::Buffer CreateXfbStreamCounterSnapshotBuffer(const Device& device,
+                                                MemoryAllocator& memory_allocator) {
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer ret = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        ret.SetObjectNameEXT("XFB stream counter snapshot");
+    }
+    return ret;
+}
+
+void BufferCacheRuntime::RegisterXfbEmulationCounterBuffer(VkBuffer buffer) {
+    xfb_emulation_counter_buffer = buffer;
+    if (!xfb_emulation_counter_snapshot_buffer) {
+        xfb_emulation_counter_snapshot_buffer =
+            CreateXfbStreamCounterSnapshotBuffer(device, memory_allocator);
+    }
+}
+
+void BufferCacheRuntime::SnapshotXfbEmulationCounter() {
+    if (xfb_emulation_counter_buffer == VK_NULL_HANDLE ||
+        !xfb_emulation_counter_snapshot_buffer) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB counter snapshot skipped: counter={} snapshot={}",
+                    xfb_emulation_counter_buffer != VK_NULL_HANDLE,
+                    static_cast<bool>(xfb_emulation_counter_snapshot_buffer));
+        return;
+    }
+    static constexpr VkMemoryBarrier READ_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    static constexpr VkMemoryBarrier WRITE_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    scheduler.RequestOutsideRenderPassOperationContext();
+    scheduler.Record([src_buffer = xfb_emulation_counter_buffer,
+                      dst_buffer = *xfb_emulation_counter_snapshot_buffer](vk::CommandBuffer cmdbuf) {
+        cmdbuf.PipelineBarrier(XfbEmulationWriteStages(), VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                               READ_BARRIER);
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = 0,
+            .dstOffset = 0,
+            .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        }};
+        cmdbuf.CopyBuffer(src_buffer, dst_buffer, copy);
+        cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
+                               WRITE_BARRIER);
+    });
+}
+
+u32 BufferCacheRuntime::ReadXfbEmulationCounterSnapshotRecords() {
+    const VkBuffer snapshot_buffer = GetXfbEmulationCounterSnapshotBuffer();
+    if (snapshot_buffer == VK_NULL_HANDLE) {
+        return 0;
+    }
+    const StagingBufferRef counter_staging =
+        staging_pool.Request(sizeof(u32), MemoryUsage::Download, true);
+    scheduler.Finish();
+    scheduler.Record([snapshot_buffer, counter_staging](vk::CommandBuffer cmdbuf) {
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = 0,
+            .dstOffset = counter_staging.offset,
+            .size = sizeof(u32),
+        }};
+        cmdbuf.CopyBuffer(snapshot_buffer, counter_staging.buffer, copy);
+    });
+    scheduler.Finish();
+    u32 records = 0;
+    std::memcpy(&records, counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+    StagingBufferRef counter_staging_ref = counter_staging;
+    staging_pool.FreeDeferred(counter_staging_ref);
+    return records;
+}
+
+void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buffer,
+                                                      u32 guest_counter_offset, u32 stride,
+                                                      u32 register_byte_fallback) {
+    const VkBuffer snapshot_buffer = GetXfbEmulationCounterSnapshotBuffer();
+    const VkBuffer counter_buffer =
+        snapshot_buffer != VK_NULL_HANDLE ? snapshot_buffer : xfb_emulation_counter_buffer;
+    const u32 safe_stride = std::max(stride, 1u);
+    const u32 register_vertex_count = register_byte_fallback / safe_stride;
+
+    LOG_INFO(Render_Vulkan,
+             "XFB DrawIndirectByteCount: stride={} register_byte_count={} "
+             "register_vertex_count={} has_snapshot={} has_counter={}",
+             stride, register_byte_fallback, register_vertex_count,
+             snapshot_buffer != VK_NULL_HANDLE, counter_buffer != VK_NULL_HANDLE);
+
+    if (counter_buffer == VK_NULL_HANDLE) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB DrawIndirectByteCount: no counter buffer; skipping draw");
+        return;
+    }
+    if (!xfb_byte_count_draw_buffer) {
+        xfb_byte_count_draw_buffer =
+            CreateXfbByteCountDrawBuffer(device, memory_allocator, staging_pool, scheduler);
+    }
+
+    u32 snapshot_records = 0;
+    if (snapshot_buffer != VK_NULL_HANDLE) {
+        const StagingBufferRef counter_staging =
+            staging_pool.Request(sizeof(u32), MemoryUsage::Download, true);
+        scheduler.Finish();
+        scheduler.Record([snapshot_buffer, counter_staging](vk::CommandBuffer cmdbuf) {
+            std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+                .srcOffset = 0,
+                .dstOffset = counter_staging.offset,
+                .size = sizeof(u32),
+            }};
+            cmdbuf.CopyBuffer(snapshot_buffer, counter_staging.buffer, copy);
+        });
+        scheduler.Finish();
+        std::memcpy(&snapshot_records,
+                    counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+        StagingBufferRef counter_staging_ref = counter_staging;
+        staging_pool.FreeDeferred(counter_staging_ref);
+    }
+
+    // Counter snapshot stores emitted records (vertices). Prefer it over the register fallback,
+    // which may still be zero when the game expects the counter buffer to be authoritative.
+    u32 vertex_count = snapshot_records > 0 ? snapshot_records : register_vertex_count;
+    LOG_INFO(Render_Vulkan,
+             "XFB DrawIndirectByteCount: snapshot_records={} vertex_count={} "
+             "(source={})",
+             snapshot_records, vertex_count,
+             snapshot_records > 0 ? "snapshot" : "register");
+    if (vertex_count == 0) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB DrawIndirectByteCount: vertex_count=0; consume draw will be empty");
+    }
+    const StagingBufferRef draw_staging =
+        staging_pool.Request(sizeof(VkDrawIndirectCommand), MemoryUsage::Upload, true);
+    const VkDrawIndirectCommand draw_cmd{
+        .vertexCount = vertex_count,
+        .instanceCount = 1,
+        .firstVertex = 0,
+        .firstInstance = 0,
+    };
+    std::memcpy(draw_staging.mapped_span.data(), &draw_cmd, sizeof(draw_cmd));
+    static constexpr VkMemoryBarrier READ_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    static constexpr VkMemoryBarrier DRAW_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
+    };
+    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.Record([counter_buffer, draw_buffer = *xfb_byte_count_draw_buffer, draw_staging,
+                      guest_counter_buffer, guest_counter_offset](vk::CommandBuffer cmdbuf) {
+        cmdbuf.PipelineBarrier(XfbEmulationWriteStages() | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
+        std::array<VkBufferCopy, 1> draw_copy{VkBufferCopy{
+            .srcOffset = draw_staging.offset,
+            .dstOffset = 0,
+            .size = sizeof(VkDrawIndirectCommand),
+        }};
+        cmdbuf.CopyBuffer(draw_staging.buffer, draw_buffer, draw_copy);
+        if (guest_counter_buffer != VK_NULL_HANDLE) {
+            std::array<VkBufferCopy, 1> guest_records_copy{VkBufferCopy{
+                .srcOffset = 0,
+                .dstOffset = guest_counter_offset,
+                .size = sizeof(u32),
+            }};
+            cmdbuf.CopyBuffer(counter_buffer, guest_counter_buffer, guest_records_copy);
+        }
+        cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
+                                   VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
+                               0, DRAW_BARRIER);
+        cmdbuf.DrawIndirect(draw_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
+    });
+    StagingBufferRef draw_staging_ref = draw_staging;
+    staging_pool.FreeDeferred(draw_staging_ref);
+}
 
 void BufferCacheRuntime::CleanupUnusedBuffers() {
     // Cleanup is now handled by the VRAM management system (gc_aggressiveness setting)
@@ -100,6 +356,13 @@ Buffer::Buffer(BufferCacheRuntime& runtime, VideoCommon::NullBufferParams null_p
     buffer = runtime.CreateNullBuffer();
     is_null = true;
 }
+
+Buffer::Buffer(BufferCacheRuntime& runtime, VideoCommon::XfbStreamCounterBufferParams)
+    : VideoCommon::BufferBase(VideoCommon::XFB_EMULATION_COUNTER_DEVICE_ADDR,
+                              VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES),
+      device{&runtime.device},
+      buffer{CreateXfbStreamCounterBuffer(*device, runtime.memory_allocator)},
+      tracker{VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES} {}
 
 Buffer::Buffer(BufferCacheRuntime& runtime, DAddr cpu_addr_, u64 size_bytes_)
     : VideoCommon::BufferBase(cpu_addr_, size_bytes_), device{&runtime.device},
@@ -549,15 +812,20 @@ void BufferCacheRuntime::BindQuadIndexBuffer(PrimitiveTopology topology, u32 fir
 
 void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size,
                                           u32 stride) {
-    if (index >= device.GetMaxVertexInputBindings()) {
+    u32 vk_index = index;
+    if (vertex_binding_remap != nullptr && vertex_binding_remap->remapped_vertex_bindings &&
+        index < vertex_binding_remap->vertex_bindings.size()) {
+        vk_index = vertex_binding_remap->vertex_bindings[index];
+    }
+    if (vk_index >= device.GetMaxVertexInputBindings()) {
         return;
     }
     if (device.IsExtExtendedDynamicStateSupported()) {
-        scheduler.Record([index, buffer, offset, size, stride](vk::CommandBuffer cmdbuf) {
+        scheduler.Record([binding = vk_index, buffer, offset, size, stride](vk::CommandBuffer cmdbuf) {
             const VkDeviceSize vk_offset = buffer != VK_NULL_HANDLE ? offset : 0;
             const VkDeviceSize vk_size = buffer != VK_NULL_HANDLE ? size : VK_WHOLE_SIZE;
             const VkDeviceSize vk_stride = stride;
-            cmdbuf.BindVertexBuffers2EXT(index, 1, &buffer, &vk_offset, &vk_size, &vk_stride);
+            cmdbuf.BindVertexBuffers2EXT(binding, 1, &buffer, &vk_offset, &vk_size, &vk_stride);
         });
     } else {
         if (!device.HasNullDescriptor() && buffer == VK_NULL_HANDLE) {
@@ -565,13 +833,55 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset
             buffer = *null_buffer;
             offset = 0;
         }
-        scheduler.Record([index, buffer, offset](vk::CommandBuffer cmdbuf) {
-            cmdbuf.BindVertexBuffer(index, buffer, offset);
+        scheduler.Record([binding = vk_index, buffer, offset](vk::CommandBuffer cmdbuf) {
+            cmdbuf.BindVertexBuffer(binding, buffer, offset);
         });
     }
 }
 
 void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
+    const u32 device_max = device.GetMaxVertexInputBindings();
+    const bool remapped = vertex_binding_remap != nullptr &&
+                          vertex_binding_remap->remapped_vertex_bindings;
+
+    if (remapped) {
+        for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+            const u32 guest_index = bindings.min_index + index;
+            u32 vk_index = guest_index;
+            if (guest_index < vertex_binding_remap->vertex_bindings.size()) {
+                vk_index = vertex_binding_remap->vertex_bindings[guest_index];
+            }
+            if (vk_index >= device_max) {
+                continue;
+            }
+            auto handle = bindings.buffers[index]->Handle();
+            u64 offset = bindings.offsets[index];
+            if (handle == VK_NULL_HANDLE) {
+                offset = 0;
+                if (!device.HasNullDescriptor()) {
+                    ReserveNullBuffer();
+                    handle = *null_buffer;
+                }
+            }
+            if (device.IsExtExtendedDynamicStateSupported()) {
+                const u64 size = bindings.sizes[index];
+                const u64 stride = bindings.strides[index];
+                scheduler.Record([vk_index, handle, offset, size, stride](vk::CommandBuffer cmdbuf) {
+                    const VkDeviceSize vk_offset = handle != VK_NULL_HANDLE ? offset : 0;
+                    const VkDeviceSize vk_size = handle != VK_NULL_HANDLE ? size : VK_WHOLE_SIZE;
+                    const VkDeviceSize vk_stride = stride;
+                    cmdbuf.BindVertexBuffers2EXT(vk_index, 1, &handle, &vk_offset, &vk_size,
+                                                 &vk_stride);
+                });
+            } else {
+                scheduler.Record([vk_index, handle, offset](vk::CommandBuffer cmdbuf) {
+                    cmdbuf.BindVertexBuffer(vk_index, handle, offset);
+                });
+            }
+        }
+        return;
+    }
+
     boost::container::small_vector<VkBuffer, 32> buffer_handles;
     for (u32 index = 0; index < bindings.buffers.size(); ++index) {
         auto handle = bindings.buffers[index]->Handle();
@@ -585,7 +895,6 @@ void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bi
         }
         buffer_handles.push_back(handle);
     }
-    const u32 device_max = device.GetMaxVertexInputBindings();
     const u32 min_binding = std::min(bindings.min_index, device_max);
     const u32 max_binding = std::min(bindings.max_index, device_max);
     const u32 binding_count = max_binding - min_binding;

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "shader_recompiler/runtime_info.h"
 #include "video_core/buffer_cache/buffer_cache_base.h"
 #include "video_core/buffer_cache/memory_tracker_base.h"
 #include "video_core/buffer_cache/usage_tracker.h"
@@ -26,6 +27,7 @@ class BufferCacheRuntime;
 class Buffer : public VideoCommon::BufferBase {
 public:
     explicit Buffer(BufferCacheRuntime&, VideoCommon::NullBufferParams null_params);
+    explicit Buffer(BufferCacheRuntime& runtime, VideoCommon::XfbStreamCounterBufferParams);
     explicit Buffer(BufferCacheRuntime& runtime, VAddr cpu_addr_, u64 size_bytes_);
 
     [[nodiscard]] VkBufferView View(u32 offset, u32 size, VideoCore::Surface::PixelFormat format);
@@ -122,6 +124,35 @@ public:
 
     void BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
+    void SetVertexBindingRemap(const Shader::RuntimeInfo* remap) {
+        vertex_binding_remap = remap;
+    }
+
+    void ClearVertexBindingRemap() {
+        vertex_binding_remap = nullptr;
+    }
+
+    void RegisterXfbEmulationCounterBuffer(VkBuffer buffer);
+
+    [[nodiscard]] VkBuffer GetXfbEmulationCounterBuffer() const {
+        return xfb_emulation_counter_buffer;
+    }
+
+    [[nodiscard]] VkBuffer GetXfbEmulationCounterSnapshotBuffer() const {
+        return xfb_emulation_counter_snapshot_buffer ? *xfb_emulation_counter_snapshot_buffer
+                                                     : VK_NULL_HANDLE;
+    }
+
+    /// Copy the live TF emulation counter after a draw so later query reads are not cleared away.
+    void SnapshotXfbEmulationCounter();
+
+    /// Read the latest emulated stream-out record count from the counter snapshot.
+    [[nodiscard]] u32 ReadXfbEmulationCounterSnapshotRecords();
+
+    /// Emulate VK_EXT_transform_feedback DrawIndirectByteCount using the emulated counter snapshot.
+    void EmulateDrawIndirectByteCount(VkBuffer guest_counter_buffer, u32 guest_counter_offset,
+                                      u32 stride, u32 register_byte_fallback);
+
     void BindTransformFeedbackBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size);
 
     void BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings);
@@ -168,6 +199,12 @@ private:
 
     std::unique_ptr<Uint8Pass> uint8_pass;
     QuadIndexedPass quad_index_pass;
+
+    const Shader::RuntimeInfo* vertex_binding_remap{};
+
+    VkBuffer xfb_emulation_counter_buffer{VK_NULL_HANDLE};
+    vk::Buffer xfb_emulation_counter_snapshot_buffer;
+    vk::Buffer xfb_byte_count_draw_buffer;
 };
 
 struct BufferCacheParams {
@@ -184,6 +221,7 @@ struct BufferCacheParams {
     static constexpr bool USE_MEMORY_MAPS = true;
     static constexpr bool SEPARATE_IMAGE_BUFFER_BINDINGS = false;
     static constexpr bool USE_MEMORY_MAPS_FOR_UPLOADS = true;
+    static constexpr bool HAS_XFB_STREAM_COUNTER_HOST_BUFFER = true;
 };
 
 using BufferCache = VideoCommon::BufferCache<BufferCacheParams>;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -742,6 +742,9 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             if (!IsVertexAttributeMapped(vertex_input_remap, index)) {
                 continue;
             }
+            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+                continue;
+            }
             if (!IsVertexBindingMapped(vertex_input_remap, attribute.buffer)) {
                 continue;
             }
@@ -751,9 +754,6 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             const u32 location = VulkanVertexLocation(vertex_input_remap, index);
             const u32 binding = VulkanVertexBinding(vertex_input_remap, attribute.buffer);
             if (location >= max_vertex_attrs || binding >= max_vertex_bindings) {
-                continue;
-            }
-            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
                 continue;
             }
             if (vertex_attributes.size() >= max_vertex_attrs) {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -21,6 +21,7 @@
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_texture_cache.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/renderer_vulkan/vertex_location_remap.h"
 #include "video_core/shader_notify.h"
 #include "video_core/texture_cache/texture_cache.h"
 #include "video_core/vulkan_common/vulkan_device.h"
@@ -265,6 +266,16 @@ GraphicsPipeline::GraphicsPipeline(
         std::ranges::copy(info->constant_buffer_used_sizes, uniform_buffer_sizes[stage].begin());
         num_textures += Shader::NumDescriptors(info->texture_descriptors);
     }
+    const bool needs_vertex_location_remap =
+        device.GetMaxVertexInputAttributes() <
+        Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes;
+    const bool needs_vertex_binding_remap =
+        device.GetMaxVertexInputBindings() <
+        Tegra::Engines::Maxwell3D::Regs::NumVertexArrays;
+    if (needs_vertex_location_remap || needs_vertex_binding_remap) {
+        PopulateVertexLocationRemap(vertex_input_remap, device.GetMaxVertexInputAttributes(),
+                                    device.GetMaxVertexInputBindings(), key.state, stage_infos[0]);
+    }
     auto func{[this, shader_notify, &render_pass_cache, &descriptor_pool, pipeline_statistics] {
         DescriptorLayoutBuilder builder{MakeBuilder(device, stage_infos)};
         split_descriptor_sets = builder.IsSplit();
@@ -324,11 +335,11 @@ template <typename Spec>
 void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
     // std::array<T, 16384> made CheckFeedbackLoop iterate the full capacity
     // per draw; small_vector lets the span size match the actual write count.
-    thread_local boost::container::small_vector<VideoCommon::ImageViewInOut, 64> views;
-    thread_local boost::container::small_vector<VideoCommon::SamplerId, 64> samplers;
-    thread_local BindlessCache bindless_cache;
-    thread_local size_t bindless_cache_rr{0};
-    thread_local std::vector<u8> bindless_scratch;
+    boost::container::small_vector<VideoCommon::ImageViewInOut, 64> views;
+    boost::container::small_vector<VideoCommon::SamplerId, 64> samplers;
+    BindlessCache bindless_cache;
+    size_t bindless_cache_rr{0};
+    std::vector<u8> bindless_scratch;
     views.clear();
     samplers.clear();
 
@@ -546,7 +557,16 @@ void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
     }
 
     buffer_cache.UpdateGraphicsBuffers(is_indexed);
+    if (vertex_input_remap.remapped_vertex_bindings) {
+        buffer_cache.runtime.SetVertexBindingRemap(&vertex_input_remap);
+    }
+    if (key.state.xfb_emulated != 0 && !device.IsExtTransformFeedbackSupported()) {
+        buffer_cache.ClearXfbStreamCounterForDraw();
+    }
     buffer_cache.BindHostGeometryBuffers(is_indexed);
+    if (vertex_input_remap.remapped_vertex_bindings) {
+        buffer_cache.runtime.ClearVertexBindingRemap();
+    }
 
     guest_descriptor_queue.Acquire();
 
@@ -685,21 +705,32 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
     boost::container::static_vector<VkVertexInputBindingDivisorDescriptionEXT, 32> vertex_binding_divisors;
     boost::container::static_vector<VkVertexInputAttributeDescription, 32> vertex_attributes;
     if (!key.state.dynamic_vertex_input) {
-        const size_t num_vertex_arrays = std::min(
-            Tegra::Engines::Maxwell3D::Regs::NumVertexArrays, static_cast<size_t>(device.GetMaxVertexInputBindings()));
-        for (size_t index = 0; index < num_vertex_arrays; ++index) {
-            const bool instanced = key.state.binding_divisors[index] != 0;
+        const u32 max_vertex_attrs = device.GetMaxVertexInputAttributes();
+        const u32 max_vertex_bindings = device.GetMaxVertexInputBindings();
+        for (size_t guest = 0; guest < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays; ++guest) {
+            if (!IsVertexBindingUsedByMappedAttributes(static_cast<u32>(guest), key.state,
+                                                       stage_infos[0], vertex_input_remap)) {
+                continue;
+            }
+            if (!IsVertexBindingMapped(vertex_input_remap, static_cast<u32>(guest))) {
+                continue;
+            }
+            const u32 vk_binding = VulkanVertexBinding(vertex_input_remap, static_cast<u32>(guest));
+            if (vk_binding >= max_vertex_bindings) {
+                continue;
+            }
+            const bool instanced = key.state.binding_divisors[guest] != 0;
             const auto rate =
                 instanced ? VK_VERTEX_INPUT_RATE_INSTANCE : VK_VERTEX_INPUT_RATE_VERTEX;
             vertex_bindings.push_back({
-                .binding = static_cast<u32>(index),
-                .stride = key.state.vertex_strides[index],
+                .binding = vk_binding,
+                .stride = key.state.vertex_strides[guest],
                 .inputRate = rate,
             });
             if (instanced) {
                 vertex_binding_divisors.push_back({
-                    .binding = static_cast<u32>(index),
-                    .divisor = key.state.binding_divisors[index],
+                    .binding = vk_binding,
+                    .divisor = key.state.binding_divisors[guest],
                 });
             }
         }
@@ -708,13 +739,40 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             if (!attribute.enabled || !stage_infos[0].loads.Generic(index)) {
                 continue;
             }
+            if (!IsVertexAttributeMapped(vertex_input_remap, index)) {
+                continue;
+            }
+            if (!IsVertexBindingMapped(vertex_input_remap, attribute.buffer)) {
+                continue;
+            }
+            if (index >= max_vertex_attrs && !vertex_input_remap.remapped_vertex_locations) {
+                break;
+            }
+            const u32 location = VulkanVertexLocation(vertex_input_remap, index);
+            const u32 binding = VulkanVertexBinding(vertex_input_remap, attribute.buffer);
+            if (location >= max_vertex_attrs || binding >= max_vertex_bindings) {
+                continue;
+            }
+            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+                continue;
+            }
+            if (vertex_attributes.size() >= max_vertex_attrs) {
+                break;
+            }
             vertex_attributes.push_back({
-                .location = static_cast<u32>(index),
-                .binding = attribute.buffer,
+                .location = location,
+                .binding = binding,
                 .format = MaxwellToVK::VertexFormat(device, attribute.Type(), attribute.Size()),
                 .offset = attribute.offset,
             });
         }
+    }
+    const u32 max_vertex_attrs = device.GetMaxVertexInputAttributes();
+    if (vertex_attributes.size() > max_vertex_attrs) {
+        LOG_ERROR(Render_Vulkan,
+                  "Graphics pipeline uses {} vertex attributes but the Vulkan device reports a "
+                  "maximum of {}; draws may fault (common on MoltenVK).",
+                  vertex_attributes.size(), max_vertex_attrs);
     }
     ASSERT(vertex_attributes.size() <= device.GetMaxVertexInputAttributes());
 
@@ -758,6 +816,9 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
         SupportsPrimitiveRestart(input_assembly_topology) ||
         (input_assembly_topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
          device.IsPatchListPrimitiveRestartSupported());
+    // Metal always applies primitive restart for strip/fan topologies; MoltenVK cannot implement
+    // vkCmdSetPrimitiveRestartEnableEXT(VK_FALSE) (VK_ERROR_FEATURE_NOT_PRESENT). Force restart in
+    // the pipeline for those topologies and omit dynamic toggle (see vk_rasterizer.cpp).
     const bool force_mvk_primitive_restart =
         device.GetDriverID() == VK_DRIVER_ID_MOLTENVK &&
         SupportsPrimitiveRestart(input_assembly_topology);

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -249,7 +249,8 @@ GraphicsPipeline::GraphicsPipeline(
     GuestDescriptorQueue& guest_descriptor_queue_, Common::ThreadWorker* worker_thread,
     PipelineStatistics* pipeline_statistics, RenderPassCache& render_pass_cache,
     const GraphicsPipelineCacheKey& key_, std::array<vk::ShaderModule, NUM_STAGES> stages,
-    const std::array<const Shader::Info*, NUM_STAGES>& infos)
+    const std::array<const Shader::Info*, NUM_STAGES>& infos,
+    std::optional<Shader::RuntimeInfo> compiled_vertex_remap)
     : key{key_}, device{device_}, texture_cache{texture_cache_}, buffer_cache{buffer_cache_},
       pipeline_cache(pipeline_cache_), scheduler{scheduler_},
       guest_descriptor_queue{guest_descriptor_queue_}, spv_modules{std::move(stages)} {
@@ -272,7 +273,14 @@ GraphicsPipeline::GraphicsPipeline(
     const bool needs_vertex_binding_remap =
         device.GetMaxVertexInputBindings() <
         Tegra::Engines::Maxwell3D::Regs::NumVertexArrays;
-    if (needs_vertex_location_remap || needs_vertex_binding_remap) {
+    if (compiled_vertex_remap) {
+        vertex_input_remap.vertex_locations = compiled_vertex_remap->vertex_locations;
+        vertex_input_remap.vertex_bindings = compiled_vertex_remap->vertex_bindings;
+        vertex_input_remap.remapped_vertex_locations =
+            compiled_vertex_remap->remapped_vertex_locations;
+        vertex_input_remap.remapped_vertex_bindings =
+            compiled_vertex_remap->remapped_vertex_bindings;
+    } else if (needs_vertex_location_remap || needs_vertex_binding_remap) {
         PopulateVertexLocationRemap(vertex_input_remap, device.GetMaxVertexInputAttributes(),
                                     device.GetMaxVertexInputBindings(), key.state, stage_infos[0]);
     }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <type_traits>
 
 #include "common/thread_worker.h"
@@ -77,7 +78,8 @@ public:
         GuestDescriptorQueue& guest_descriptor_queue, Common::ThreadWorker* worker_thread,
         PipelineStatistics* pipeline_statistics, RenderPassCache& render_pass_cache,
         const GraphicsPipelineCacheKey& key, std::array<vk::ShaderModule, NUM_STAGES> stages,
-        const std::array<const Shader::Info*, NUM_STAGES>& infos);
+        const std::array<const Shader::Info*, NUM_STAGES>& infos,
+        std::optional<Shader::RuntimeInfo> compiled_vertex_remap = std::nullopt);
 
     GraphicsPipeline& operator=(GraphicsPipeline&&) noexcept = delete;
     GraphicsPipeline(GraphicsPipeline&&) noexcept = delete;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -12,6 +12,7 @@
 
 #include "common/thread_worker.h"
 #include "shader_recompiler/shader_info.h"
+#include "shader_recompiler/runtime_info.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_vulkan/fixed_pipeline_state.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
@@ -113,6 +114,14 @@ public:
         gpu_memory = gpu_memory_;
     }
 
+    [[nodiscard]] const Shader::RuntimeInfo& VertexInputRemap() const noexcept {
+        return vertex_input_remap;
+    }
+
+    [[nodiscard]] bool UsesEmulatedTransformFeedback() const noexcept {
+        return key.state.xfb_emulated != 0;
+    }
+
 private:
     template <typename Spec>
     void ConfigureImpl(bool is_indexed);
@@ -142,6 +151,7 @@ private:
     std::array<vk::ShaderModule, NUM_STAGES> spv_modules;
 
     std::array<Shader::Info, NUM_STAGES> stage_infos;
+    Shader::RuntimeInfo vertex_input_remap{};
     std::array<u32, 5> enabled_uniform_buffer_masks{};
     VideoCommon::UniformBufferSizes uniform_buffer_sizes{};
     u32 num_textures{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -278,8 +278,10 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             ASSERT(false);
             return Shader::TessSpacing::Equal;
         }();
-        if (guest_has_geometry_shader && !geometry_supported) {
-            PopulateXfbRuntimeInfo(info, key);
+        if (!has_geometry) {
+            if (guest_has_geometry_shader && !geometry_supported) {
+                PopulateXfbRuntimeInfo(info, key);
+            }
             info.convert_depth_mode = gl_ndc;
         }
         break;
@@ -344,7 +346,8 @@ void PropagateSkippedGeometryStores(Shader::IR::Program& program,
     if (skipped_geometry_program == nullptr) {
         return;
     }
-    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB) {
+    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB &&
+        program.stage != Shader::Stage::TessellationEval) {
         return;
     }
     if (skipped_geometry_program->is_geometry_passthrough) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -924,6 +924,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     std::array<vk::ShaderModule, Tegra::Engines::Maxwell3D::Regs::MaxShaderStage> modules;
 
     const Shader::IR::Program* previous_stage{};
+    std::optional<Shader::RuntimeInfo> compiled_vertex_remap;
     Shader::Backend::Bindings binding;
     const bool has_geometry_stage =
         geometry_supported && guest_has_geometry_shader &&
@@ -954,6 +955,9 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
             programs, key, program, previous_stage, skipped_geometry_program, has_geometry_stage,
             guest_has_geometry_shader, geometry_supported, uses_tessellation, max_vertex_attributes,
             max_vertex_bindings)};
+        if (program.stage == Shader::Stage::VertexB) {
+            compiled_vertex_remap = runtime_info;
+        }
         if (key.state.xfb_enabled != 0 && runtime_info.xfb_count > 0) {
             LOG_INFO(Render_Vulkan,
                      "Pipeline 0x{:016x} stage={} xfb_count={} xfb_emulated={} gs={} tess={}",
@@ -976,7 +980,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     return std::make_unique<GraphicsPipeline>(
         scheduler, buffer_cache, texture_cache, vulkan_pipeline_cache, &shader_notify, device,
         descriptor_pool, guest_descriptor_queue, thread_worker, statistics, render_pass_cache, key,
-        std::move(modules), infos);
+        std::move(modules), infos, std::move(compiled_vertex_remap));
 
 } catch (const vk::Exception& exception) {
     if (exception.GetResult() == VK_ERROR_OUT_OF_DEVICE_MEMORY) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -34,6 +34,7 @@
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_util.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/renderer_vulkan/vertex_location_remap.h"
 #include "video_core/shader_cache.h"
 #include "video_core/shader_environment.h"
 #include "video_core/shader_notify.h"
@@ -54,7 +55,7 @@ using VideoCommon::FileEnvironment;
 using VideoCommon::GenericEnvironment;
 using VideoCommon::GraphicsEnvironment;
 
-constexpr u32 CACHE_VERSION = 14;
+constexpr u32 CACHE_VERSION = 24;
 constexpr std::array<char, 8> VULKAN_CACHE_MAGIC_NUMBER{'y', 'u', 'z', 'u', 'v', 'k', 'c', 'h'};
 
 template <typename Container>
@@ -159,35 +160,69 @@ Shader::FragmentOutputType GetFragmentOutputType(u8 encoded_format) {
                : Shader::FragmentOutputType::UnsignedInt;
 }
 
+void PopulateXfbRuntimeInfo(Shader::RuntimeInfo& info, const GraphicsPipelineCacheKey& key) {
+    if (key.state.xfb_enabled == 0) {
+        return;
+    }
+    auto [varyings, count] = VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
+    info.xfb_varyings = varyings;
+    info.xfb_count = count;
+    for (size_t i = 0; i < info.xfb_buffer_bytes.size(); ++i) {
+        const s32 size = key.state.xfb_state.buffer_sizes[i];
+        info.xfb_buffer_bytes[i] = size > 0 ? static_cast<u32>(size) : 0U;
+    }
+}
+
 Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> programs,
                                     const GraphicsPipelineCacheKey& key,
                                     const Shader::IR::Program& program,
-                                    const Shader::IR::Program* previous_program) {
+                                    const Shader::IR::Program* previous_program,
+                                    const Shader::IR::Program* skipped_geometry_program,
+                                    bool has_geometry_stage, bool guest_has_geometry_shader,
+                                    bool geometry_supported, bool uses_tessellation,
+                                    u32 max_vertex_attributes, u32 max_vertex_bindings) {
     Shader::RuntimeInfo info;
     if (previous_program) {
-        info.previous_stage_stores = previous_program->info.stores;
-        info.previous_stage_legacy_stores_mapping = previous_program->info.legacy_stores_mapping;
-        if (previous_program->is_geometry_passthrough) {
-            info.previous_stage_stores.mask |= previous_program->info.passthrough.mask;
+        const bool link_through_skipped_geometry = skipped_geometry_program != nullptr &&
+                                                   !geometry_supported &&
+                                                   program.stage == Shader::Stage::Fragment;
+        if (link_through_skipped_geometry) {
+            if (skipped_geometry_program->is_geometry_passthrough) {
+                info.previous_stage_stores = previous_program->info.stores;
+                info.previous_stage_legacy_stores_mapping =
+                    previous_program->info.legacy_stores_mapping;
+                info.previous_stage_stores.mask |= skipped_geometry_program->info.passthrough.mask;
+            } else {
+                info.previous_stage_stores = skipped_geometry_program->info.stores;
+                info.previous_stage_legacy_stores_mapping =
+                    skipped_geometry_program->info.legacy_stores_mapping;
+            }
+        } else {
+            info.previous_stage_stores = previous_program->info.stores;
+            info.previous_stage_legacy_stores_mapping = previous_program->info.legacy_stores_mapping;
+            if (previous_program->is_geometry_passthrough) {
+                info.previous_stage_stores.mask |= previous_program->info.passthrough.mask;
+            }
         }
     } else {
         info.previous_stage_stores.mask.set();
     }
     const Shader::Stage stage{program.stage};
-    const bool has_geometry{key.unique_hashes[4] != 0 && !programs[4].is_geometry_passthrough};
+    const bool has_geometry{has_geometry_stage};
     const bool gl_ndc{key.state.ndc_minus_one_to_one != 0};
     const float point_size{Common::BitCast<float>(key.state.point_size)};
     switch (stage) {
-    case Shader::Stage::VertexB:
+    case Shader::Stage::VertexB: {
+        std::ranges::fill(info.generic_input_types, Shader::AttributeType::Disabled);
         if (!has_geometry) {
             if (key.state.topology == Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology::Points) {
                 info.fixed_state_point_size = point_size;
             }
-            if (key.state.xfb_enabled) {
-                auto [varyings, count] =
-                    VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
-                info.xfb_varyings = varyings;
-                info.xfb_count = count;
+            // When the guest binds a geometry shader but the host cannot run one, stream-out
+            // emulation must run on the last stage before the skipped geometry stage.
+            const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
+            if (!guest_has_geometry_shader || (guest_gs_skipped && !uses_tessellation)) {
+                PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
         }
@@ -197,10 +232,24 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
                 info.generic_input_types[index] = AttributeType(key.state, index);
             }
         } else {
-            std::ranges::transform(key.state.attributes, info.generic_input_types.begin(),
-                                   &CastAttributeType);
+            for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes;
+                 ++index) {
+                info.generic_input_types[index] =
+                    CastAttributeType(key.state.attributes[index]);
+            }
+        }
+        if (max_vertex_attributes < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes ||
+            max_vertex_bindings < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+            PopulateVertexLocationRemap(info, max_vertex_attributes, max_vertex_bindings, key.state,
+                                        program.info);
+            for (size_t index = 0; index < info.vertex_locations.size(); ++index) {
+                if (info.vertex_locations[index] == Shader::VERTEX_INPUT_DROPPED) {
+                    info.generic_input_types[index] = Shader::AttributeType::Disabled;
+                }
+            }
         }
         break;
+    }
     case Shader::Stage::TessellationEval:
         info.tess_clockwise = key.state.tessellation_clockwise != 0;
         info.tess_primitive = [&key] {
@@ -229,16 +278,17 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             ASSERT(false);
             return Shader::TessSpacing::Equal;
         }();
+        if (guest_has_geometry_shader && !geometry_supported) {
+            PopulateXfbRuntimeInfo(info, key);
+            info.convert_depth_mode = gl_ndc;
+        }
         break;
     case Shader::Stage::Geometry:
         if (program.output_topology == Shader::OutputTopology::PointList) {
             info.fixed_state_point_size = point_size;
         }
-        if (key.state.xfb_enabled != 0) {
-            auto [varyings, count] =
-                VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
-            info.xfb_varyings = varyings;
-            info.xfb_count = count;
+        if (geometry_supported) {
+            PopulateXfbRuntimeInfo(info, key);
         }
         info.convert_depth_mode = gl_ndc;
         break;
@@ -285,7 +335,23 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
     }
     info.force_early_z = key.state.early_z != 0;
     info.y_negate = key.state.y_negate != 0;
+    info.emulate_transform_feedback = key.state.xfb_emulated != 0;
     return info;
+}
+
+void PropagateSkippedGeometryStores(Shader::IR::Program& program,
+                                    const Shader::IR::Program* skipped_geometry_program) {
+    if (skipped_geometry_program == nullptr) {
+        return;
+    }
+    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB) {
+        return;
+    }
+    if (skipped_geometry_program->is_geometry_passthrough) {
+        program.info.stores.mask |= skipped_geometry_program->info.passthrough.mask;
+    } else {
+        program.info.stores.mask |= skipped_geometry_program->info.stores.mask;
+    }
 }
 
 size_t GetTotalPipelineWorkers() {
@@ -340,6 +406,12 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
       serialization_thread(1, "VkPipelineSerialization") {
     const auto& float_control{device.FloatControlProperties()};
     const VkDriverId driver_id{device.GetDriverID()};
+    if (driver_id == VK_DRIVER_ID_MOLTENVK && use_asynchronous_shaders) {
+        LOG_INFO(Render_Vulkan,
+                 "Disabling asynchronous shaders on MoltenVK to avoid prolonged black frames "
+                 "while graphics pipelines compile");
+        use_asynchronous_shaders = false;
+    }
     // OPTIMIZED FOR LOW GPU ACCURACY - enable mediump in fragment shaders for better perf
     const bool low_gpu_accuracy = Settings::IsGPULevelLow();
 
@@ -393,11 +465,12 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
                                        driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE ||
                                        driver_id == VK_DRIVER_ID_MESA_RADV ||
                                        driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS ||
-                                       driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA,
+                                       driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA ||
+                                       driver_id == VK_DRIVER_ID_MOLTENVK,
 
         .has_broken_spirv_clamp = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS,
         .has_broken_spirv_position_input = driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY,
-        .has_broken_unsigned_image_offsets = false,
+        .has_broken_unsigned_image_offsets = driver_id == VK_DRIVER_ID_MOLTENVK,
         .has_broken_signed_operations = false,
         .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY,
         .ignore_nan_fp_comparisons = false,
@@ -452,6 +525,7 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
             allow_eds3 && device.IsExtExtendedDynamicState3EnablesSupported(),
         .has_dynamic_vertex_input = allow_eds3 && device.IsExtVertexInputDynamicStateSupported(),
         .has_transform_feedback = device.IsExtTransformFeedbackSupported(),
+        .emulate_transform_feedback = !device.IsExtTransformFeedbackSupported(),
     };
 }
 
@@ -602,6 +676,9 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
     const auto load_compute{[&](std::ifstream& file, FileEnvironment env) {
         ComputePipelineCacheKey key;
         file.read(reinterpret_cast<char*>(&key), sizeof(key));
+        if (file.gcount() != static_cast<std::streamsize>(sizeof(key))) {
+            throw std::ios_base::failure("truncated compute pipeline key");
+        }
 
         workers.QueueWork([this, key, env_ = std::move(env), &state, &callback]() mutable {
             ShaderPools pools;
@@ -622,7 +699,12 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
     const auto load_graphics{[&](std::ifstream& file, std::vector<FileEnvironment> envs) {
         GraphicsPipelineCacheKey key;
         file.read(reinterpret_cast<char*>(&key), sizeof(key));
+        if (file.gcount() != static_cast<std::streamsize>(sizeof(key))) {
+            throw std::ios_base::failure("truncated graphics pipeline key");
+        }
 
+        const bool host_xfb = dynamic_features.has_transform_feedback ||
+                              dynamic_features.emulate_transform_feedback;
         if ((key.state.extended_dynamic_state != 0) !=
                 dynamic_features.has_extended_dynamic_state ||
             (key.state.extended_dynamic_state_2 != 0) !=
@@ -634,13 +716,32 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
             (key.state.extended_dynamic_state_3_enables != 0) !=
                 dynamic_features.has_extended_dynamic_state_3_enables ||
             (key.state.dynamic_vertex_input != 0) != dynamic_features.has_dynamic_vertex_input ||
-            (key.state.xfb_enabled != 0 && !dynamic_features.has_transform_feedback)) {
+            (key.state.xfb_enabled != 0 && !host_xfb)) {
             // NOTE: xfb_enabled uses a unidirectional check. It encodes both a
             // device capability AND per-pipeline runtime state. We only reject
             // the pipeline if it actively requires XFB but the host device
             // does not support it
             LOG_WARNING(Render_Vulkan, "Skipping cached graphics pipeline: EDS feature mismatch");
             return;
+        }
+        {
+            const bool skip_xfb_pipeline = [&] {
+                if (key.state.xfb_enabled == 0) {
+                    return false;
+                }
+                if (!host_xfb) {
+                    return true;
+                }
+                return (key.state.xfb_emulated != 0) != dynamic_features.emulate_transform_feedback;
+            }();
+            if (skip_xfb_pipeline) {
+                LOG_WARNING(Render_Vulkan,
+                            "Skipping cached XFB pipeline 0x{:016x}: cached xfb_emulated={} host "
+                            "emulate={}",
+                            key.Hash(), key.state.xfb_emulated != 0,
+                            dynamic_features.emulate_transform_feedback);
+                return;
+            }
         }
         workers.QueueWork([this, key, envs_ = std::move(envs), &state, &callback]() mutable {
             ShaderPools pools;
@@ -741,9 +842,20 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     std::array<Shader::IR::Program, Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram> programs;
     const bool uses_vertex_a{key.unique_hashes[0] != 0};
     const bool uses_vertex_b{key.unique_hashes[1] != 0};
+    const size_t geometry_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+    const size_t tess_init_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::TessellationInit);
+    const size_t tess_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::Tessellation);
+    const bool geometry_supported = device.IsGeometryShaderSupported();
+    const bool guest_has_geometry_shader = key.unique_hashes[geometry_stage_index] != 0;
+    const bool uses_tessellation = key.unique_hashes[tess_init_stage_index] != 0 ||
+                                   key.unique_hashes[tess_stage_index] != 0;
 
     // Layer passthrough generation for devices without VK_EXT_shader_viewport_index_layer
     Shader::IR::Program* layer_source_program{};
+    const Shader::IR::Program* skipped_geometry_program{};
 
     for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
         const bool is_emulated_stage =
@@ -753,6 +865,28 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
             auto topology = MaxwellToOutputTopology(key.state.topology);
             programs[index] = GenerateGeometryPassthrough(pools.inst, pools.block, host_info,
                                                           *layer_source_program, topology);
+            continue;
+        }
+        if (index == geometry_stage_index && !geometry_supported) {
+            if (key.unique_hashes[index] != 0) {
+                Shader::Environment& env{*envs[env_index]};
+                ++env_index;
+
+                const u32 cfg_offset{
+                    static_cast<u32>(env.StartAddress() + sizeof(Shader::ProgramHeader))};
+                Shader::Maxwell::Flow::CFG cfg(env, pools.flow_block, cfg_offset, index == 0);
+                programs[index] =
+                    TranslateProgram(pools.inst, pools.block, env, cfg, host_info);
+                skipped_geometry_program = &programs[index];
+
+                if (Settings::values.dump_shaders) {
+                    env.Dump(hash, key.unique_hashes[index]);
+                }
+
+                LOG_INFO(Render_Vulkan,
+                         "Translated skipped guest geometry shader {:016x} (passthrough={})",
+                         key.unique_hashes[index], programs[index].is_geometry_passthrough);
+            }
             continue;
         }
         if (key.unique_hashes[index] == 0) {
@@ -786,11 +920,23 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
 
     const Shader::IR::Program* previous_stage{};
     Shader::Backend::Bindings binding;
-    for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0;
-         index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
-        const bool is_emulated_stage =
-            layer_source_program != nullptr &&
-            index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+    const bool has_geometry_stage =
+        geometry_supported && guest_has_geometry_shader &&
+        !programs[geometry_stage_index].is_geometry_passthrough;
+    const u32 max_vertex_attributes = device.GetMaxVertexInputAttributes();
+    const u32 max_vertex_bindings = device.GetMaxVertexInputBindings();
+    for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram;
+         ++index) {
+        if (index == geometry_stage_index && !geometry_supported) {
+            const bool is_emulated_stage = layer_source_program != nullptr &&
+                                           index == static_cast<u32>(
+                                               Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+            if (!is_emulated_stage) {
+                continue;
+            }
+        }
+        const bool is_emulated_stage = layer_source_program != nullptr &&
+                                       index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && !is_emulated_stage) {
             continue;
         }
@@ -800,7 +946,20 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
         const size_t stage_index{index - 1};
         infos[stage_index] = &program.info;
 
-        const auto runtime_info{MakeRuntimeInfo(programs, key, program, previous_stage)};
+        if (!geometry_supported && skipped_geometry_program != nullptr) {
+            PropagateSkippedGeometryStores(program, skipped_geometry_program);
+        }
+
+        const auto runtime_info{MakeRuntimeInfo(
+            programs, key, program, previous_stage, skipped_geometry_program, has_geometry_stage,
+            guest_has_geometry_shader, geometry_supported, uses_tessellation, max_vertex_attributes,
+            max_vertex_bindings)};
+        if (key.state.xfb_enabled != 0 && runtime_info.xfb_count > 0) {
+            LOG_INFO(Render_Vulkan,
+                     "Pipeline 0x{:016x} stage={} xfb_count={} xfb_emulated={} gs={} tess={}",
+                     hash, static_cast<u32>(program.stage), runtime_info.xfb_count,
+                     key.state.xfb_emulated != 0, guest_has_geometry_shader, uses_tessellation);
+        }
         ConvertLegacyToGeneric(program, runtime_info);
         std::vector<u32> code = EmitSPIRV(profile, runtime_info, program, binding);
         // Reserve space to reduce allocations during shader compilation
@@ -824,6 +983,13 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
         LOG_ERROR(Render_Vulkan,
                   "Out of device memory during graphics pipeline creation, attempting recovery");
         EvictOldPipelines();
+        return nullptr;
+    }
+    if (exception.GetResult() == VK_ERROR_INITIALIZATION_FAILED) {
+        LOG_ERROR(Render_Vulkan,
+                  "Graphics pipeline creation failed (0x{:x}): incompatible shader interface, "
+                  "skipping pipeline",
+                  key.Hash());
         return nullptr;
     }
     throw;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -221,7 +221,8 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             // When the guest binds a geometry shader but the host cannot run one, stream-out
             // emulation must run on the last stage before the skipped geometry stage.
             const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
-            if (!guest_has_geometry_shader || (guest_gs_skipped && !uses_tessellation)) {
+            if ((!guest_has_geometry_shader && !uses_tessellation) ||
+                (guest_gs_skipped && !uses_tessellation)) {
                 PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
@@ -279,7 +280,8 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             return Shader::TessSpacing::Equal;
         }();
         if (!has_geometry) {
-            if (guest_has_geometry_shader && !geometry_supported) {
+            const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
+            if (uses_tessellation && (!guest_has_geometry_shader || guest_gs_skipped)) {
                 PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
@@ -862,7 +864,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
 
     for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
         const bool is_emulated_stage =
-            layer_source_program != nullptr &&
+            geometry_supported && layer_source_program != nullptr &&
             index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && is_emulated_stage) {
             auto topology = MaxwellToOutputTopology(key.state.topology);
@@ -931,14 +933,9 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram;
          ++index) {
         if (index == geometry_stage_index && !geometry_supported) {
-            const bool is_emulated_stage = layer_source_program != nullptr &&
-                                           index == static_cast<u32>(
-                                               Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
-            if (!is_emulated_stage) {
-                continue;
-            }
+            continue;
         }
-        const bool is_emulated_stage = layer_source_program != nullptr &&
+        const bool is_emulated_stage = geometry_supported && layer_source_program != nullptr &&
                                        index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && !is_emulated_stage) {
             continue;

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -369,6 +369,7 @@ public:
         {
             std::scoped_lock lk(flush_guard);
             pending_flush_sets.emplace_back(std::move(pending_flush_queries));
+            pending_flush_queries.clear();
         }
     }
 
@@ -909,6 +910,7 @@ public:
         free_queue.clear();
         download_buffers.emplace_back(staging_ref);
         pending_flush_sets.emplace_back(std::move(pending_flush_queries));
+        pending_flush_queries.clear();
     }
 
     void PopUnsyncedQueries() override {
@@ -1065,12 +1067,12 @@ private:
                 .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
             };
             scheduler.RequestOutsideRenderPassOperationContext();
-            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer,
-                              slot](vk::CommandBuffer cmdbuf) {
+            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer, slot,
+                              stream](vk::CommandBuffer cmdbuf) {
                 cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                        VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
                 std::array<VkBufferCopy, 1> copy{VkBufferCopy{
-                    .srcOffset = 0,
+                    .srcOffset = stream * TFBQueryBank::QUERY_SIZE,
                     .dstOffset = slot * TFBQueryBank::QUERY_SIZE,
                     .size = TFBQueryBank::QUERY_SIZE,
                 }};
@@ -1289,8 +1291,9 @@ public:
                     return num_vertices >= 2 ? num_vertices - 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Patches:
                 case Maxwell3D::Regs::PrimitiveTopology::Triangles:
-                case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
                     return num_vertices / 3;
+                case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
+                    return num_vertices / 6;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <map>
@@ -661,17 +662,23 @@ class PrimitivesSucceededStreamer;
 
 class TFBCounterStreamer : public BaseStreamer {
 public:
-    explicit TFBCounterStreamer(size_t id_, QueryCacheRuntime& runtime_, const Device& device_,
-                                Scheduler& scheduler_, const MemoryAllocator& memory_allocator_,
+    explicit TFBCounterStreamer(size_t id_, QueryCacheRuntime& runtime_, BufferCache& buffer_cache_,
+                                const Device& device_, Scheduler& scheduler_,
+                                const MemoryAllocator& memory_allocator_,
                                 StagingBufferPool& staging_pool_)
-        : BaseStreamer(id_), runtime{runtime_}, device{device_}, scheduler{scheduler_},
-          memory_allocator{memory_allocator_}, staging_pool{staging_pool_} {
+        : BaseStreamer(id_), runtime{runtime_}, buffer_cache{buffer_cache_}, device{device_},
+          scheduler{scheduler_}, memory_allocator{memory_allocator_},
+          staging_pool{staging_pool_} {
         buffers_count = 0;
         current_bank = nullptr;
         counter_buffers.fill(VK_NULL_HANDLE);
         offsets.fill(0);
         last_queries.fill(0);
         last_queries_stride.fill(1);
+        streams_mask = 0;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            return;
+        }
         const VkBufferCreateInfo buffer_ci = {
             .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
             .pNext = nullptr,
@@ -737,6 +744,8 @@ public:
     void SyncWrites() override {
         CloseCounter();
         std::unordered_map<size_t, std::vector<HostSyncValues>> sync_values_stash;
+        std::vector<size_t> emulated_pending;
+        std::vector<VideoCommon::SyncValuesStruct> emulated_sync_values;
         for (auto q : pending_sync) {
             auto* query = GetQuery(q);
             if (True(query->flags & VideoCommon::QueryFlagBits::IsRewritten)) {
@@ -745,6 +754,12 @@ public:
             if (True(query->flags & VideoCommon::QueryFlagBits::IsInvalidated)) {
                 continue;
             }
+            if (!device.IsExtTransformFeedbackSupported()) {
+                if (emulated_query_strides.contains(q)) {
+                    emulated_pending.push_back(q);
+                    continue;
+                }
+            }
             query->flags |= VideoCommon::QueryFlagBits::IsHostSynced;
             sync_values_stash.try_emplace(query->start_bank_id);
             sync_values_stash[query->start_bank_id].emplace_back(HostSyncValues{
@@ -752,6 +767,51 @@ public:
                 .size = TFBQueryBank::QUERY_SIZE,
                 .offset = query->start_slot * TFBQueryBank::QUERY_SIZE,
             });
+        }
+        if (!emulated_pending.empty()) {
+            auto staging_ref = staging_pool.Request(
+                emulated_pending.size() * TFBQueryBank::QUERY_SIZE, MemoryUsage::Download, true);
+            size_t offset_base = staging_ref.offset;
+            for (const size_t q : emulated_pending) {
+                auto* query = GetQuery(q);
+                auto& bank = bank_pool.GetBank(query->start_bank_id);
+                bank.Sync(staging_ref, offset_base, query->start_slot, 1);
+                offset_base += TFBQueryBank::QUERY_SIZE;
+            }
+            static constexpr VkMemoryBarrier WRITE_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT,
+            };
+            scheduler.RequestOutsideRenderPassOperationContext();
+            scheduler.Record([](vk::CommandBuffer cmdbuf) {
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, WRITE_BARRIER);
+            });
+            scheduler.Finish();
+            offset_base = staging_ref.offset;
+            emulated_sync_values.reserve(emulated_pending.size());
+            for (const size_t q : emulated_pending) {
+                auto* query = GetQuery(q);
+                u32 records = 0;
+                std::memcpy(&records, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
+                offset_base += TFBQueryBank::QUERY_SIZE;
+                const u32 stride = emulated_query_strides.at(q);
+                emulated_query_strides.erase(q);
+                const u64 byte_value = static_cast<u64>(records) * stride;
+                query->value = byte_value;
+                query->flags |= VideoCommon::QueryFlagBits::IsHostSynced |
+                                VideoCommon::QueryFlagBits::IsFinalValueSynced;
+                emulated_sync_values.push_back(VideoCommon::SyncValuesStruct{
+                    .address = query->guest_address,
+                    .value = byte_value,
+                    .size = TFBQueryBank::QUERY_SIZE,
+                });
+                bank_pool.GetBank(query->start_bank_id).CloseReference();
+            }
+            staging_pool.FreeDeferred(staging_ref);
+            runtime.template SyncValues<VideoCommon::SyncValuesStruct>(emulated_sync_values);
         }
         for (auto& p : sync_values_stash) {
             auto& bank = bank_pool.GetBank(p.first);
@@ -780,12 +840,20 @@ public:
             new_query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             return index;
         }
+        if (!device.IsExtTransformFeedbackSupported()) {
+            // Ensure the emulated TF draw has finished writing the counter SSBO before we copy it.
+            scheduler.Flush();
+        }
         CloseCounter();
         auto [bank_slot, data_slot] = ProduceCounterBuffer(subreport);
         new_query->start_bank_id = static_cast<u32>(bank_slot);
         new_query->size_banks = 1;
         new_query->start_slot = static_cast<u32>(data_slot);
         new_query->size_slots = 1;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            emulated_query_strides[index] =
+                static_cast<u32>(std::max<size_t>(last_queries_stride[subreport], 1));
+        }
         pending_sync.push_back(index);
         pending_flush_queries.push_back(index);
         return index;
@@ -809,6 +877,9 @@ public:
 
     void PushUnsyncedQueries() override {
         CloseCounter();
+        if (!device.IsExtTransformFeedbackSupported() && !pending_flush_queries.empty()) {
+            scheduler.Flush();
+        }
         auto staging_ref = staging_pool.Request(
             pending_flush_queries.size() * TFBQueryBank::QUERY_SIZE, MemoryUsage::Download, true);
         size_t offset_base = staging_ref.offset;
@@ -850,13 +921,24 @@ public:
             download_buffers.pop_front();
             pending_flush_sets.pop_front();
         }
+        if (!device.IsExtTransformFeedbackSupported()) {
+            scheduler.Finish();
+        }
 
         size_t offset_base = staging_ref.offset;
         for (auto q : flushed_queries) {
             auto* query = GetQuery(q);
             u32 result = 0;
             std::memcpy(&result, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
-            query->value = static_cast<u64>(result);
+            u64 value = result;
+            if (!device.IsExtTransformFeedbackSupported()) {
+                if (const auto it = emulated_query_strides.find(q);
+                    it != emulated_query_strides.end()) {
+                    value *= it->second;
+                    emulated_query_strides.erase(it);
+                }
+            }
+            query->value = value;
             query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             offset_base += TFBQueryBank::QUERY_SIZE;
         }
@@ -873,6 +955,10 @@ private:
             return;
         }
         has_flushed_end_pending = true;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            UpdateBuffers();
+            return;
+        }
         if (!has_started || buffers_count == 0) {
             scheduler.Record([](vk::CommandBuffer cmdbuf) {
                 cmdbuf.BeginTransformFeedbackEXT(0, 0, nullptr, nullptr);
@@ -891,6 +977,10 @@ private:
             return;
         }
         has_flushed_end_pending = false;
+
+        if (!device.IsExtTransformFeedbackSupported()) {
+            return;
+        }
 
         // Enhanced query ending with better error handling
         try {
@@ -916,6 +1006,7 @@ private:
     void UpdateBuffers() {
         last_queries.fill(0);
         last_queries_stride.fill(1);
+        streams_mask = 0;
         runtime.View3DRegs([this](Maxwell3D& maxwell3d) {
             buffers_count = 0;
             out_topology = maxwell3d.draw_manager->GetDrawState().topology;
@@ -943,6 +1034,52 @@ private:
         auto [dont_care, other] = current_bank->Reserve();
         const size_t slot = other; // workaround to compile bug.
         current_bank->AddReference();
+
+        if (!device.IsExtTransformFeedbackSupported()) {
+            const VkBuffer snapshot_buffer =
+                buffer_cache.runtime.GetXfbEmulationCounterSnapshotBuffer();
+            const VkBuffer live_buffer = buffer_cache.runtime.GetXfbEmulationCounterBuffer();
+            const VkBuffer src_buffer =
+                snapshot_buffer != VK_NULL_HANDLE ? snapshot_buffer : live_buffer;
+            static constexpr VkMemoryBarrier WRITE_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
+            };
+            if (src_buffer == VK_NULL_HANDLE) {
+                scheduler.RequestOutsideRenderPassOperationContext();
+                scheduler.Record([dst_buffer = current_bank->GetBuffer(),
+                                  slot](vk::CommandBuffer cmdbuf) {
+                    cmdbuf.FillBuffer(dst_buffer, slot * TFBQueryBank::QUERY_SIZE,
+                                      TFBQueryBank::QUERY_SIZE, 0);
+                    cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                           VK_PIPELINE_STAGE_TRANSFER_BIT, 0, WRITE_BARRIER);
+                });
+                return {current_bank_id, slot};
+            }
+            static constexpr VkMemoryBarrier READ_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            };
+            scheduler.RequestOutsideRenderPassOperationContext();
+            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer,
+                              slot](vk::CommandBuffer cmdbuf) {
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
+                std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+                    .srcOffset = 0,
+                    .dstOffset = slot * TFBQueryBank::QUERY_SIZE,
+                    .size = TFBQueryBank::QUERY_SIZE,
+                }};
+                cmdbuf.CopyBuffer(src_buffer, dst_buffer, copy);
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                       VK_PIPELINE_STAGE_TRANSFER_BIT, 0, WRITE_BARRIER);
+            });
+            return {current_bank_id, slot};
+        }
 
         static constexpr VkMemoryBarrier READ_BARRIER{
             .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
@@ -979,10 +1116,12 @@ private:
     static constexpr size_t NUM_STREAMS = 4;
 
     QueryCacheRuntime& runtime;
+    BufferCache& buffer_cache;
     const Device& device;
     Scheduler& scheduler;
     const MemoryAllocator& memory_allocator;
     StagingBufferPool& staging_pool;
+    std::unordered_map<size_t, u32> emulated_query_strides;
     VideoCommon::BankPool<TFBQueryBank> bank_pool;
     size_t current_bank_id;
     TFBQueryBank* current_bank;
@@ -1125,16 +1264,17 @@ public:
 
             query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             u64 num_vertices = 0;
+            const u64 stride = std::max<u64>(query->stride, 1);
             if (query->dependant_manage) {
                 auto* dependant_query = tfb_streamer.GetQuery(query->dependant_index);
-                num_vertices = dependant_query->value / query->stride;
+                num_vertices = dependant_query->value / stride;
                 tfb_streamer.Free(query->dependant_index);
             } else {
                 u8* pointer = device_memory.GetPointer<u8>(query->dependant_address);
                 if (pointer != nullptr) {
                     u32 result;
                     std::memcpy(&result, pointer, sizeof(u32));
-                    num_vertices = static_cast<u64>(result) / query->stride;
+                    num_vertices = static_cast<u64>(result) / stride;
                 }
             }
             query->value = [&]() -> u64 {
@@ -1144,9 +1284,9 @@ public:
                 case Maxwell3D::Regs::PrimitiveTopology::Lines:
                     return num_vertices / 2;
                 case Maxwell3D::Regs::PrimitiveTopology::LineLoop:
-                    return (num_vertices / 2) + 1;
+                    return num_vertices >= 2 ? num_vertices : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::LineStrip:
-                    return num_vertices - 1;
+                    return num_vertices >= 2 ? num_vertices - 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Patches:
                 case Maxwell3D::Regs::PrimitiveTopology::Triangles:
                 case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
@@ -1154,11 +1294,11 @@ public:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
-                    return num_vertices - 2;
+                    return num_vertices >= 3 ? num_vertices - 2 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Quads:
                     return num_vertices / 4;
                 case Maxwell3D::Regs::PrimitiveTopology::Polygon:
-                    return 1U;
+                    return num_vertices >= 3 ? 1U : 0U;
                 default:
                     return num_vertices;
                 }
@@ -1196,8 +1336,8 @@ struct QueryCacheRuntimeImpl {
           sample_streamer(static_cast<size_t>(QueryType::ZPassPixelCount64), runtime, rasterizer,
                           device, scheduler, memory_allocator, compute_pass_descriptor_queue,
                           descriptor_pool),
-          tfb_streamer(static_cast<size_t>(QueryType::StreamingByteCount), runtime, device,
-                       scheduler, memory_allocator, staging_pool),
+          tfb_streamer(static_cast<size_t>(QueryType::StreamingByteCount), runtime, buffer_cache_,
+                       device, scheduler, memory_allocator, staging_pool),
           primitives_succeeded_streamer(
               static_cast<size_t>(QueryType::StreamingPrimitivesSucceeded), runtime, tfb_streamer,
               device_memory_),

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -813,6 +813,9 @@ public:
             }
             staging_pool.FreeDeferred(staging_ref);
             runtime.template SyncValues<VideoCommon::SyncValuesStruct>(emulated_sync_values);
+            std::erase_if(pending_flush_queries, [&emulated_pending](size_t q) {
+                return std::ranges::find(emulated_pending, q) != emulated_pending.end();
+            });
         }
         for (auto& p : sync_values_stash) {
             auto& bank = bank_pool.GetBank(p.first);
@@ -1296,8 +1299,9 @@ public:
                     return num_vertices / 6;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
-                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
                     return num_vertices >= 3 ? num_vertices - 2 : 0;
+                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
+                    return num_vertices >= 6 ? (num_vertices - 6) / 2 + 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Quads:
                     return num_vertices / 4;
                 case Maxwell3D::Regs::PrimitiveTopology::Polygon:

--- a/src/video_core/transform_feedback.h
+++ b/src/video_core/transform_feedback.h
@@ -19,6 +19,7 @@ struct TransformFeedbackState {
         u32 stride;
     };
     std::array<Layout, Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers> layouts;
+    std::array<s32, Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers> buffer_sizes;
     std::array<std::array<Tegra::Engines::Maxwell3D::Regs::StreamOutLayout, 32>,
                Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers>
         varyings;

--- a/src/video_core/vulkan_common/vulkan.h
+++ b/src/video_core/vulkan_common/vulkan.h
@@ -8,6 +8,7 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__APPLE__)
 #define VK_USE_PLATFORM_METAL_EXT
+#define VK_ENABLE_BETA_EXTENSIONS
 #elif defined(__ANDROID__)
 #define VK_USE_PLATFORM_ANDROID_KHR
 #else

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -189,6 +189,8 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
         VK_FORMAT_B8G8R8A8_UNORM,
         VK_FORMAT_BC1_RGBA_SRGB_BLOCK,
         VK_FORMAT_BC1_RGBA_UNORM_BLOCK,
+        VK_FORMAT_BC1_RGB_SRGB_BLOCK,
+        VK_FORMAT_BC1_RGB_UNORM_BLOCK,
         VK_FORMAT_BC2_SRGB_BLOCK,
         VK_FORMAT_BC2_UNORM_BLOCK,
         VK_FORMAT_BC3_SRGB_BLOCK,
@@ -208,6 +210,17 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
         VK_FORMAT_D32_SFLOAT,
         VK_FORMAT_D32_SFLOAT_S8_UINT,
         VK_FORMAT_E5B9G9R9_UFLOAT_PACK32,
+        VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK,
+        // EAC (often used with ETC2; queried by texture / format checks on Metal/MoltenVK)
+        VK_FORMAT_EAC_R11_UNORM_BLOCK,
+        VK_FORMAT_EAC_R11_SNORM_BLOCK,
+        VK_FORMAT_EAC_R11G11_UNORM_BLOCK,
+        VK_FORMAT_EAC_R11G11_SNORM_BLOCK,
         VK_FORMAT_R16G16B16A16_SFLOAT,
         VK_FORMAT_R16G16B16A16_SINT,
         VK_FORMAT_R16G16B16A16_SNORM,
@@ -730,12 +743,20 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     if (is_mvk) {
-        LOG_WARNING(Render_Vulkan,
-                    "MVK driver breaks when using more than 16 vertex attributes/bindings");
+        // Older MoltenVK builds fault above 16; Metal supports 31. Use the reported limit capped at
+        // 31 instead of forcing 16 so titles like Minecraft can use >16 streams when supported.
+        constexpr u32 MVK_VERTEX_INPUT_LIMIT = 31;
+        const u32 reported_attrs = properties.properties.limits.maxVertexInputAttributes;
+        const u32 reported_bindings = properties.properties.limits.maxVertexInputBindings;
         properties.properties.limits.maxVertexInputAttributes =
-            std::min(properties.properties.limits.maxVertexInputAttributes, 16U);
+            std::min(reported_attrs, MVK_VERTEX_INPUT_LIMIT);
         properties.properties.limits.maxVertexInputBindings =
-            std::min(properties.properties.limits.maxVertexInputBindings, 16U);
+            std::min(reported_bindings, MVK_VERTEX_INPUT_LIMIT);
+        LOG_INFO(Render_Vulkan,
+                 "MoltenVK vertex input limits: attributes={} bindings={} (reported {}/{})",
+                 properties.properties.limits.maxVertexInputAttributes,
+                 properties.properties.limits.maxVertexInputBindings, reported_attrs,
+                 reported_bindings);
     }
 
     if (is_turnip) {
@@ -934,11 +955,9 @@ bool Device::TestDepthStencilBlits(VkFormat format) const {
 bool Device::IsFormatSupported(VkFormat wanted_format, VkFormatFeatureFlags wanted_usage,
                                FormatType format_type) const {
     const auto it = format_properties.find(wanted_format);
-    if (it == format_properties.end()) {
-        UNIMPLEMENTED_MSG("Unimplemented format query={}", wanted_format);
-        return true;
-    }
-    const auto supported_usage = GetFormatFeatures(it->second, format_type);
+    const VkFormatProperties& props =
+        it != format_properties.end() ? it->second : physical.GetFormatProperties(wanted_format);
+    const auto supported_usage = GetFormatFeatures(props, format_type);
     return (supported_usage & wanted_usage) == wanted_usage;
 }
 
@@ -1072,6 +1091,13 @@ bool Device::GetSuitability(bool requires_swapchain) {
     FOR_EACH_VK_FEATURE_EXT(FEATURE_EXTENSION);
     FOR_EACH_VK_EXTENSION(EXTENSION);
 
+#ifdef __APPLE__
+    if (supported_extensions.contains(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        loaded_extensions.insert(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+        extensions.portability_subset = true;
+    }
+#endif
+
 #undef FEATURE_EXTENSION
 #undef EXTENSION
 
@@ -1129,6 +1155,14 @@ bool Device::GetSuitability(bool requires_swapchain) {
     } else {
         FOR_EACH_VK_FEATURE_1_3(EXT_FEATURE);
     }
+
+#ifdef __APPLE__
+    if (extensions.portability_subset) {
+        features.portability_subset_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR;
+        SetNext(next, features.portability_subset_features);
+    }
+#endif
 
 #undef EXT_FEATURE
 #undef FEATURE

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -418,6 +418,11 @@ public:
         return extensions.geometry_shader_passthrough;
     }
 
+    /// Returns true if core Vulkan geometry shaders are supported.
+    bool IsGeometryShaderSupported() const {
+        return features.features.geometryShader;
+    }
+
     /// Returns true if the device supports VK_NV_low_latency2.
     bool IsNvLowLatency2Supported() const {
         return extensions.low_latency2;
@@ -812,6 +817,10 @@ private:
         FOR_EACH_VK_FEATURE_EXT(FEATURE);
         FOR_EACH_VK_EXTENSION(EXTENSION);
 
+#ifdef __APPLE__
+        bool portability_subset{};
+#endif
+
 #undef EXTENSION
 #undef FEATURE
     };
@@ -826,6 +835,10 @@ private:
         FOR_EACH_VK_FEATURE_1_2(FEATURE_CORE);
         FOR_EACH_VK_FEATURE_1_3(FEATURE_CORE);
         FOR_EACH_VK_FEATURE_EXT(FEATURE_EXT);
+
+#ifdef __APPLE__
+        VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features{};
+#endif
 
 #undef FEATURE_CORE
 #undef FEATURE_EXT


### PR DESCRIPTION
## Summary
SPIR-V XFB, buffer cache, fixed pipeline state, queries, and Vulkan device caps for Apple GPUs.

Split from `moltenvk-xfb`.

## Test plan
- [ ] Vulkan titles using transform feedback on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transform feedback emulation with host-side stream counters, snapshotting, and draw indirect byte-count emulation.
  * Added Vulkan vertex input remapping for limited max attribute/binding environments.
  * Extended Vulkan probing/capability handling, including geometry shader support queries and improved Apple portability subset setup.
* **Bug Fixes**
  * Improved shader/SPIR-V transform feedback emulation stores, runtime info handling, and disabled generic output pointer resolution for empty generics.
  * Enhanced device memory read/unmapped-page handling with better host pointer recovery and safer fallback behavior; ensured required region flush before walking memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->