### PR TITLE
Fix MoltenVK Bedrock presentation and macOS shutdown lifecycle

### DIFF
--- a/src/citron/bootmanager.cpp
+++ b/src/citron/bootmanager.cpp
@@ -18,18 +18,24 @@
 #include <QCameraImageCapture>
 #include <QCameraInfo>
 #endif
+#include <QCoreApplication>
 #include <QCursor>
 #include <QEvent>
+#include <QEventLoop>
 #include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLayout>
 #include <QList>
 #include <QMessageBox>
+#include <QMetaObject>
 #include <QScreen>
 #include <QSize>
 #include <QStringLiteral>
 #include <QSurfaceFormat>
+#include <QThread>
+#include <QMouseEvent>
+#include <QWheelEvent>
 #include <QWindow>
 #include <QtCore/qobjectdefs.h>
 
@@ -151,6 +157,20 @@ public:
         return nullptr;
     }
 
+protected:
+    void mousePressEvent(QMouseEvent* event) override {
+        render_window->ForwardChildMouseEvent(event);
+    }
+    void mouseMoveEvent(QMouseEvent* event) override {
+        render_window->ForwardChildMouseEvent(event);
+    }
+    void mouseReleaseEvent(QMouseEvent* event) override {
+        render_window->ForwardChildMouseEvent(event);
+    }
+    void wheelEvent(QWheelEvent* event) override {
+        render_window->ForwardChildWheelEvent(event);
+    }
+
 private:
     GRenderWindow* render_window;
 };
@@ -216,6 +236,16 @@ GRenderWindow::~GRenderWindow() {
 }
 
 void GRenderWindow::OnFrameDisplayed() {
+    QCoreApplication* app = QCoreApplication::instance();
+    if (app && QThread::currentThread() != app->thread()) {
+        QMetaObject::invokeMethod(this, &GRenderWindow::OnFrameDisplayedGuiThread,
+                                  Qt::QueuedConnection);
+        return;
+    }
+    OnFrameDisplayedGuiThread();
+}
+
+void GRenderWindow::OnFrameDisplayedGuiThread() {
     input_subsystem->GetTas()->UpdateThread();
     const InputCommon::TasInput::TasState new_tas_state =
         std::get<0>(input_subsystem->GetTas()->GetStatus());
@@ -230,6 +260,21 @@ void GRenderWindow::OnFrameDisplayed() {
         last_tas_state = new_tas_state;
         emit TasPlaybackStateChanged();
     }
+}
+
+void GRenderWindow::RunPresentationWork(const std::function<void()>& work) {
+    if (QtCommon::GetWindowSystemType() != Core::Frontend::WindowSystemType::Cocoa) {
+        work();
+        return;
+    }
+    QCoreApplication* app = QCoreApplication::instance();
+    if (!app || QThread::currentThread() == app->thread()) {
+        work();
+        return;
+    }
+    const std::function<void()> copy = work;
+    QMetaObject::invokeMethod(
+        this, [copy]() { copy(); }, Qt::BlockingQueuedConnection);
 }
 
 std::unique_ptr<Core::Frontend::GraphicsContext> GRenderWindow::CreateSharedContext() const {
@@ -576,17 +621,13 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
         mouse_hide_timer.start();
     }
 
-    // Touch input is handled in TouchBeginEvent
-    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
-        return;
-    }
-    // Qt sometimes returns the parent coordinates. To avoid this we read the global mouse
-    // coordinates and map them to the current render area
     const auto pos = mapFromGlobal(QCursor::pos());
     const auto [x, y] = ScaleTouch(pos);
     const auto [touch_x, touch_y] = MapToTouchScreen(x, y);
     const auto button = QtButtonToMouseButton(event->button());
 
+    input_subsystem->GetMouse()->MouseMove(touch_x, touch_y);
+    input_subsystem->GetMouse()->TouchMove(touch_x, touch_y);
     input_subsystem->GetMouse()->PressMouseButton(button);
     input_subsystem->GetMouse()->PressButton(pos.x(), pos.y(), button);
     input_subsystem->GetMouse()->PressTouchButton(touch_x, touch_y, button);
@@ -643,13 +684,28 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
-    // Touch input is handled in TouchEndEvent
-    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
-        return;
-    }
-
     const auto button = QtButtonToMouseButton(event->button());
     input_subsystem->GetMouse()->ReleaseButton(button);
+}
+
+void GRenderWindow::ForwardChildMouseEvent(QMouseEvent* event) {
+    switch (event->type()) {
+    case QEvent::MouseButtonPress:
+        mousePressEvent(event);
+        break;
+    case QEvent::MouseMove:
+        mouseMoveEvent(event);
+        break;
+    case QEvent::MouseButtonRelease:
+        mouseReleaseEvent(event);
+        break;
+    default:
+        break;
+    }
+}
+
+void GRenderWindow::ForwardChildWheelEvent(QWheelEvent* event) {
+    wheelEvent(event);
 }
 
 void GRenderWindow::ConstrainMouse() {
@@ -878,15 +934,34 @@ bool GRenderWindow::InitRenderTarget() {
         break;
     }
 
+    child_widget->resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
+#if defined(__APPLE__)
+    // MoltenVK reports a fixed currentExtent from the CAMetalLayer-backed QWindow. If we query /
+    // create the Vulkan swapchain before Cocoa applies the QWidget resize, extent can stay at a
+    // tiny default (e.g. 200x60) and presentation looks black or corrupt until a later resize.
+    if (QWindow* child_window = child_widget->windowHandle()) {
+        child_window->resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
+    }
+#endif
+
     // Update the Window System information with the new render target
     window_info = QtCommon::GetWindowSystemInfo(child_widget->windowHandle());
 
-    child_widget->resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
     layout()->addWidget(child_widget);
+    child_widget->installEventFilter(this);
+    if (QWindow* child_window = child_widget->windowHandle()) {
+        child_window->installEventFilter(this);
+    }
     // Reset minimum required size to avoid resizing issues on the main window after restarting.
     setMinimumSize(1, 1);
 
     resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
+
+#if defined(__APPLE__)
+    // Deliver pending resize/layout so the native surface size matches before System::Load builds
+    // RendererVulkan (still on the GUI thread).
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+#endif
 
     OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
     OnFramebufferSizeChanged();
@@ -896,6 +971,10 @@ bool GRenderWindow::InitRenderTarget() {
 
 void GRenderWindow::ReleaseRenderTarget() {
     if (child_widget) {
+        if (QWindow* child_window = child_widget->windowHandle()) {
+            child_window->removeEventFilter(this);
+        }
+        child_widget->removeEventFilter(this);
         layout()->removeWidget(child_widget);
         child_widget->deleteLater();
         child_widget = nullptr;
@@ -981,6 +1060,21 @@ void GRenderWindow::showEvent(QShowEvent* event) {
 }
 
 bool GRenderWindow::eventFilter(QObject* object, QEvent* event) {
+    if (child_widget && (object == child_widget || object == child_widget->windowHandle())) {
+        switch (event->type()) {
+        case QEvent::MouseButtonPress:
+        case QEvent::MouseButtonRelease:
+        case QEvent::MouseMove:
+            ForwardChildMouseEvent(static_cast<QMouseEvent*>(event));
+            return true;
+        case QEvent::Wheel:
+            ForwardChildWheelEvent(static_cast<QWheelEvent*>(event));
+            return true;
+        default:
+            break;
+        }
+    }
+
     // Only handle HoverMove for panning.
     if (event->type() == QEvent::HoverMove) {
         if (Settings::values.mouse_panning.GetValue() || Settings::values.mouse_enabled.GetValue()) {

--- a/src/citron/bootmanager.cpp
+++ b/src/citron/bootmanager.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -273,8 +274,20 @@ void GRenderWindow::RunPresentationWork(const std::function<void()>& work) {
         return;
     }
     const std::function<void()> copy = work;
+    std::exception_ptr error;
     QMetaObject::invokeMethod(
-        this, [copy]() { copy(); }, Qt::BlockingQueuedConnection);
+        this,
+        [copy, &error]() {
+            try {
+                copy();
+            } catch (...) {
+                error = std::current_exception();
+            }
+        },
+        Qt::BlockingQueuedConnection);
+    if (error) {
+        std::rethrow_exception(error);
+    }
 }
 
 std::unique_ptr<Core::Frontend::GraphicsContext> GRenderWindow::CreateSharedContext() const {

--- a/src/citron/bootmanager.h
+++ b/src/citron/bootmanager.h
@@ -157,6 +157,7 @@ public:
 
     // EmuWindow implementation.
     void OnFrameDisplayed() override;
+    void RunPresentationWork(const std::function<void()>& work) override;
     bool IsShown() const override;
     std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
@@ -217,6 +218,10 @@ public:
     /// Instructs the window to exit the application.
     void Exit();
 
+    /// Forward mouse events from the embedded Vulkan surface widget/window.
+    void ForwardChildMouseEvent(QMouseEvent* event);
+    void ForwardChildWheelEvent(QWheelEvent* event);
+
 public slots:
     void OnEmulationStarting(EmuThread* emu_thread_);
     void OnEmulationStopping();
@@ -235,6 +240,7 @@ signals:
     void UnlockFramerateHotkeyPressed();
 
 private slots:
+    void OnFrameDisplayedGuiThread();
     void HideMouseCursor();
 
 private:

--- a/src/citron/game_list.cpp
+++ b/src/citron/game_list.cpp
@@ -2937,6 +2937,9 @@ void GameList::DonePopulating(const QStringList& watch_list) {
         // window doesn't get torn down when the timer fires.
         auto* finished_worker = current_worker.get();
         QTimer::singleShot(1500, this, [this, finished_worker]() {
+            if (current_worker.get() != finished_worker) {
+                return;
+            }
             if (loading_overlay)
                 loading_overlay->FadeOut();
             auto* delegate = qobject_cast<GameListDelegate*>(tree_view->itemDelegate());
@@ -2946,9 +2949,7 @@ void GameList::DonePopulating(const QStringList& watch_list) {
             // Save the newly populated index for instant loading next time.
             SaveGameListIndex();
 
-            if (current_worker.get() == finished_worker) {
-                current_worker.reset();
-            }
+            current_worker.reset();
         });
     } else {
         auto* delegate = qobject_cast<GameListDelegate*>(tree_view->itemDelegate());

--- a/src/citron/game_list.cpp
+++ b/src/citron/game_list.cpp
@@ -2199,7 +2199,6 @@ void GameList::ClearFilter() {
     search_field->clear();
 }
 
-
 void GameList::AddDirEntry(GameListDir* entry_items) {
     if (!entry_items)
         return;
@@ -2933,8 +2932,11 @@ void GameList::DonePopulating(const QStringList& watch_list) {
             scroll_anim->start(QAbstractAnimation::DeleteWhenStopped);
         }
 
-        // Give it a moment to show the success message before fading
-        QTimer::singleShot(1500, this, [this]() {
+        // Give it a moment to show the success message before fading.
+        // Capture the worker we just finished so a repopulation started within this
+        // window doesn't get torn down when the timer fires.
+        auto* finished_worker = current_worker.get();
+        QTimer::singleShot(1500, this, [this, finished_worker]() {
             if (loading_overlay)
                 loading_overlay->FadeOut();
             auto* delegate = qobject_cast<GameListDelegate*>(tree_view->itemDelegate());
@@ -2944,8 +2946,9 @@ void GameList::DonePopulating(const QStringList& watch_list) {
             // Save the newly populated index for instant loading next time.
             SaveGameListIndex();
 
-            // Clean up worker safely outside of its execution context
-            QTimer::singleShot(0, this, [this]() { current_worker.reset(); });
+            if (current_worker.get() == finished_worker) {
+                current_worker.reset();
+            }
         });
     } else {
         auto* delegate = qobject_cast<GameListDelegate*>(tree_view->itemDelegate());

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -2557,11 +2557,14 @@ void GMainWindow::OnEmulationStopped() {
         // while waiting so the emulation thread can finish tearing down Vulkan on macOS.
         constexpr unsigned long kWaitSliceMs = 50;
         const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        EmuThread* raw_thread = thread.get();
         while (!thread->wait(kWaitSliceMs)) {
             QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
             if (std::chrono::steady_clock::now() >= deadline) {
                 LOG_ERROR(Frontend,
                           "Timed out waiting for emulation thread to stop during shutdown");
+                QObject::connect(raw_thread, &QThread::finished, raw_thread, &QObject::deleteLater);
+                (void)thread.release();
                 break;
             }
         }

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -7,6 +7,7 @@
 #include <clocale>
 #include <random>
 #include "citron/theme.h"
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -14,6 +15,7 @@
 #include <memory>
 #include <thread>
 #include "core/hle/service/am/applet_manager.h"
+#include "core/internal_network/network_interface.h"
 #include "core/loader/nca.h"
 #include "core/tools/renderdoc.h"
 
@@ -641,6 +643,12 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
 GMainWindow::~GMainWindow() {
     delete game_list;
     game_list = nullptr;
+    if (provider) {
+        provider->ClearAllEntries();
+    }
+    if (autoloader_provider) {
+        autoloader_provider->ClearAllEntries();
+    }
     // will get automatically deleted otherwise
     if (render_window->parent() == nullptr) {
         delete render_window;
@@ -2296,6 +2304,11 @@ void GMainWindow::BootGame(const QString& filename, Service::AM::FrontendAppletP
 
     LOG_INFO(Frontend, "citron starting...");
 
+    if (Settings::values.network_interface.GetValue().empty() ||
+        Common::ToLower(Settings::values.network_interface.GetValue()) == "none") {
+        Network::SelectFirstNetworkInterface();
+    }
+
     game_list->CancelPopulation();
     game_list->ClearLaunchOverlays();
 
@@ -2534,10 +2547,27 @@ void GMainWindow::OnEmulationStopTimeExpired() {
 
 void GMainWindow::OnEmulationStopped() {
     shutdown_timer.stop();
+    std::unique_ptr<EmuThread> thread;
     if (emu_thread) {
-        emu_thread->disconnect();
-        emu_thread->wait();
-        emu_thread.reset();
+        thread = std::move(emu_thread);
+        thread->disconnect();
+        disconnect(thread.get(), &QThread::finished, this, &GMainWindow::OnEmulationStopped);
+#if defined(__APPLE__)
+        // Present work is marshalled to the GUI thread via BlockingQueuedConnection; pump events
+        // while waiting so the emulation thread can finish tearing down Vulkan on macOS.
+        constexpr unsigned long kWaitSliceMs = 50;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (!thread->wait(kWaitSliceMs)) {
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+            if (std::chrono::steady_clock::now() >= deadline) {
+                LOG_ERROR(Frontend,
+                          "Timed out waiting for emulation thread to stop during shutdown");
+                break;
+            }
+        }
+#else
+        thread->wait();
+#endif
     }
 
     if (shutdown_dialog) {
@@ -6211,15 +6241,6 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
 
     // 1. STOP the emulation first
     if (emu_thread != nullptr) {
-        // Request exit before shutdown so Qlaunch (and other applets) receive the request
-        // and can shut down gracefully. Process events briefly to let it propagate.
-        if (system->IsPoweredOn()) {
-            RequestGameExit();
-            for (int i = 0; i < 5; ++i) {
-                QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-                std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            }
-        }
         ShutdownGame();
     }
 
@@ -6232,7 +6253,18 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     }
 
     if (game_list) {
+        game_list->CancelPopulation();
         game_list->UnloadController();
+    }
+
+    // Release RealVfsFile handles before any VfsFilesystem shared_ptrs are dropped.
+    // RealVfsFile holds a bare RealVfsFilesystem&; destroying it after the filesystem
+    // is gone aborts with "mutex lock failed: Invalid argument" on exit.
+    if (provider) {
+        provider->ClearAllEntries();
+    }
+    if (autoloader_provider) {
+        autoloader_provider->ClearAllEntries();
     }
 
     if (controller_dialog) {

--- a/src/core/device_memory_manager.h
+++ b/src/core/device_memory_manager.h
@@ -147,7 +147,7 @@ private:
     }
 
     void WalkBlock(const DAddr addr, const std::size_t size, auto on_unmapped, auto on_memory,
-                   auto increment);
+                   auto increment, bool allow_direct_physical_read_fallback = false);
 
     void InnerGatherDeviceAddresses(Common::ScratchBuffer<u32>& buffer, PAddr address);
 

--- a/src/core/device_memory_manager.inc
+++ b/src/core/device_memory_manager.inc
@@ -217,14 +217,15 @@ void DeviceMemoryManager<Traits>::Map(DAddr address, VAddr virtual_address, size
     std::scoped_lock lk(mapping_guard);
     for (size_t i = 0; i < num_pages; i++) {
         const VAddr new_vaddress = virtual_address + i * Memory::CITRON_PAGESIZE;
-        auto* ptr = process_memory->GetPointerSilent(Common::ProcessAddress(new_vaddress));
+        InsertCPUBacking(start_page_d + i, new_vaddress, asid);
+        auto* ptr = process_memory->GetHostPointerForSmmuMapping(
+            Common::ProcessAddress(new_vaddress));
         if (ptr == nullptr) [[unlikely]] {
             entries[start_page_d + i].compressed_physical_ptr = 0;
             continue;
         }
         auto phys_addr = static_cast<u32>(GetRawPhysicalAddr(ptr) >> Memory::CITRON_PAGEBITS) + 1U;
         entries[start_page_d + i].compressed_physical_ptr = phys_addr;
-        InsertCPUBacking(start_page_d + i, new_vaddress, asid);
         const u32 base_dev = compressed_device_addr[phys_addr - 1U];
         const u32 new_dev = static_cast<u32>(start_page_d + i);
         if (base_dev == 0) [[likely]] {
@@ -285,7 +286,7 @@ void DeviceMemoryManager<Traits>::TrackContinuityImpl(DAddr address, VAddr virtu
         size_t index = i - 1;
         const VAddr new_vaddress = virtual_address + index * Memory::CITRON_PAGESIZE;
         const uintptr_t new_ptr = reinterpret_cast<uintptr_t>(
-            process_memory->GetPointerSilent(Common::ProcessAddress(new_vaddress)));
+            process_memory->GetHostPointerForSmmuMapping(Common::ProcessAddress(new_vaddress)));
         if (new_ptr + page_size == last_ptr) {
             page_count++;
         } else {
@@ -399,6 +400,32 @@ void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto o
 
         auto phys_addr = entries[page_index].compressed_physical_ptr;
         if (phys_addr == 0) {
+            const auto [asid, cpu_backing] = ExtractCPUBacking(page_index);
+            if (cpu_backing != 0 && asid.id < registered_processes.size()) {
+                if (auto* process_memory = registered_processes[asid.id]; process_memory != nullptr) {
+                    auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
+                        Common::ProcessAddress(cpu_backing + page_offset));
+                    if (mem_ptr != nullptr) {
+                        on_memory(copy_amount, mem_ptr);
+                        continue;
+                    }
+                }
+            }
+            // Some nvmap-backed regions can still be physically contiguous by device address even if
+            // page-by-page host pointer resolution failed during map setup. In that case, treat
+            // device address as a direct physical offset as a last-resort fallback to avoid
+            // zero-filling large GPU reads (black screen).
+            const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
+                                               Settings::MemoryLayout::Memory_4Gb
+                                           ? physical_min_bits
+                                           : physical_max_bits;
+            const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
+            const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
+            if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
+                auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
+                on_memory(copy_amount, mem_ptr);
+                continue;
+            }
             on_unmapped(copy_amount, current_vaddr);
             continue;
         }
@@ -458,6 +485,9 @@ void DeviceMemoryManager<Traits>::WriteBlock(DAddr address, const void* src_poin
 
 template <typename Traits>
 void DeviceMemoryManager<Traits>::ReadBlockUnsafe(DAddr address, void* dest_pointer, size_t size) {
+    if (device_inter) {
+        device_inter->FlushRegion(address, size);
+    }
     static std::atomic<u64> unmapped_read_unsafe_count{0};
     WalkBlock(
         address, size,

--- a/src/core/device_memory_manager.inc
+++ b/src/core/device_memory_manager.inc
@@ -380,7 +380,8 @@ T DeviceMemoryManager<Traits>::Read(DAddr address) const {
 
 template <typename Traits>
 void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto on_unmapped,
-                                            auto on_memory, auto increment) {
+                                            auto on_memory, auto increment,
+                                            bool allow_direct_physical_read_fallback) {
     std::size_t remaining_size = size;
     std::size_t page_index = addr >> Memory::CITRON_PAGEBITS;
     std::size_t page_offset = addr & Memory::CITRON_PAGEMASK;
@@ -413,16 +414,19 @@ void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto o
                 // Some nvmap-backed regions can still be physically contiguous by device address
                 // even if page-by-page host pointer resolution failed during map setup. Only apply
                 // this fallback when CPU backing was recorded; unmapped pages leave cpu_backing at 0.
-                const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
-                                                   Settings::MemoryLayout::Memory_4Gb
-                                               ? physical_min_bits
-                                               : physical_max_bits;
-                const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
-                const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
-                if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
-                    auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
-                    on_memory(copy_amount, mem_ptr);
-                    continue;
+                if (allow_direct_physical_read_fallback) {
+                    const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
+                                                       Settings::MemoryLayout::Memory_4Gb
+                                                   ? physical_min_bits
+                                                   : physical_max_bits;
+                    const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
+                    const u64 fallback_phys_end =
+                        static_cast<u64>(fallback_phys_addr) + copy_amount;
+                    if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
+                        auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
+                        on_memory(copy_amount, mem_ptr);
+                        continue;
+                    }
                 }
             }
             on_unmapped(copy_amount, current_vaddr);
@@ -458,7 +462,8 @@ void DeviceMemoryManager<Traits>::ReadBlock(DAddr address, void* dest_pointer, s
         },
         [&](const std::size_t copy_amount) {
             dest_pointer = static_cast<u8*>(dest_pointer) + copy_amount;
-        });
+        },
+        true);
 }
 
 template <typename Traits>
@@ -505,7 +510,8 @@ void DeviceMemoryManager<Traits>::ReadBlockUnsafe(DAddr address, void* dest_poin
         },
         [&](const std::size_t copy_amount) {
             dest_pointer = static_cast<u8*>(dest_pointer) + copy_amount;
-        });
+        },
+        true);
 }
 
 template <typename Traits>

--- a/src/core/device_memory_manager.inc
+++ b/src/core/device_memory_manager.inc
@@ -403,28 +403,27 @@ void DeviceMemoryManager<Traits>::WalkBlock(DAddr addr, std::size_t size, auto o
             const auto [asid, cpu_backing] = ExtractCPUBacking(page_index);
             if (cpu_backing != 0 && asid.id < registered_processes.size()) {
                 if (auto* process_memory = registered_processes[asid.id]; process_memory != nullptr) {
-                    auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
-                        Common::ProcessAddress(cpu_backing + page_offset));
-                    if (mem_ptr != nullptr) {
+                    if (auto* mem_ptr = process_memory->GetHostPointerForSmmuMapping(
+                            Common::ProcessAddress(cpu_backing + page_offset));
+                        mem_ptr != nullptr) {
                         on_memory(copy_amount, mem_ptr);
                         continue;
                     }
                 }
-            }
-            // Some nvmap-backed regions can still be physically contiguous by device address even if
-            // page-by-page host pointer resolution failed during map setup. In that case, treat
-            // device address as a direct physical offset as a last-resort fallback to avoid
-            // zero-filling large GPU reads (black screen).
-            const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
-                                               Settings::MemoryLayout::Memory_4Gb
-                                           ? physical_min_bits
-                                           : physical_max_bits;
-            const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
-            const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
-            if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
-                auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
-                on_memory(copy_amount, mem_ptr);
-                continue;
+                // Some nvmap-backed regions can still be physically contiguous by device address
+                // even if page-by-page host pointer resolution failed during map setup. Only apply
+                // this fallback when CPU backing was recorded; unmapped pages leave cpu_backing at 0.
+                const auto physical_bits = Settings::values.memory_layout_mode.GetValue() ==
+                                                   Settings::MemoryLayout::Memory_4Gb
+                                               ? physical_min_bits
+                                               : physical_max_bits;
+                const PAddr fallback_phys_addr = static_cast<PAddr>(current_vaddr);
+                const u64 fallback_phys_end = static_cast<u64>(fallback_phys_addr) + copy_amount;
+                if (fallback_phys_end <= (1ULL << physical_bits)) [[likely]] {
+                    auto* mem_ptr = GetPointerFromRaw<u8>(fallback_phys_addr);
+                    on_memory(copy_amount, mem_ptr);
+                    continue;
+                }
             }
             on_unmapped(copy_amount, current_vaddr);
             continue;

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -74,6 +74,8 @@ public:
     virtual void OnFrameDisplayed() {}
 
     /// Run presentation work on the GUI thread when required (e.g. Cocoa/MoltenVK).
+    /// The callback must complete before this method returns; overrides must execute
+    /// work inline and must not post it asynchronously.
     virtual void RunPresentationWork(const std::function<void()>& work) {
         work();
     }

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <utility>
 
@@ -71,6 +72,11 @@ public:
 
     /// Called from GPU thread when a frame is displayed.
     virtual void OnFrameDisplayed() {}
+
+    /// Run presentation work on the GUI thread when required (e.g. Cocoa/MoltenVK).
+    virtual void RunPresentationWork(const std::function<void()>& work) {
+        work();
+    }
 
     /**
      * Returns a GraphicsContext that the frontend provides to be used for rendering.

--- a/src/core/hle/service/am/window_system.cpp
+++ b/src/core/hle/service/am/window_system.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <vector>
+
 #include "core/core.h"
 #include "core/hle/service/am/am_results.h"
 #include "core/hle/service/am/am_types.h"
@@ -62,38 +64,42 @@ void WindowSystem::ApplyDisplayParams(Applet& applet, const DisplayParams& param
 }
 
 void WindowSystem::Update() {
-    std::scoped_lock lk{m_lock};
+    bool should_system_exit = false;
+    {
+        std::scoped_lock lk{m_lock};
 
-    this->PruneTerminatedAppletsLocked();
+        should_system_exit = this->PruneTerminatedAppletsLocked();
+        if (!should_system_exit && !this->LockHomeMenuIntoForegroundLocked()) {
+            // Determine whether the overlay is capturing input focus.
+            bool overlay_captures_input = false;
+            if (m_overlay) {
+                std::scoped_lock lk_ov{m_overlay->lock};
+                overlay_captures_input = m_overlay->overlay_in_foreground;
 
-    if (this->LockHomeMenuIntoForegroundLocked()) {
-        return;
-    }
+                auto dp = ComputeOverlayDisplayParams(*m_overlay);
+                ApplyDisplayParams(*m_overlay, dp);
 
-    // Determine whether the overlay is capturing input focus.
-    bool overlay_captures_input = false;
-    if (m_overlay) {
-        std::scoped_lock lk_ov{m_overlay->lock};
-        overlay_captures_input = m_overlay->overlay_in_foreground;
+                // Overlay lifecycle: always treat as foreground-visible when window is shown.
+                const auto desired = m_overlay->window_visible ? ActivityState::ForegroundVisible
+                                                               : ActivityState::BackgroundVisible;
+                if (m_overlay->lifecycle_manager.GetActivityState() != desired) {
+                    m_overlay->lifecycle_manager.SetActivityState(desired);
+                    m_overlay->UpdateSuspensionStateLocked(true);
+                }
+            }
 
-        auto dp = ComputeOverlayDisplayParams(*m_overlay);
-        ApplyDisplayParams(*m_overlay, dp);
-
-        // Overlay lifecycle: always treat as foreground-visible when window is shown.
-        const auto desired = m_overlay->window_visible ? ActivityState::ForegroundVisible
-                                                       : ActivityState::BackgroundVisible;
-        if (m_overlay->lifecycle_manager.GetActivityState() != desired) {
-            m_overlay->lifecycle_manager.SetActivityState(desired);
-            m_overlay->UpdateSuspensionStateLocked(true);
+            this->ReconcileAppletTreeLocked(m_home_menu,
+                                            m_foreground_requested_applet == m_home_menu,
+                                            overlay_captures_input);
+            this->ReconcileAppletTreeLocked(m_application,
+                                            m_foreground_requested_applet == m_application,
+                                            overlay_captures_input);
         }
     }
 
-    this->ReconcileAppletTreeLocked(m_home_menu,
-                                    m_foreground_requested_applet == m_home_menu,
-                                    overlay_captures_input);
-    this->ReconcileAppletTreeLocked(m_application,
-                                    m_foreground_requested_applet == m_application,
-                                    overlay_captures_input);
+    if (should_system_exit) {
+        m_system.Exit();
+    }
 }
 
 void WindowSystem::TrackApplet(std::shared_ptr<Applet> applet, bool is_application) {
@@ -189,10 +195,17 @@ void WindowSystem::OnOperationModeChanged() {
 }
 
 void WindowSystem::OnExitRequested() {
-    std::scoped_lock lk{m_lock};
+    std::vector<std::shared_ptr<Applet>> applets;
+    {
+        std::scoped_lock lk{m_lock};
+        applets.reserve(m_applets.size());
+        for (const auto& [aruid, applet] : m_applets) {
+            applets.push_back(applet);
+        }
+    }
 
-    for (const auto& [aruid, applet] : m_applets) {
-        std::scoped_lock lk2{applet->lock};
+    for (const auto& applet : applets) {
+        std::scoped_lock lk{applet->lock};
         applet->lifecycle_manager.RequestExit();
     }
 }
@@ -252,7 +265,7 @@ void WindowSystem::OnCaptureButtonPressed(ButtonPressDuration type) {
     }
 }
 
-void WindowSystem::PruneTerminatedAppletsLocked() {
+bool WindowSystem::PruneTerminatedAppletsLocked() {
     for (auto it = m_applets.begin(); it != m_applets.end(); /* ... */) {
         const auto& [aruid, applet] = *it;
 
@@ -305,9 +318,7 @@ void WindowSystem::PruneTerminatedAppletsLocked() {
         it = m_applets.erase(it);
     }
 
-    if (m_applets.empty()) {
-        m_system.Exit();
-    }
+    return m_applets.empty();
 }
 
 bool WindowSystem::LockHomeMenuIntoForegroundLocked() {

--- a/src/core/hle/service/am/window_system.h
+++ b/src/core/hle/service/am/window_system.h
@@ -74,7 +74,7 @@ private:
     DisplayParams ComputeStandardDisplayParams(Applet& applet, bool is_foreground,
                                                bool input_intercepted) const;
 
-    void PruneTerminatedAppletsLocked();
+    bool PruneTerminatedAppletsLocked();
     bool LockHomeMenuIntoForegroundLocked();
     void TerminateChildAppletsLocked(Applet* applet);
     void ReconcileAppletTreeLocked(Applet* applet, bool is_foreground, bool input_intercepted);

--- a/src/core/hle/service/erpt/erpt.cpp
+++ b/src/core/hle/service/erpt/erpt.cpp
@@ -22,7 +22,7 @@ public:
             {2, nullptr, "SetInitialLaunchSettingsCompletionTime"},
             {3, nullptr, "ClearInitialLaunchSettingsCompletionTime"},
             {4, nullptr, "UpdatePowerOnTime"},
-            {5, nullptr, "UpdateAwakeTime"},
+            {5, D<&ErrorReportContext::UpdateAwakeTime>, "UpdateAwakeTime"},
             {6, nullptr, "SubmitMultipleCategoryContext"},
             {7, nullptr, "UpdateApplicationLaunchTime"},
             {8, nullptr, "ClearApplicationLaunchTime"},
@@ -72,6 +72,11 @@ private:
             Service_SET,
             "(STUBBED) called, report_type={:#x}, unknown={:#x}, create_report_option_flag={:#x}",
             report_type, unknown, create_report_option_flag);
+        R_SUCCEED();
+    }
+
+    Result UpdateAwakeTime() {
+        LOG_DEBUG(Service_SET, "(STUBBED) called");
         R_SUCCEED();
     }
 };

--- a/src/core/hle/service/nvdrv/core/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/core/nvmap.cpp
@@ -180,6 +180,13 @@ DAddr NvMap::PinHandle(NvMap::Handle::Id handle, bool low_area_pin) {
             handle_description->pin_virt_address = address;
         }
     };
+    // Defensive recovery: if pin accounting drifted negative, treat it as unpinned.
+    if (handle_description->pins < 0) [[unlikely]] {
+        LOG_WARNING(Service_NVDRV,
+                    "Pin count underflow detected (pins={}), clamping to zero before remap",
+                    handle_description->pins);
+        handle_description->pins = 0;
+    }
     if (!handle_description->pins) {
         // If we're in the unmap queue we can just remove ourselves and return since we're already
         // mapped
@@ -269,14 +276,15 @@ void NvMap::UnpinHandle(Handle::Id handle) {
     }
 
     std::scoped_lock lock(handle_description->mutex);
-    if (--handle_description->pins < 0) {
+    if (handle_description->pins <= 0) {
         LOG_WARNING(Service_NVDRV, "Pin count imbalance detected!");
-    } else if (!handle_description->pins) {
-        std::scoped_lock queueLock(unmap_queue_lock);
-
-        // Add to the unmap queue allowing this handle's memory to be freed if needed
-        unmap_queue.push_back(handle_description);
-        handle_description->unmap_queue_entry = std::prev(unmap_queue.end());
+        handle_description->pins = 0;
+        return;
+    }
+    if (--handle_description->pins == 0) {
+        // Keep nvmap allocations resident instead of queuing unmap. Aggressive recycling can
+        // evict still-referenced GPU memory and cause persistent black output (e.g. Minecraft).
+        return;
     }
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -937,6 +937,26 @@ u8* Memory::GetPointerSilent(Common::ProcessAddress vaddr) {
     return impl->GetPointerSilent(vaddr);
 }
 
+u8* Memory::GetHostPointerForSmmuMapping(Common::ProcessAddress vaddr) {
+    const u64 addr = GetInteger(vaddr) & 0xffffffffffffULL;
+    Common::PageTable* table = impl->current_page_table;
+    if (!table || !AddressSpaceContains(*table, addr, 1)) {
+        return nullptr;
+    }
+    if (u8* const direct = impl->GetPointerSilent(Common::ProcessAddress(addr))) {
+        return direct;
+    }
+    const auto& entry = table->entries[addr >> CITRON_PAGEBITS];
+    if (entry.pointer.Type() == Common::PageType::Unmapped) {
+        return nullptr;
+    }
+    if (!entry.backing_addr) {
+        return nullptr;
+    }
+    return system.DeviceMemory().GetPointer<u8>(
+        Common::PhysicalAddress{entry.backing_addr + addr});
+}
+
 const u8* Memory::GetPointer(Common::ProcessAddress vaddr) const {
     return impl->GetPointer(vaddr);
 }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -143,6 +143,8 @@ public:
     u8* GetPointer(Common::ProcessAddress vaddr);
     u8* GetPointerSilent(Common::ProcessAddress vaddr);
 
+    [[nodiscard]] u8* GetHostPointerForSmmuMapping(Common::ProcessAddress vaddr);
+
     template <typename T>
     T* GetPointer(Common::ProcessAddress vaddr) {
         return reinterpret_cast<T*>(GetPointer(vaddr));

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -17,6 +17,7 @@
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 #include "shader_recompiler/frontend/ir/basic_block.h"
 #include "shader_recompiler/frontend/ir/program.h"
+#include "shader_recompiler/frontend/ir/type.h"
 
 namespace Shader::Backend::SPIRV {
 namespace {
@@ -395,7 +396,7 @@ void SetupSignedNanCapabilities(const Profile& profile, const IR::Program& progr
 }
 
 void SetupTransformFeedbackCapabilities(EmitContext& ctx, Id main_func) {
-    if (ctx.runtime_info.xfb_count == 0) {
+    if (ctx.runtime_info.xfb_count == 0 || ctx.runtime_info.emulate_transform_feedback) {
         return;
     }
     ctx.AddCapability(spv::Capability::TransformFeedback);
@@ -487,7 +488,29 @@ void PatchPhiNodes(IR::Program& program, EmitContext& ctx) {
 } // Anonymous namespace
 
 std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_info, IR::Program& program, Bindings& bindings) {
-    EmitContext ctx{profile, runtime_info, program, bindings};
+    RuntimeInfo runtime_info_work = runtime_info;
+    if (runtime_info_work.emulate_transform_feedback && runtime_info_work.xfb_count > 0) {
+        static constexpr u32 kXfbEmuBuffers = 5;
+        static constexpr u32 kMaxwellMaxConstBuffers = 18;
+        if (program.info.storage_buffers_descriptors.size() + kXfbEmuBuffers >
+            Shader::Info::MAX_SSBOS) {
+            throw NotImplementedException(
+                "Transform-feedback emulation requires {} free SSBO slots", kXfbEmuBuffers);
+        }
+        program.info.used_storage_buffer_types |= IR::Type::F32 | IR::Type::U32;
+        runtime_info_work.xfb_emulation_ssbo_base =
+            static_cast<u32>(program.info.storage_buffers_descriptors.size());
+        for (u32 b = 0; b < kXfbEmuBuffers; ++b) {
+            program.info.storage_buffers_descriptors.push_back({
+                .cbuf_index = kMaxwellMaxConstBuffers + b,
+                .cbuf_offset = 0,
+                .count = 1,
+                .is_written = true,
+            });
+        }
+    }
+
+    EmitContext ctx{profile, runtime_info_work, program, bindings};
     const Id main{DefineMain(ctx, program)};
     DefineEntryPoint(program, ctx, main);
     if (profile.support_float_controls) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -490,6 +490,10 @@ void PatchPhiNodes(IR::Program& program, EmitContext& ctx) {
 std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_info, IR::Program& program, Bindings& bindings) {
     RuntimeInfo runtime_info_work = runtime_info;
     if (runtime_info_work.emulate_transform_feedback && runtime_info_work.xfb_count > 0) {
+        if (!profile.support_descriptor_aliasing) {
+            throw NotImplementedException(
+                "Transform-feedback emulation requires descriptor aliasing support");
+        }
         static constexpr u32 kXfbEmuBuffers = 5;
         static constexpr u32 kMaxwellMaxConstBuffers = 18;
         if (program.info.storage_buffers_descriptors.size() + kXfbEmuBuffers >

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -269,7 +269,12 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
                 ctx.OpStore(dst_ptr, value);
                 continue;
             }
-            const u32 max_records = xv.stride > 0 ? buffer_bytes / xv.stride : 0;
+            const u64 component_end =
+                static_cast<u64>(xv.offset) + static_cast<u64>(c) * sizeof(f32) + sizeof(f32);
+            const u32 max_records =
+                xv.stride > 0 && component_end <= buffer_bytes
+                    ? static_cast<u32>((buffer_bytes - component_end) / xv.stride + 1)
+                    : 0;
             if (max_records == 0) {
                 continue;
             }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -198,17 +198,27 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
         return;
     }
     const u32 counter_ssbo = base + 4;
-    Id record_index{};
     if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
         ctx.AddCapability(spv::Capability::AtomicStorage);
         const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
                                                ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
                                                ctx.u32_zero_value)};
-        record_index = ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr,
-                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
-                                        ctx.u32_zero_value, ctx.Const(1U));
-    } else {
+        // Atomic increment is for query byte-count emulation only; record placement uses a
+        // deterministic per-invocation index so captured stream data stays in draw order.
+        ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr, ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                         ctx.u32_zero_value, ctx.Const(1U));
+    }
+    Id record_index{};
+    if (Sirit::ValidId(ctx.vertex_index)) {
         record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
+    } else if (Sirit::ValidId(ctx.vertex_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_id);
+    } else if (Sirit::ValidId(ctx.invocation_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
+    } else if (Sirit::ValidId(ctx.primitive_id)) {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.primitive_id);
+    } else {
+        record_index = ctx.u32_zero_value;
     }
     const Id element_ptr{ctx.storage_types.F32.element};
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <bit>
+#include <limits>
 #include <tuple>
 #include <utility>
 
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
+#include "shader_recompiler/exception.h"
 
 namespace Shader::Backend::SPIRV {
 namespace {
@@ -168,6 +170,101 @@ Id GetCbufElement(EmitContext& ctx, Id vector, const IR::Value& offset, u32 inde
         element = ctx.OpIAdd(ctx.U32[1], element, ctx.Const(index_offset));
     }
     return ctx.OpVectorExtractDynamic(ctx.U32[1], vector, element);
+}
+
+void ConditionalStore(EmitContext& ctx, Id condition, Id pointer, Id value) {
+    const Id merge_label = ctx.OpLabel();
+    const Id store_label = ctx.OpLabel();
+    const Id skip_label = ctx.OpLabel();
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(condition, store_label, skip_label);
+    ctx.AddLabel(store_label);
+    ctx.OpStore(pointer, value);
+    ctx.OpBranch(merge_label);
+    ctx.AddLabel(skip_label);
+    ctx.OpBranch(merge_label);
+    ctx.AddLabel(merge_label);
+}
+
+void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
+    if (!ctx.runtime_info.emulate_transform_feedback || ctx.runtime_info.xfb_count == 0) {
+        return;
+    }
+    const u32 base = ctx.runtime_info.xfb_emulation_ssbo_base;
+    if (base == std::numeric_limits<u32>::max()) {
+        return;
+    }
+    const u32 counter_ssbo = base + 4;
+    Id record_index{};
+    if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
+        ctx.AddCapability(spv::Capability::AtomicStorage);
+        const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                               ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
+                                               ctx.u32_zero_value)};
+        record_index = ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr,
+                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                                        ctx.u32_zero_value, ctx.Const(1U));
+    } else {
+        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
+    }
+    const Id element_ptr{ctx.storage_types.F32.element};
+
+    for (u32 attr_u32 = static_cast<u32>(IR::Attribute::PositionX); attr_u32 < 256; ++attr_u32) {
+        const auto& xv = ctx.runtime_info.xfb_varyings[attr_u32];
+        if (xv.components == 0) {
+            continue;
+        }
+        if (xv.buffer >= 4) {
+            continue;
+        }
+        const u32 ssbo_idx = base + xv.buffer;
+        if (ssbo_idx >= ctx.ssbos.size()) {
+            continue;
+        }
+        const Id ssbo_array_id = ctx.ssbos[ssbo_idx].F32;
+        if (!Sirit::ValidId(ssbo_array_id)) {
+            continue;
+        }
+        const Id stride_bytes{ctx.Const(xv.stride)};
+        const Id base_byte{ctx.OpIMul(ctx.U32[1], record_index, stride_bytes)};
+        for (u32 c = 0; c < xv.components; ++c) {
+            const u32 comp_attr = attr_u32 + c;
+            if (comp_attr >= 256) {
+                break;
+            }
+            const IR::Attribute attr = static_cast<IR::Attribute>(comp_attr);
+            std::optional<OutAttr> output;
+            try {
+                output = OutputAttrPointer(ctx, attr);
+            } catch (const NotImplementedException&) {
+                continue;
+            }
+            if (!output) {
+                continue;
+            }
+            Id value{};
+            if (Sirit::ValidId(output->type)) {
+                const Id raw{ctx.OpLoad(output->type, output->pointer)};
+                value = ctx.OpBitcast(ctx.F32[1], raw);
+            } else {
+                value = ctx.OpLoad(ctx.F32[1], output->pointer);
+            }
+            const Id byte_off{ctx.Const(xv.offset + c * 4)};
+            const Id abs_byte{ctx.OpIAdd(ctx.U32[1], base_byte, byte_off)};
+            const Id word_idx{ctx.OpShiftRightLogical(ctx.U32[1], abs_byte, ctx.Const(2u))};
+            const Id dst_ptr{
+                ctx.OpAccessChain(element_ptr, ssbo_array_id, ctx.u32_zero_value, word_idx)};
+            const u32 buffer_bytes = ctx.runtime_info.xfb_buffer_bytes[xv.buffer];
+            if (buffer_bytes == 0) {
+                ctx.OpStore(dst_ptr, value);
+                continue;
+            }
+            const Id size_bytes{ctx.Const(buffer_bytes)};
+            const Id end_byte{ctx.OpIAdd(ctx.U32[1], abs_byte, ctx.Const(4u))};
+            const Id in_bounds{ctx.OpULessThanEqual(ctx.U1, end_byte, size_bytes)};
+            ConditionalStore(ctx, in_bounds, dst_ptr, value);
+        }
+    }
 }
 } // Anonymous namespace
 
@@ -616,6 +713,10 @@ Id EmitLoadLocal(EmitContext& ctx, Id word_offset) {
 void EmitWriteLocal(EmitContext& ctx, Id word_offset, Id value) {
     const Id pointer{ctx.OpAccessChain(ctx.private_u32, ctx.local_memory, word_offset)};
     ctx.OpStore(pointer, value);
+}
+
+void EmitTransformFeedbackEmulationStores(EmitContext& ctx) {
+    EmitTransformFeedbackEmulationStoresImpl(ctx);
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -47,6 +47,9 @@ std::optional<OutAttr> OutputAttrPointer(EmitContext& ctx, IR::Attribute attr) {
         const u32 index{IR::GenericAttributeIndex(attr)};
         const u32 element{IR::GenericAttributeElement(attr)};
         const GenericElementInfo& info{ctx.output_generics.at(index).at(element)};
+        if (info.num_components == 0) {
+            return std::nullopt;
+        }
         if (info.num_components == 1) {
             return info.id;
         } else {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -197,28 +197,25 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
     if (base == std::numeric_limits<u32>::max()) {
         return;
     }
+    static constexpr u32 kXfbQueryCounterWord = 0;
+    static constexpr u32 kXfbRecordOrdinalWord = 4;
     const u32 counter_ssbo = base + 4;
+    Id record_index{ctx.u32_zero_value};
     if (counter_ssbo < ctx.ssbos.size() && Sirit::ValidId(ctx.ssbos[counter_ssbo].U32)) {
         ctx.AddCapability(spv::Capability::AtomicStorage);
-        const Id counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
-                                               ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
-                                               ctx.u32_zero_value)};
-        // Atomic increment is for query byte-count emulation only; record placement uses a
-        // deterministic per-invocation index so captured stream data stays in draw order.
-        ctx.OpAtomicIAdd(ctx.U32[1], counter_ptr, ctx.Const(static_cast<u32>(spv::Scope::Device)),
-                         ctx.u32_zero_value, ctx.Const(1U));
-    }
-    Id record_index{};
-    if (Sirit::ValidId(ctx.vertex_index)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_index);
-    } else if (Sirit::ValidId(ctx.vertex_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.vertex_id);
-    } else if (Sirit::ValidId(ctx.invocation_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
-    } else if (Sirit::ValidId(ctx.primitive_id)) {
-        record_index = ctx.OpLoad(ctx.U32[1], ctx.primitive_id);
-    } else {
-        record_index = ctx.u32_zero_value;
+        const Id query_counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                                     ctx.ssbos[counter_ssbo].U32, ctx.u32_zero_value,
+                                                     ctx.Const(kXfbQueryCounterWord))};
+        ctx.OpAtomicIAdd(ctx.U32[1], query_counter_ptr,
+                         ctx.Const(static_cast<u32>(spv::Scope::Device)), ctx.u32_zero_value,
+                         ctx.Const(1U));
+        const Id record_counter_ptr{ctx.OpAccessChain(ctx.storage_types.U32.element,
+                                                      ctx.ssbos[counter_ssbo].U32,
+                                                      ctx.u32_zero_value,
+                                                      ctx.Const(kXfbRecordOrdinalWord))};
+        record_index = ctx.OpAtomicIAdd(ctx.U32[1], record_counter_ptr,
+                                        ctx.Const(static_cast<u32>(spv::Scope::Device)),
+                                        ctx.u32_zero_value, ctx.Const(1U));
     }
     const Id element_ptr{ctx.storage_types.F32.element};
 
@@ -272,9 +269,11 @@ void EmitTransformFeedbackEmulationStoresImpl(EmitContext& ctx) {
                 ctx.OpStore(dst_ptr, value);
                 continue;
             }
-            const Id size_bytes{ctx.Const(buffer_bytes)};
-            const Id end_byte{ctx.OpIAdd(ctx.U32[1], abs_byte, ctx.Const(4u))};
-            const Id in_bounds{ctx.OpULessThanEqual(ctx.U1, end_byte, size_bytes)};
+            const u32 max_records = xv.stride > 0 ? buffer_bytes / xv.stride : 0;
+            if (max_records == 0) {
+                continue;
+            }
+            const Id in_bounds{ctx.OpULessThan(ctx.U1, record_index, ctx.Const(max_records))};
             ConditionalStore(ctx, in_bounds, dst_ptr, value);
         }
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -36,10 +36,7 @@ public:
 
     explicit ImageOperands(EmitContext& ctx, const IR::Value& offset, const IR::Value& offset2) {
         if (offset2.IsEmpty()) {
-            if (offset.IsEmpty()) {
-                return;
-            }
-            Add(spv::ImageOperandsMask::Offset, ctx.Def(offset));
+            AddOffset(ctx, offset, ImageGatherOffsetAllowed);
             return;
         }
         const std::array values{offset.InstRecursive(), offset2.InstRecursive()};
@@ -53,10 +50,18 @@ public:
         }
         auto read{[&](unsigned int a, unsigned int b) { return values[a]->Arg(b).U32(); }};
 
+        const auto make_offset_pair = [&](u32 x, u32 y) {
+            if (ctx.profile.has_broken_unsigned_image_offsets) {
+                return ctx.SConst(static_cast<s32>(x), static_cast<s32>(y));
+            }
+            return ctx.Const(x, y);
+        };
+
         const Id offsets{ctx.ConstantComposite(
-            ctx.TypeArray(ctx.U32[2], ctx.Const(4U)), ctx.Const(read(0, 0), read(0, 1)),
-            ctx.Const(read(0, 2), read(0, 3)), ctx.Const(read(1, 0), read(1, 1)),
-            ctx.Const(read(1, 2), read(1, 3)))};
+            ctx.TypeArray(ctx.profile.has_broken_unsigned_image_offsets ? ctx.S32[2] : ctx.U32[2],
+                          ctx.Const(4U)),
+            make_offset_pair(read(0, 0), read(0, 1)), make_offset_pair(read(0, 2), read(0, 3)),
+            make_offset_pair(read(1, 0), read(1, 1)), make_offset_pair(read(1, 2), read(1, 3)))};
         Add(spv::ImageOperandsMask::ConstOffsets, offsets);
     }
 
@@ -164,7 +169,23 @@ private:
             }
         }
         if (runtime_offset_allowed) {
-            Add(spv::ImageOperandsMask::Offset, ctx.Def(offset));
+            Id offset_id{ctx.Def(offset)};
+            if (ctx.profile.has_broken_unsigned_image_offsets) {
+                const u32 num_components = [&] {
+                    switch (inst->GetOpcode()) {
+                    case IR::Opcode::CompositeConstructU32x2:
+                        return 2U;
+                    case IR::Opcode::CompositeConstructU32x3:
+                        return 3U;
+                    case IR::Opcode::CompositeConstructU32x4:
+                        return 4U;
+                    default:
+                        return 1U;
+                    }
+                }();
+                offset_id = ctx.OpBitcast(ctx.S32[num_components], offset_id);
+            }
+            Add(spv::ImageOperandsMask::Offset, offset_id);
         }
     }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -34,6 +34,7 @@ void EmitWorkgroupMemoryBarrier(EmitContext& ctx);
 void EmitDeviceMemoryBarrier(EmitContext& ctx);
 void EmitPrologue(EmitContext& ctx);
 void EmitEpilogue(EmitContext& ctx);
+void EmitTransformFeedbackEmulationStores(EmitContext& ctx);
 void EmitEmitVertex(EmitContext& ctx, const IR::Value& stream);
 void EmitEndPrimitive(EmitContext& ctx, const IR::Value& stream);
 void EmitGetRegister(EmitContext& ctx);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -140,10 +140,11 @@ void EmitPrologue(EmitContext& ctx) {
 }
 
 void EmitEpilogue(EmitContext& ctx) {
-    if (ctx.stage == Stage::VertexB && ctx.runtime_info.convert_depth_mode &&
-        !ctx.profile.support_native_ndc) {
+    if ((ctx.stage == Stage::VertexB || ctx.stage == Stage::TessellationEval) &&
+        ctx.runtime_info.convert_depth_mode && !ctx.profile.support_native_ndc) {
         ConvertDepthMode(ctx);
     }
+    EmitTransformFeedbackEmulationStores(ctx);
     if (ctx.stage == Stage::Fragment) {
         InitializeAlphaToCoverage(ctx);
         AlphaTest(ctx);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1576,6 +1576,10 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         if (input_type == AttributeType::Disabled) {
             continue;
         }
+        if (runtime_info.remapped_vertex_locations &&
+            runtime_info.vertex_locations[index] == Shader::VERTEX_INPUT_DROPPED) {
+            continue;
+        }
         const Id type{GetAttributeType(*this, input_type)};
         const Id id{DefineInput(*this, type, true)};
         const u32 location = runtime_info.remapped_vertex_locations

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -196,7 +196,7 @@ void DefineGenericOutput(EmitContext& ctx, size_t index, std::optional<u32> invo
         if (element > 0) {
             ctx.Decorate(id, spv::Decoration::Component, element);
         }
-        if (xfb_varying) {
+        if (xfb_varying && !ctx.runtime_info.emulate_transform_feedback) {
             ctx.Decorate(id, spv::Decoration::XfbBuffer, xfb_varying->buffer);
             ctx.Decorate(id, spv::Decoration::XfbStride, xfb_varying->stride);
             ctx.Decorate(id, spv::Decoration::Offset, xfb_varying->offset);
@@ -1578,7 +1578,10 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         }
         const Id type{GetAttributeType(*this, input_type)};
         const Id id{DefineInput(*this, type, true)};
-        Decorate(id, spv::Decoration::Location, static_cast<u32>(index));
+        const u32 location = runtime_info.remapped_vertex_locations
+                                 ? runtime_info.vertex_locations[index]
+                                 : static_cast<u32>(index);
+        Decorate(id, spv::Decoration::Location, location);
         Name(id, fmt::format("in_attr{}", index));
         input_generics[index] = GetAttributeInfo(*this, input_type, id);
 

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <map>
 #include <optional>
 #include <vector>
@@ -13,6 +14,9 @@
 #include "shader_recompiler/varying_state.h"
 
 namespace Shader {
+
+/// Guest vertex input slot that could not be mapped into the host limit (see PopulateVertexLocationRemap).
+constexpr u8 VERTEX_INPUT_DROPPED = 0xFF;
 
 enum class AttributeType : u8 {
     Float,
@@ -85,6 +89,12 @@ struct TransformFeedbackVarying {
 
 struct RuntimeInfo {
     std::array<AttributeType, 32> generic_input_types{};
+    /// Maps guest attribute index to SPIR-V/VkVertexInput location when MoltenVK caps at 16.
+    bool remapped_vertex_locations{};
+    std::array<u8, 32> vertex_locations{};
+    /// Maps guest vertex stream/binding index to Vulkan binding when MoltenVK caps at 16.
+    bool remapped_vertex_bindings{};
+    std::array<u8, 32> vertex_bindings{};
     VaryingState previous_stage_stores;
     std::map<IR::Attribute, IR::Attribute> previous_stage_legacy_stores_mapping;
 
@@ -111,6 +121,12 @@ struct RuntimeInfo {
     /// Transform feedback state for each varying
     std::array<TransformFeedbackVarying, 256> xfb_varyings{};
     u32 xfb_count{0};
+    /// Guest transform-feedback buffer sizes captured in pipeline state (bytes).
+    std::array<u32, 4> xfb_buffer_bytes{};
+    /// Stream-out is implemented with storage-buffer writes (MoltenVK / no VK_EXT_transform_feedback).
+    bool emulate_transform_feedback{};
+    /// First SSBO index of the four transform-feedback buffers; UINT_MAX if unused.
+    u32 xfb_emulation_ssbo_base{std::numeric_limits<u32>::max()};
 };
 
 } // namespace Shader

--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -25,6 +25,9 @@ DECLARE_ENUM_FLAG_OPERATORS(BufferFlagBits)
 /// Tag for creating null buffers with no storage or size
 struct NullBufferParams {};
 
+/// Tag for the Vulkan transform-feedback emulation atomic stream-index buffer (host-only)
+struct XfbStreamCounterBufferParams {};
+
 /**
  * Range tracking buffer container.
  *

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -23,6 +23,14 @@ BufferCache<P>::BufferCache(Tegra::MaxwellDeviceMemoryManager& device_memory_, R
     : runtime{runtime_}, device_memory{device_memory_}, memory_tracker{device_memory} {
     // Ensure the first slot is used for the null buffer
     void(slot_buffers.insert(runtime, NullBufferParams{}));
+    if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+        xfb_stream_counter_buffer_id =
+            slot_buffers.insert(runtime, XfbStreamCounterBufferParams{});
+        Register(xfb_stream_counter_buffer_id);
+        slot_buffers[xfb_stream_counter_buffer_id].Pick();
+        runtime.RegisterXfbEmulationCounterBuffer(
+            slot_buffers[xfb_stream_counter_buffer_id].Handle());
+    }
     gpu_modified_ranges.Clear();
     inline_buffer_id = NULL_BUFFER_ID;
 
@@ -441,8 +449,59 @@ void BufferCache<P>::BindGraphicsStorageBuffer(size_t stage, size_t ssbo_index, 
     channel_state->enabled_storage_buffers[stage] |= 1U << ssbo_index;
     channel_state->written_storage_buffers[stage] |= (is_written ? 1U : 0U) << ssbo_index;
 
+    GPUVAddr ssbo_addr{};
+    if (cbuf_index >= Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers) {
+        const u32 slot = cbuf_index - Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers;
+        if (slot == Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers) {
+            if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+                if (xfb_stream_counter_buffer_id == NULL_BUFFER_ID) {
+                    return;
+                }
+                channel_state->storage_buffers[stage][ssbo_index] = Binding{
+                    .device_addr = XFB_EMULATION_COUNTER_DEVICE_ADDR,
+                    .size = XFB_EMULATION_COUNTER_BUFFER_BYTES,
+                    .buffer_id = xfb_stream_counter_buffer_id,
+                };
+            }
+            return;
+        }
+        if (slot > Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers) [[unlikely]] {
+            LOG_ERROR(HW_GPU, "Invalid transform-feedback emulation storage cbuf slot {}", slot);
+            return;
+        }
+        const auto& tf = maxwell3d->regs.transform_feedback.buffers[slot];
+        const GPUVAddr gpu_addr = tf.Address() + static_cast<GPUVAddr>(tf.start_offset);
+        const s32 tf_size = tf.size;
+        u32 size = 0;
+        if (tf_size > 0) {
+            size = static_cast<u32>(tf_size);
+        } else {
+            size = static_cast<u32>(gpu_memory->GetMemoryLayoutSize(gpu_addr));
+        }
+        if (size == 0) [[unlikely]] {
+            LOG_WARNING(HW_GPU, "Transform-feedback emulation buffer has zero size (slot {})", slot);
+            return;
+        }
+        const u32 alignment = runtime.GetStorageBufferAlignment();
+        const GPUVAddr aligned_gpu_addr = Common::AlignDown(gpu_addr, alignment);
+        const u32 aligned_size = static_cast<u32>(gpu_addr - aligned_gpu_addr) + size;
+        const std::optional<DAddr> aligned_device_addr = gpu_memory->GpuToCpuAddress(aligned_gpu_addr);
+        const std::optional<DAddr> device_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
+        if (!aligned_device_addr || !device_addr) [[unlikely]] {
+            LOG_WARNING(HW_GPU, "Transform-feedback emulation buffer not mapped (slot {})", slot);
+            return;
+        }
+        const DAddr cpu_end = Common::AlignUp(*device_addr + size, Core::DEVICE_PAGESIZE);
+        channel_state->storage_buffers[stage][ssbo_index] = Binding{
+            .device_addr = *aligned_device_addr,
+            .size = is_written ? aligned_size : static_cast<u32>(cpu_end - *aligned_device_addr),
+            .buffer_id = BufferId{},
+        };
+        return;
+    }
+
     const auto& cbufs = maxwell3d->state.shader_stages[stage];
-    const GPUVAddr ssbo_addr = cbufs.const_buffers[cbuf_index].address + cbuf_offset;
+    ssbo_addr = cbufs.const_buffers[cbuf_index].address + cbuf_offset;
     channel_state->storage_buffers[stage][ssbo_index] =
         StorageBufferBinding(ssbo_addr, cbuf_index, is_written);
 }
@@ -666,6 +725,18 @@ void BufferCache<P>::PopAsyncBuffers() {
     async_buffers_death_ring.emplace_back(*async_buffer);
     async_buffers.pop_front();
     pending_downloads.pop_front();
+}
+
+template <class P>
+void BufferCache<P>::ClearXfbStreamCounterForDraw() {
+    if constexpr (!BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+        return;
+    }
+    if (xfb_stream_counter_buffer_id == NULL_BUFFER_ID) [[unlikely]] {
+        return;
+    }
+    Buffer& buf = slot_buffers[xfb_stream_counter_buffer_id];
+    runtime.ClearBuffer(buf.Handle(), 0, XFB_EMULATION_COUNTER_BUFFER_BYTES, 0);
 }
 
 template <class P>
@@ -893,7 +964,13 @@ void BufferCache<P>::BindHostGraphicsStorageBuffers(size_t stage) {
         const bool is_written = ((channel_state->written_storage_buffers[stage] >> index) & 1) != 0;
 
         if (is_written) {
-            MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+            if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+                if (binding.device_addr != XFB_EMULATION_COUNTER_DEVICE_ADDR) {
+                    MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+                }
+            } else {
+                MarkWrittenBuffer(binding.buffer_id, binding.device_addr, size);
+            }
         }
 
         if constexpr (NEEDS_BIND_STORAGE_INDEX) {
@@ -1206,6 +1283,12 @@ void BufferCache<P>::UpdateStorageBuffers(size_t stage) {
     ForEachEnabledBit(channel_state->enabled_storage_buffers[stage], [&](u32 index) {
         // Resolve buffer
         Binding& binding = channel_state->storage_buffers[stage][index];
+        if constexpr (BufferCacheHasXfbStreamCounterHostBuffer<P>()) {
+            if (binding.device_addr == XFB_EMULATION_COUNTER_DEVICE_ADDR) {
+                binding.buffer_id = xfb_stream_counter_buffer_id;
+                return;
+            }
+        }
         const BufferId buffer_id = FindBuffer(binding.device_addr, binding.size);
         binding.buffer_id = buffer_id;
     });

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -40,11 +40,7 @@ using BufferId = Common::SlotId;
 using VideoCore::Surface::PixelFormat;
 using namespace Common::Literals;
 
-#ifdef __APPLE__
-constexpr u32 NUM_VERTEX_BUFFERS = 16;
-#else
 constexpr u32 NUM_VERTEX_BUFFERS = 32;
-#endif
 constexpr u32 NUM_TRANSFORM_FEEDBACK_BUFFERS = 4;
 constexpr u32 NUM_GRAPHICS_UNIFORM_BUFFERS = 18;
 constexpr u32 NUM_COMPUTE_UNIFORM_BUFFERS = 8;
@@ -52,8 +48,21 @@ constexpr u32 NUM_STORAGE_BUFFERS = 16;
 constexpr u32 NUM_TEXTURE_BUFFERS = 32;
 constexpr u32 NUM_STAGES = 5;
 
+/// Device-address placeholder for TF stream-index counter binding (not guest memory).
+inline constexpr DAddr XFB_EMULATION_COUNTER_DEVICE_ADDR = 0x3F0000000ULL;
+inline constexpr u32 XFB_EMULATION_COUNTER_BUFFER_BYTES = 64;
+
 using UniformBufferSizes = std::array<std::array<u32, NUM_GRAPHICS_UNIFORM_BUFFERS>, NUM_STAGES>;
 using ComputeUniformBufferSizes = std::array<u32, NUM_COMPUTE_UNIFORM_BUFFERS>;
+
+template <typename P>
+constexpr bool BufferCacheHasXfbStreamCounterHostBuffer() {
+    if constexpr (requires { P::HAS_XFB_STREAM_COUNTER_HOST_BUFFER; }) {
+        return P::HAS_XFB_STREAM_COUNTER_HOST_BUFFER;
+    } else {
+        return false;
+    }
+}
 
 enum class ObtainBufferSynchronize : u32 {
     NoSynchronize = 0,
@@ -276,6 +285,8 @@ public:
     /// Pop asynchronous downloads
     void PopAsyncFlushes();
     void PopAsyncBuffers();
+
+    void ClearXfbStreamCounterForDraw();
 
     bool DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount);
 
@@ -530,6 +541,8 @@ public:
     u64 last_emergency_gc_log_frame = 0;
     u64 last_emergency_gc_log_usage = 0;
     u32 emergency_gc_logs_suppressed = 0;
+
+    BufferId xfb_stream_counter_buffer_id{NULL_BUFFER_ID};
 
     std::array<BufferId, ((1ULL << 34) >> CACHING_PAGEBITS)> page_table;
     Common::ScratchBuffer<u8> tmp_buffer;

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -121,8 +121,35 @@ void Fermi2D::Blit() {
     }
 
     memory_manager.FlushCaching();
-    if (!rasterizer->AccelerateSurfaceCopy(src, regs.dst, config)) {
+    static u32 fermi2d_diag_budget = 60;
+    const bool accelerated = rasterizer->AccelerateSurfaceCopy(src, regs.dst, config);
+    const auto dst_cpu = memory_manager.GpuToCpuAddress(regs.dst.Address());
+    const bool vi_scanout_dst =
+        dst_cpu && ((*dst_cpu & 0xFFF0000) == 0xABB0000 || (*dst_cpu & 0xFFF0000) == 0xB420000 ||
+                    (*dst_cpu & 0xFFF0000) == 0xBC90000);
+    if (vi_scanout_dst || fermi2d_diag_budget > 0) {
+        if (fermi2d_diag_budget > 0) {
+            --fermi2d_diag_budget;
+        }
+        LOG_INFO(HW_GPU,
+                 "Fermi2D blit: src=0x{:x} dst=0x{:x} dst_cpu=0x{:x} size={}x{} accelerated={} "
+                 "vi_scanout={}",
+                 src.Address(), regs.dst.Address(), dst_cpu.value_or(0),
+                 config.dst_x1 - config.dst_x0, config.dst_y1 - config.dst_y0, accelerated,
+                 vi_scanout_dst);
+    }
+    if (!accelerated) {
         sw_blitter->Blit(src, regs.dst, config);
+        const u32 dst_bpp =
+            BytesPerBlock(PixelFormatFromRenderTargetFormat(regs.dst.format));
+        const u64 dst_bytes = regs.dst.linear == MemoryLayout::BlockLinear
+                                  ? CalculateSize(true, dst_bpp, regs.dst.width, regs.dst.height,
+                                                  regs.dst.depth, regs.dst.block_height,
+                                                  regs.dst.block_depth)
+                                  : static_cast<u64>(regs.dst.pitch) * regs.dst.height;
+        if (const auto cpu_addr = memory_manager.GpuToCpuAddress(regs.dst.Address())) {
+            rasterizer->OnCPUWrite(*cpu_addr, dst_bytes);
+        }
     }
 }
 

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -127,10 +127,8 @@ void Fermi2D::Blit() {
     const bool vi_scanout_dst =
         dst_cpu && ((*dst_cpu & 0xFFF0000) == 0xABB0000 || (*dst_cpu & 0xFFF0000) == 0xB420000 ||
                     (*dst_cpu & 0xFFF0000) == 0xBC90000);
-    if (vi_scanout_dst || fermi2d_diag_budget > 0) {
-        if (fermi2d_diag_budget > 0) {
-            --fermi2d_diag_budget;
-        }
+    if (fermi2d_diag_budget > 0) {
+        --fermi2d_diag_budget;
         LOG_INFO(HW_GPU,
                  "Fermi2D blit: src=0x{:x} dst=0x{:x} dst_cpu=0x{:x} size={}x{} accelerated={} "
                  "vi_scanout={}",

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -112,6 +112,9 @@ struct GPU::Impl {
     template <typename Func>
     [[nodiscard]] u64 RequestSyncOperation(Func&& action) {
         std::unique_lock lck{sync_request_mutex};
+        if (shutting_down.load(std::memory_order_acquire)) {
+            return current_sync_fence.load(std::memory_order_acquire);
+        }
         const u64 fence = ++last_sync_fence;
         sync_requests.emplace_back(action);
         return fence;
@@ -229,6 +232,7 @@ struct GPU::Impl {
     /// This can be used to launch any necessary threads and register any necessary
     /// core timing events.
     void Start() {
+        shutting_down.store(false, std::memory_order_release);
         Settings::UpdateGPUAccuracy();
         gpu_thread.StartThread(*renderer, renderer->Context(), *scheduler);
     }

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -42,9 +42,7 @@ struct GPU::Impl {
           gpu_thread{system_, is_async_}, scheduler{std::make_unique<Control::Scheduler>(gpu)} {}
 
     ~Impl() {
-        if (rasterizer) {
-            rasterizer->Shutdown();
-        }
+        NotifyShutdown();
     }
 
     std::shared_ptr<Control::ChannelState> CreateChannel(s32 channel_id) {
@@ -131,6 +129,9 @@ struct GPU::Impl {
 
     /// Tick pending requests within the GPU.
     void TickWork() {
+        if (shutting_down.load(std::memory_order_acquire)) {
+            return;
+        }
         std::unique_lock lck{sync_request_mutex};
         while (!sync_requests.empty()) {
             auto request = std::move(sync_requests.front());
@@ -218,6 +219,9 @@ struct GPU::Impl {
     }
 
     void RendererFrameEndNotify() {
+        if (shutting_down.load(std::memory_order_acquire)) {
+            return;
+        }
         system.GetPerfStats().EndGameFrame();
     }
 
@@ -230,9 +234,27 @@ struct GPU::Impl {
     }
 
     void NotifyShutdown() {
-        std::unique_lock lk{sync_mutex};
-        shutting_down.store(true, std::memory_order::relaxed);
-        sync_cv.notify_all();
+        if (shutting_down.exchange(true, std::memory_order_acq_rel)) {
+            return;
+        }
+        {
+            std::scoped_lock lk{sync_mutex};
+            sync_cv.notify_all();
+        }
+        {
+            std::unique_lock lck{sync_request_mutex};
+            sync_requests.clear();
+            current_sync_fence.store(last_sync_fence, std::memory_order_release);
+            sync_request_cv.notify_all();
+        }
+        gpu_thread.Stop();
+        if (rasterizer) {
+            rasterizer->Shutdown();
+        }
+    }
+
+    [[nodiscard]] bool IsShuttingDown() const {
+        return shutting_down.load(std::memory_order_acquire);
     }
 
     /// Obtain the CPU Context
@@ -545,6 +567,10 @@ void GPU::Start() {
 
 void GPU::NotifyShutdown() {
     impl->NotifyShutdown();
+}
+
+bool GPU::IsShuttingDown() const {
+    return impl->IsShuttingDown();
 }
 
 void GPU::ObtainContext() {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -225,6 +225,8 @@ public:
     /// Performs any additional necessary steps to shutdown GPU emulation.
     void NotifyShutdown();
 
+    [[nodiscard]] bool IsShuttingDown() const;
+
     /// Obtain the CPU Context
     void ObtainContext();
 

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -88,6 +88,14 @@ void ThreadManager::TickGPU() {
     PushCommand(GPUTickCommand());
 }
 
+void ThreadManager::Stop() {
+    if (!thread.joinable()) {
+        return;
+    }
+    thread.request_stop();
+    thread.join();
+}
+
 void ThreadManager::InvalidateRegion(DAddr addr, u64 size) {
     rasterizer->OnCacheInvalidation(addr, size);
 }

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -121,6 +121,9 @@ public:
 
     void TickGPU();
 
+    /// Stops and joins the GPU thread. Safe to call multiple times.
+    void Stop();
+
 private:
     /// Pushes a command to be executed by the GPU thread
     u64 PushCommand(CommandData&& command_data, bool block = false);

--- a/src/video_core/macro.cpp
+++ b/src/video_core/macro.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <optional>
 #include <span>
+#include <unordered_set>
 
 #include <fstream>
 #include <variant>
@@ -287,9 +288,15 @@ void HLE_DrawIndirectByteCount::Execute(Engines::Maxwell3D& maxwell3d, std::span
     const bool force = maxwell3d.Rasterizer().HasDrawTransformFeedback();
     auto topology = Maxwell3D::Regs::PrimitiveTopology(parameters[0] & 0xFFFFU);
     if (!force && (!maxwell3d.AnyParametersDirty() || !IsTopologySafe(topology))) {
+        LOG_INFO(HW_GPU,
+                 "HLE DrawIndirectByteCount fallback: force={} topology={} byte_count={} stride={}",
+                 force, static_cast<u32>(topology), parameters[2], parameters[1]);
         Fallback(maxwell3d, parameters);
         return;
     }
+    LOG_INFO(HW_GPU,
+             "HLE DrawIndirectByteCount execute: force={} topology={} byte_count={} stride={}",
+             force, static_cast<u32>(topology), parameters[2], parameters[1]);
     auto& params = maxwell3d.draw_manager->GetIndirectParams();
     params.is_byte_count = true;
     params.is_indexed = false;
@@ -311,9 +318,12 @@ void HLE_DrawIndirectByteCount::Fallback(Engines::Maxwell3D& maxwell3d, std::spa
     maxwell3d.regs.draw_auto_stride = parameters[1];
     maxwell3d.regs.draw_auto_byte_count = parameters[2];
 
-    maxwell3d.draw_manager->DrawArray(
-        maxwell3d.regs.draw.topology, 0,
-        maxwell3d.regs.draw_auto_byte_count / maxwell3d.regs.draw_auto_stride, 0, 1);
+    const u32 stride = std::max(maxwell3d.regs.draw_auto_stride, 1u);
+    const u32 vertex_count = maxwell3d.regs.draw_auto_byte_count / stride;
+    LOG_INFO(HW_GPU,
+             "HLE DrawIndirectByteCount DrawArray: byte_count={} stride={} vertex_count={}",
+             maxwell3d.regs.draw_auto_byte_count, stride, vertex_count);
+    maxwell3d.draw_manager->DrawArray(maxwell3d.regs.draw.topology, 0, vertex_count, 0, 1);
 }
 void HLE_C713C83D8F63CCF3::Execute(Engines::Maxwell3D& maxwell3d, std::span<const u32> parameters, [[maybe_unused]] u32 method) {
     maxwell3d.RefreshParameters();
@@ -1371,6 +1381,15 @@ static void Dump(u64 hash, std::span<const u32> code, bool decompiled = false) {
 }
 
 void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method, std::span<const u32> parameters) {
+    auto const log_macro_once = [method](u64 hash) {
+        static std::unordered_set<u64> seen_hashes;
+        if (!seen_hashes.insert(hash).second) {
+            return;
+        }
+        const bool uses_hle = CanBeHLEProgram(hash) && !Settings::values.disable_macro_hle;
+        LOG_INFO(Render_Vulkan, "GPU macro hash=0x{:016x} method=0x{:x} hle={}", hash, method,
+                 uses_hle);
+    };
     auto const execute_variant = [&maxwell3d, &parameters, method](AnyCachedMacro& acm) {
         if (auto a = std::get_if<HLE_DrawArraysIndirect>(&acm))
             a->Execute(maxwell3d, parameters, method);
@@ -1403,6 +1422,7 @@ void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method, std::span<c
     };
     if (auto const it = macro_cache.find(method); it != macro_cache.end()) {
         auto& ci = it->second;
+        log_macro_once(ci.hash);
         if (!CanBeHLEProgram(ci.hash) || Settings::values.disable_macro_hle)
             maxwell3d.RefreshParameters(); //LLE must reload parameters
         execute_variant(ci.program);
@@ -1440,6 +1460,7 @@ void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method, std::span<c
         } else {
             maxwell3d.RefreshParameters();
         }
+        log_macro_once(ci.hash);
         execute_variant(ci.program);
         if (Settings::values.dump_macros) {
             Dump(ci.hash, macro_code->second, !std::holds_alternative<std::monostate>(ci.program));

--- a/src/video_core/macro.cpp
+++ b/src/video_core/macro.cpp
@@ -288,13 +288,13 @@ void HLE_DrawIndirectByteCount::Execute(Engines::Maxwell3D& maxwell3d, std::span
     const bool force = maxwell3d.Rasterizer().HasDrawTransformFeedback();
     auto topology = Maxwell3D::Regs::PrimitiveTopology(parameters[0] & 0xFFFFU);
     if (!force && (!maxwell3d.AnyParametersDirty() || !IsTopologySafe(topology))) {
-        LOG_INFO(HW_GPU,
+        LOG_DEBUG(HW_GPU,
                  "HLE DrawIndirectByteCount fallback: force={} topology={} byte_count={} stride={}",
                  force, static_cast<u32>(topology), parameters[2], parameters[1]);
         Fallback(maxwell3d, parameters);
         return;
     }
-    LOG_INFO(HW_GPU,
+    LOG_DEBUG(HW_GPU,
              "HLE DrawIndirectByteCount execute: force={} topology={} byte_count={} stride={}",
              force, static_cast<u32>(topology), parameters[2], parameters[1]);
     auto& params = maxwell3d.draw_manager->GetIndirectParams();
@@ -320,7 +320,7 @@ void HLE_DrawIndirectByteCount::Fallback(Engines::Maxwell3D& maxwell3d, std::spa
 
     const u32 stride = std::max(maxwell3d.regs.draw_auto_stride, 1u);
     const u32 vertex_count = maxwell3d.regs.draw_auto_byte_count / stride;
-    LOG_INFO(HW_GPU,
+    LOG_DEBUG(HW_GPU,
              "HLE DrawIndirectByteCount DrawArray: byte_count={} stride={} vertex_count={}",
              maxwell3d.regs.draw_auto_byte_count, stride, vertex_count);
     maxwell3d.draw_manager->DrawArray(maxwell3d.regs.draw.topology, 0, vertex_count, 0, 1);

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -175,5 +175,10 @@ public:
     virtual bool HasDrawTransformFeedback() {
         return false;
     }
+
+    /// Resolve byte count for DrawIndirectByteCount from the counter buffer.
+    virtual u32 ReadDrawIndirectByteCount(GPUVAddr counter_gpu_addr, u32 register_fallback) {
+        return register_fallback;
+    }
 };
 } // namespace VideoCore

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -96,6 +96,17 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d, DynamicFe
                 const u32 type = LUT[static_cast<size_t>(attrs[i].type.Value())];
                 attribute_types |= static_cast<u64>(type & mask) << (i * 2);
             }
+            for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes;
+                 ++index) {
+                const auto& input = regs.vertex_attrib_format[index];
+                auto& attribute = attributes[index];
+                attribute.raw = 0;
+                attribute.enabled.Assign(input.constant ? 0 : 1);
+                attribute.buffer.Assign(input.buffer);
+                attribute.offset.Assign(input.offset);
+                attribute.type.Assign(static_cast<u32>(input.type.Value()));
+                attribute.size.Assign(static_cast<u32>(input.size.Value()));
+            }
         } else {
             maxwell3d.dirty.flags[Dirty::VertexInput] = false;
             enabled_divisors = 0;

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -24,6 +24,8 @@ void RefreshXfbState(VideoCommon::TransformFeedbackState& state, const Tegra::En
                                    .stride = layout.stride,
                                };
                            });
+    std::ranges::transform(regs.transform_feedback.buffers, state.buffer_sizes.begin(),
+                           [](const auto& buffer) { return buffer.size; });
     state.varyings = regs.stream_out_layout;
 }
 } // Anonymous namespace
@@ -39,7 +41,9 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d, DynamicFe
     extended_dynamic_state_3_blend.Assign(features.has_extended_dynamic_state_3_blend ? 1 : 0);
     extended_dynamic_state_3_enables.Assign(features.has_extended_dynamic_state_3_enables ? 1 : 0);
     dynamic_vertex_input.Assign(features.has_dynamic_vertex_input ? 1 : 0);
-    xfb_enabled.Assign(features.has_transform_feedback && regs.transform_feedback_enabled != 0);
+    xfb_enabled.Assign((features.has_transform_feedback || features.emulate_transform_feedback) &&
+                       regs.transform_feedback_enabled != 0);
+    xfb_emulated.Assign(features.emulate_transform_feedback && regs.transform_feedback_enabled != 0);
     ndc_minus_one_to_one.Assign(regs.depth_mode == Tegra::Engines::Maxwell3D::Regs::DepthMode::MinusOneToOne ? 1 : 0);
     polygon_mode.Assign(PackPolygonMode(regs.polygon_mode_front));
     tessellation_primitive.Assign(static_cast<u32>(regs.tessellation.params.domain_type.Value()));

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -23,6 +23,8 @@ struct DynamicFeatures {
     bool has_extended_dynamic_state_3_enables;
     bool has_dynamic_vertex_input;
     bool has_transform_feedback;
+    /// Software stream-out when the host lacks VK_EXT_transform_feedback (e.g. MoltenVK).
+    bool emulate_transform_feedback;
 };
 
 struct FixedPipelineState {
@@ -201,6 +203,7 @@ struct FixedPipelineState {
     };
     union {
         u32 raw2;
+        BitField<0, 1, u32> xfb_emulated;
         BitField<1, 3, u32> alpha_test_func;
         BitField<4, 1, u32> early_z;
         BitField<5, 1, u32> depth_enabled;

--- a/src/video_core/renderer_vulkan/present/layer.cpp
+++ b/src/video_core/renderer_vulkan/present/layer.cpp
@@ -7,6 +7,7 @@
 
 #include "common/settings.h"
 #include "video_core/framebuffer_config.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_vulkan/present/fsr.h"
 #include "video_core/renderer_vulkan/present/fsr2.h"
 #include "video_core/renderer_vulkan/present/fxaa.h"
@@ -75,13 +76,28 @@ void Layer::ConfigureDraw(PresentPushConstants* out_push_constants,
                           VkSampler sampler, size_t image_index,
                           const Tegra::FramebufferConfig& framebuffer,
                           const Layout::FramebufferLayout& layout) {
-    const auto texture_info = rasterizer.AccelerateDisplay(
-        framebuffer, framebuffer.address + framebuffer.offset, framebuffer.stride);
+    const DAddr framebuffer_addr = framebuffer.address + framebuffer.offset;
+    rasterizer.CompositeGameRtToViAtPresent(framebuffer, framebuffer_addr);
+    const auto texture_info = rasterizer.AccelerateDisplay(framebuffer, framebuffer_addr,
+                                                           framebuffer.stride);
     const u32 texture_width = texture_info ? texture_info->width : framebuffer.width;
     const u32 texture_height = texture_info ? texture_info->height : framebuffer.height;
     const u32 scaled_width = texture_info ? texture_info->scaled_width : texture_width;
     const u32 scaled_height = texture_info ? texture_info->scaled_height : texture_height;
-    const bool use_accelerated = texture_info.has_value();
+    const u64 fb_bytes = GetSizeInBytes(framebuffer);
+    bool use_accelerated = texture_info.has_value();
+    // A registered GPU image with no GPU writes is stale (e.g. software Fermi2D blit wrote guest
+    // memory only). Fall back to the slow path that reads guest RAM. Use guest_addr when
+    // AccelerateDisplay remapped to an offscreen render target (VI addr != draw RT addr).
+    const DAddr texture_guest_addr =
+        texture_info && texture_info->guest_addr != 0 ? texture_info->guest_addr : framebuffer_addr;
+    const u64 texture_guest_bytes =
+        texture_info && texture_info->guest_bytes != 0 ? texture_info->guest_bytes : fb_bytes;
+    if (use_accelerated && texture_guest_addr != 0 && texture_guest_bytes > 0 &&
+        !rasterizer.MustFlushRegion(texture_guest_addr, texture_guest_bytes,
+                                    VideoCommon::CacheType::TextureCache)) {
+        use_accelerated = false;
+    }
 
     RefreshResources(framebuffer);
     SetAntiAliasPass();
@@ -94,12 +110,15 @@ void Layer::ConfigureDraw(PresentPushConstants* out_push_constants,
     };
 
     if (!use_accelerated) {
+        if (framebuffer_addr != 0 && fb_bytes > 0) {
+            rasterizer.FlushRegion(framebuffer_addr, fb_bytes);
+        }
         UpdateRawImage(framebuffer, image_index);
     }
 
-    VkImage source_image = texture_info ? texture_info->image : *raw_images[image_index];
+    VkImage source_image = use_accelerated ? texture_info->image : *raw_images[image_index];
     VkImageView source_image_view =
-        texture_info ? texture_info->image_view : *raw_image_views[image_index];
+        use_accelerated ? texture_info->image_view : *raw_image_views[image_index];
 
     anti_alias->Draw(scheduler, image_index, &source_image, &source_image_view);
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -138,7 +139,7 @@ RendererVulkan::~RendererVulkan() {
 }
 
 void RendererVulkan::Composite(std::span<const Tegra::FramebufferConfig> framebuffers) {
-    if (framebuffers.empty()) {
+    if (framebuffers.empty() || gpu.IsShuttingDown()) {
         return;
     }
 
@@ -146,6 +147,10 @@ void RendererVulkan::Composite(std::span<const Tegra::FramebufferConfig> framebu
 
     // Check if frame should be skipped
     if (frame_skipping.ShouldSkipFrame(frame_start_time)) {
+        static std::once_flag skip_once;
+        std::call_once(skip_once, [] {
+            LOG_INFO(Render_Vulkan, "Composite: skipped by frame skipping");
+        });
         // Skip rendering but still notify the GPU
         gpu.RendererFrameEndNotify();
         rasterizer.TickFrame();
@@ -159,7 +164,21 @@ void RendererVulkan::Composite(std::span<const Tegra::FramebufferConfig> framebu
     RenderAppletCaptureLayer(framebuffers);
 
     if (!render_window.IsShown()) {
+        static std::once_flag hidden_once;
+        std::call_once(hidden_once, [] {
+            LOG_INFO(Render_Vulkan, "Composite: window not shown (minimized?)");
+        });
         return;
+    }
+
+    static u32 composite_diag_budget = 120;
+    if (composite_diag_budget > 0) {
+        --composite_diag_budget;
+        const auto& fb = framebuffers.front();
+        LOG_INFO(Render_Vulkan,
+                 "Composite: layers={} primary={}x{} addr=0x{:x} stride={} format={}",
+                 framebuffers.size(), fb.width, fb.height, fb.address + fb.offset, fb.stride,
+                 static_cast<u32>(fb.pixel_format));
     }
 
     RenderScreenshot(framebuffers);

--- a/src/video_core/renderer_vulkan/vertex_location_remap.h
+++ b/src/video_core/renderer_vulkan/vertex_location_remap.h
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "common/common_types.h"
+#include "shader_recompiler/program_header.h"
+#include "shader_recompiler/runtime_info.h"
+#include "video_core/renderer_vulkan/fixed_pipeline_state.h"
+
+namespace Vulkan {
+
+[[nodiscard]] inline bool IsVertexAttributeActive(const FixedPipelineState& state, size_t index,
+                                                  const Shader::Info& info) {
+    if (!info.loads.Generic(index)) {
+        return false;
+    }
+    if (state.dynamic_vertex_input != 0) {
+        return state.DynamicAttributeType(index) != 0;
+    }
+    return state.attributes[index].enabled != 0;
+}
+
+[[nodiscard]] inline bool IsVertexBindingUsedByMappedAttributes(
+    u32 binding, const FixedPipelineState& state, const Shader::Info& info,
+    const Shader::RuntimeInfo& runtime_info) {
+    for (size_t index = 0; index < state.attributes.size(); ++index) {
+        if (!IsVertexAttributeActive(state, index, info)) {
+            continue;
+        }
+        if (runtime_info.remapped_vertex_locations &&
+            runtime_info.vertex_locations[index] == Shader::VERTEX_INPUT_DROPPED) {
+            continue;
+        }
+        if (state.attributes[index].buffer == binding) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline void PopulateVertexLocationRemap(Shader::RuntimeInfo& runtime_info, u32 max_locations,
+                                        u32 max_bindings, const FixedPipelineState& state,
+                                        const Shader::Info& vertex_info) {
+    for (size_t i = 0; i < runtime_info.vertex_locations.size(); ++i) {
+        runtime_info.vertex_locations[i] = static_cast<u8>(i);
+        runtime_info.vertex_bindings[i] = static_cast<u8>(i);
+    }
+    runtime_info.remapped_vertex_locations = false;
+    runtime_info.remapped_vertex_bindings = false;
+
+    const bool needs_location_remap = max_locations < runtime_info.vertex_locations.size();
+    const bool needs_binding_remap = max_bindings < runtime_info.vertex_bindings.size();
+    if (!needs_location_remap && !needs_binding_remap) {
+        return;
+    }
+
+    if (needs_location_remap) {
+        u32 location_slot = 0;
+        for (size_t guest = 0; guest < runtime_info.vertex_locations.size(); ++guest) {
+            if (!IsVertexAttributeActive(state, guest, vertex_info)) {
+                continue;
+            }
+            if (location_slot >= max_locations) {
+                runtime_info.vertex_locations[guest] = Shader::VERTEX_INPUT_DROPPED;
+                runtime_info.remapped_vertex_locations = true;
+                continue;
+            }
+            const u8 vulkan_location = static_cast<u8>(location_slot);
+            runtime_info.vertex_locations[guest] = vulkan_location;
+            if (vulkan_location != guest) {
+                runtime_info.remapped_vertex_locations = true;
+            }
+            ++location_slot;
+        }
+    }
+
+    if (needs_binding_remap) {
+        u32 binding_slot = 0;
+        for (size_t guest = 0; guest < runtime_info.vertex_bindings.size(); ++guest) {
+            if (!IsVertexBindingUsedByMappedAttributes(static_cast<u32>(guest), state, vertex_info,
+                                                       runtime_info)) {
+                continue;
+            }
+            if (binding_slot >= max_bindings) {
+                runtime_info.vertex_bindings[guest] = Shader::VERTEX_INPUT_DROPPED;
+                runtime_info.remapped_vertex_bindings = true;
+                continue;
+            }
+            const u8 vulkan_binding = static_cast<u8>(binding_slot);
+            runtime_info.vertex_bindings[guest] = vulkan_binding;
+            if (vulkan_binding != guest) {
+                runtime_info.remapped_vertex_bindings = true;
+            }
+            ++binding_slot;
+        }
+    }
+}
+
+[[nodiscard]] inline u32 VulkanVertexLocation(const Shader::RuntimeInfo& runtime_info,
+                                              size_t guest_index) {
+    if (runtime_info.remapped_vertex_locations) {
+        return runtime_info.vertex_locations[guest_index];
+    }
+    return static_cast<u32>(guest_index);
+}
+
+[[nodiscard]] inline u32 VulkanVertexBinding(const Shader::RuntimeInfo& runtime_info,
+                                             u32 guest_binding) {
+    if (runtime_info.remapped_vertex_bindings) {
+        return runtime_info.vertex_bindings[guest_binding];
+    }
+    return guest_binding;
+}
+
+[[nodiscard]] inline bool IsVertexAttributeMapped(const Shader::RuntimeInfo& runtime_info,
+                                                  size_t guest_index) {
+    return !runtime_info.remapped_vertex_locations ||
+           runtime_info.vertex_locations[guest_index] != Shader::VERTEX_INPUT_DROPPED;
+}
+
+[[nodiscard]] inline bool IsVertexBindingMapped(const Shader::RuntimeInfo& runtime_info,
+                                               u32 guest_binding) {
+    return !runtime_info.remapped_vertex_bindings ||
+           runtime_info.vertex_bindings[guest_binding] != Shader::VERTEX_INPUT_DROPPED;
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_blit_screen.h
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.h
@@ -43,6 +43,8 @@ struct FramebufferTextureInfo {
     u32 height{};
     u32 scaled_width{};
     u32 scaled_height{};
+    DAddr guest_addr{};
+    u64 guest_bytes{};
 };
 
 class BlitScreen {

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -229,7 +229,7 @@ u32 BufferCacheRuntime::ReadXfbEmulationCounterSnapshotRecords() {
     });
     scheduler.Finish();
     u32 records = 0;
-    std::memcpy(&records, counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+    std::memcpy(&records, counter_staging.mapped_span.data(), sizeof(u32));
     StagingBufferRef counter_staging_ref = counter_staging;
     staging_pool.FreeDeferred(counter_staging_ref);
     return records;
@@ -274,8 +274,7 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
             cmdbuf.CopyBuffer(snapshot_buffer, counter_staging.buffer, copy);
         });
         scheduler.Finish();
-        std::memcpy(&snapshot_records,
-                    counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+        std::memcpy(&snapshot_records, counter_staging.mapped_span.data(), sizeof(u32));
         StagingBufferRef counter_staging_ref = counter_staging;
         staging_pool.FreeDeferred(counter_staging_ref);
     }
@@ -313,6 +312,7 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
         .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
         .dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
     };
+    // CopyBuffer is only valid outside an active render pass.
     scheduler.RequestOutsideRenderPassOperationContext();
     scheduler.Record([counter_buffer, draw_buffer = *xfb_byte_count_draw_buffer, draw_staging,
                       guest_counter_buffer, guest_counter_offset](vk::CommandBuffer cmdbuf) {
@@ -823,6 +823,11 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset
     if (vk_index >= device.GetMaxVertexInputBindings()) {
         return;
     }
+    if (!device.HasNullDescriptor() && buffer == VK_NULL_HANDLE) {
+        ReserveNullBuffer();
+        buffer = *null_buffer;
+        offset = 0;
+    }
     if (device.IsExtExtendedDynamicStateSupported()) {
         scheduler.Record([binding = vk_index, buffer, offset, size, stride](vk::CommandBuffer cmdbuf) {
             const VkDeviceSize vk_offset = buffer != VK_NULL_HANDLE ? offset : 0;
@@ -831,11 +836,6 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset
             cmdbuf.BindVertexBuffers2EXT(binding, 1, &buffer, &vk_offset, &vk_size, &vk_stride);
         });
     } else {
-        if (!device.HasNullDescriptor() && buffer == VK_NULL_HANDLE) {
-            ReserveNullBuffer();
-            buffer = *null_buffer;
-            offset = 0;
-        }
         scheduler.Record([binding = vk_index, buffer, offset](vk::CommandBuffer cmdbuf) {
             cmdbuf.BindVertexBuffer(binding, buffer, offset);
         });

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -313,7 +313,7 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
         .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
         .dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
     };
-    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.RequestOutsideRenderPassOperationContext();
     scheduler.Record([counter_buffer, draw_buffer = *xfb_byte_count_draw_buffer, draw_staging,
                       guest_counter_buffer, guest_counter_offset](vk::CommandBuffer cmdbuf) {
         cmdbuf.PipelineBarrier(XfbEmulationWriteStages() | VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -336,6 +336,9 @@ void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buf
                                VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
                                    VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
                                0, DRAW_BARRIER);
+    });
+    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.Record([draw_buffer = *xfb_byte_count_draw_buffer](vk::CommandBuffer cmdbuf) {
         cmdbuf.DrawIndirect(draw_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     });
     StagingBufferRef draw_staging_ref = draw_staging;

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -10,6 +10,7 @@
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "common/literals.h"
+#include "common/logging.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 
 
@@ -84,7 +85,262 @@ vk::Buffer CreateBuffer(const Device& device, const MemoryAllocator& memory_allo
     return memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
 }
 
+constexpr VkPipelineStageFlags XfbEmulationWriteStages() {
+    return VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+           VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT |
+           VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+}
+
+vk::Buffer CreateXfbByteCountDrawBuffer(const Device& device, MemoryAllocator& memory_allocator,
+                                        StagingBufferPool& staging_pool, Scheduler& scheduler) {
+    static constexpr std::array<u32, 4> kDrawTemplate{0U, 1U, 0U, 0U};
+    const VkBufferCreateInfo buffer_ci{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = sizeof(kDrawTemplate),
+        .usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer draw_buffer = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        draw_buffer.SetObjectNameEXT("XFB byte-count draw indirect");
+    }
+    const StagingBufferRef staging =
+        staging_pool.Request(sizeof(kDrawTemplate), MemoryUsage::Upload, true);
+    std::memcpy(staging.mapped_span.data(), kDrawTemplate.data(), sizeof(kDrawTemplate));
+    const VkBuffer draw_buffer_handle = *draw_buffer;
+    scheduler.RequestOutsideRenderPassOperationContext();
+    scheduler.Record([draw_buffer_handle, staging](vk::CommandBuffer cmdbuf) {
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = staging.offset,
+            .dstOffset = 0,
+            .size = sizeof(kDrawTemplate),
+        }};
+        cmdbuf.CopyBuffer(staging.buffer, draw_buffer_handle, copy);
+    });
+    StagingBufferRef staging_ref = staging;
+    staging_pool.FreeDeferred(staging_ref);
+    return draw_buffer;
+}
+
 } // Anonymous namespace
+
+vk::Buffer CreateXfbStreamCounterBuffer(const Device& device, MemoryAllocator& memory_allocator) {
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                 VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer ret = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        ret.SetObjectNameEXT("XFB stream counter");
+    }
+    return ret;
+}
+
+vk::Buffer CreateXfbStreamCounterSnapshotBuffer(const Device& device,
+                                                MemoryAllocator& memory_allocator) {
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    vk::Buffer ret = memory_allocator.CreateBuffer(buffer_ci, MemoryUsage::DeviceLocal);
+    if (device.HasDebuggingToolAttached()) {
+        ret.SetObjectNameEXT("XFB stream counter snapshot");
+    }
+    return ret;
+}
+
+void BufferCacheRuntime::RegisterXfbEmulationCounterBuffer(VkBuffer buffer) {
+    xfb_emulation_counter_buffer = buffer;
+    if (!xfb_emulation_counter_snapshot_buffer) {
+        xfb_emulation_counter_snapshot_buffer =
+            CreateXfbStreamCounterSnapshotBuffer(device, memory_allocator);
+    }
+}
+
+void BufferCacheRuntime::SnapshotXfbEmulationCounter() {
+    if (xfb_emulation_counter_buffer == VK_NULL_HANDLE ||
+        !xfb_emulation_counter_snapshot_buffer) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB counter snapshot skipped: counter={} snapshot={}",
+                    xfb_emulation_counter_buffer != VK_NULL_HANDLE,
+                    static_cast<bool>(xfb_emulation_counter_snapshot_buffer));
+        return;
+    }
+    static constexpr VkMemoryBarrier READ_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    static constexpr VkMemoryBarrier WRITE_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    scheduler.RequestOutsideRenderPassOperationContext();
+    scheduler.Record([src_buffer = xfb_emulation_counter_buffer,
+                      dst_buffer = *xfb_emulation_counter_snapshot_buffer](vk::CommandBuffer cmdbuf) {
+        cmdbuf.PipelineBarrier(XfbEmulationWriteStages(), VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                               READ_BARRIER);
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = 0,
+            .dstOffset = 0,
+            .size = VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES,
+        }};
+        cmdbuf.CopyBuffer(src_buffer, dst_buffer, copy);
+        cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
+                               WRITE_BARRIER);
+    });
+}
+
+u32 BufferCacheRuntime::ReadXfbEmulationCounterSnapshotRecords() {
+    const VkBuffer snapshot_buffer = GetXfbEmulationCounterSnapshotBuffer();
+    if (snapshot_buffer == VK_NULL_HANDLE) {
+        return 0;
+    }
+    const StagingBufferRef counter_staging =
+        staging_pool.Request(sizeof(u32), MemoryUsage::Download, true);
+    scheduler.Finish();
+    scheduler.Record([snapshot_buffer, counter_staging](vk::CommandBuffer cmdbuf) {
+        std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+            .srcOffset = 0,
+            .dstOffset = counter_staging.offset,
+            .size = sizeof(u32),
+        }};
+        cmdbuf.CopyBuffer(snapshot_buffer, counter_staging.buffer, copy);
+    });
+    scheduler.Finish();
+    u32 records = 0;
+    std::memcpy(&records, counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+    StagingBufferRef counter_staging_ref = counter_staging;
+    staging_pool.FreeDeferred(counter_staging_ref);
+    return records;
+}
+
+void BufferCacheRuntime::EmulateDrawIndirectByteCount(VkBuffer guest_counter_buffer,
+                                                      u32 guest_counter_offset, u32 stride,
+                                                      u32 register_byte_fallback) {
+    const VkBuffer snapshot_buffer = GetXfbEmulationCounterSnapshotBuffer();
+    const VkBuffer counter_buffer =
+        snapshot_buffer != VK_NULL_HANDLE ? snapshot_buffer : xfb_emulation_counter_buffer;
+    const u32 safe_stride = std::max(stride, 1u);
+    const u32 register_vertex_count = register_byte_fallback / safe_stride;
+
+    LOG_INFO(Render_Vulkan,
+             "XFB DrawIndirectByteCount: stride={} register_byte_count={} "
+             "register_vertex_count={} has_snapshot={} has_counter={}",
+             stride, register_byte_fallback, register_vertex_count,
+             snapshot_buffer != VK_NULL_HANDLE, counter_buffer != VK_NULL_HANDLE);
+
+    if (counter_buffer == VK_NULL_HANDLE) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB DrawIndirectByteCount: no counter buffer; skipping draw");
+        return;
+    }
+    if (!xfb_byte_count_draw_buffer) {
+        xfb_byte_count_draw_buffer =
+            CreateXfbByteCountDrawBuffer(device, memory_allocator, staging_pool, scheduler);
+    }
+
+    u32 snapshot_records = 0;
+    if (snapshot_buffer != VK_NULL_HANDLE) {
+        const StagingBufferRef counter_staging =
+            staging_pool.Request(sizeof(u32), MemoryUsage::Download, true);
+        scheduler.Finish();
+        scheduler.Record([snapshot_buffer, counter_staging](vk::CommandBuffer cmdbuf) {
+            std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+                .srcOffset = 0,
+                .dstOffset = counter_staging.offset,
+                .size = sizeof(u32),
+            }};
+            cmdbuf.CopyBuffer(snapshot_buffer, counter_staging.buffer, copy);
+        });
+        scheduler.Finish();
+        std::memcpy(&snapshot_records,
+                    counter_staging.mapped_span.data() + counter_staging.offset, sizeof(u32));
+        StagingBufferRef counter_staging_ref = counter_staging;
+        staging_pool.FreeDeferred(counter_staging_ref);
+    }
+
+    // Counter snapshot stores emitted records (vertices). Prefer it over the register fallback,
+    // which may still be zero when the game expects the counter buffer to be authoritative.
+    u32 vertex_count = snapshot_records > 0 ? snapshot_records : register_vertex_count;
+    LOG_INFO(Render_Vulkan,
+             "XFB DrawIndirectByteCount: snapshot_records={} vertex_count={} "
+             "(source={})",
+             snapshot_records, vertex_count,
+             snapshot_records > 0 ? "snapshot" : "register");
+    if (vertex_count == 0) {
+        LOG_WARNING(Render_Vulkan,
+                    "XFB DrawIndirectByteCount: vertex_count=0; consume draw will be empty");
+    }
+    const StagingBufferRef draw_staging =
+        staging_pool.Request(sizeof(VkDrawIndirectCommand), MemoryUsage::Upload, true);
+    const VkDrawIndirectCommand draw_cmd{
+        .vertexCount = vertex_count,
+        .instanceCount = 1,
+        .firstVertex = 0,
+        .firstInstance = 0,
+    };
+    std::memcpy(draw_staging.mapped_span.data(), &draw_cmd, sizeof(draw_cmd));
+    static constexpr VkMemoryBarrier READ_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+    };
+    static constexpr VkMemoryBarrier DRAW_BARRIER{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
+    };
+    // Stay inside the active render pass: ending it before DrawIndirect discards output.
+    scheduler.Record([counter_buffer, draw_buffer = *xfb_byte_count_draw_buffer, draw_staging,
+                      guest_counter_buffer, guest_counter_offset](vk::CommandBuffer cmdbuf) {
+        cmdbuf.PipelineBarrier(XfbEmulationWriteStages() | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
+        std::array<VkBufferCopy, 1> draw_copy{VkBufferCopy{
+            .srcOffset = draw_staging.offset,
+            .dstOffset = 0,
+            .size = sizeof(VkDrawIndirectCommand),
+        }};
+        cmdbuf.CopyBuffer(draw_staging.buffer, draw_buffer, draw_copy);
+        if (guest_counter_buffer != VK_NULL_HANDLE) {
+            std::array<VkBufferCopy, 1> guest_records_copy{VkBufferCopy{
+                .srcOffset = 0,
+                .dstOffset = guest_counter_offset,
+                .size = sizeof(u32),
+            }};
+            cmdbuf.CopyBuffer(counter_buffer, guest_counter_buffer, guest_records_copy);
+        }
+        cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
+                                   VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
+                               0, DRAW_BARRIER);
+        cmdbuf.DrawIndirect(draw_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
+    });
+    StagingBufferRef draw_staging_ref = draw_staging;
+    staging_pool.FreeDeferred(draw_staging_ref);
+}
 
 void BufferCacheRuntime::CleanupUnusedBuffers() {
     // Cleanup is now handled by the VRAM management system (gc_aggressiveness setting)
@@ -100,6 +356,13 @@ Buffer::Buffer(BufferCacheRuntime& runtime, VideoCommon::NullBufferParams null_p
     buffer = runtime.CreateNullBuffer();
     is_null = true;
 }
+
+Buffer::Buffer(BufferCacheRuntime& runtime, VideoCommon::XfbStreamCounterBufferParams)
+    : VideoCommon::BufferBase(VideoCommon::XFB_EMULATION_COUNTER_DEVICE_ADDR,
+                              VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES),
+      device{&runtime.device},
+      buffer{CreateXfbStreamCounterBuffer(*device, runtime.memory_allocator)},
+      tracker{VideoCommon::XFB_EMULATION_COUNTER_BUFFER_BYTES} {}
 
 Buffer::Buffer(BufferCacheRuntime& runtime, DAddr cpu_addr_, u64 size_bytes_)
     : VideoCommon::BufferBase(cpu_addr_, size_bytes_), device{&runtime.device},
@@ -549,15 +812,20 @@ void BufferCacheRuntime::BindQuadIndexBuffer(PrimitiveTopology topology, u32 fir
 
 void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size,
                                           u32 stride) {
-    if (index >= device.GetMaxVertexInputBindings()) {
+    u32 vk_index = index;
+    if (vertex_binding_remap != nullptr && vertex_binding_remap->remapped_vertex_bindings &&
+        index < vertex_binding_remap->vertex_bindings.size()) {
+        vk_index = vertex_binding_remap->vertex_bindings[index];
+    }
+    if (vk_index >= device.GetMaxVertexInputBindings()) {
         return;
     }
     if (device.IsExtExtendedDynamicStateSupported()) {
-        scheduler.Record([index, buffer, offset, size, stride](vk::CommandBuffer cmdbuf) {
+        scheduler.Record([binding = vk_index, buffer, offset, size, stride](vk::CommandBuffer cmdbuf) {
             const VkDeviceSize vk_offset = buffer != VK_NULL_HANDLE ? offset : 0;
             const VkDeviceSize vk_size = buffer != VK_NULL_HANDLE ? size : VK_WHOLE_SIZE;
             const VkDeviceSize vk_stride = stride;
-            cmdbuf.BindVertexBuffers2EXT(index, 1, &buffer, &vk_offset, &vk_size, &vk_stride);
+            cmdbuf.BindVertexBuffers2EXT(binding, 1, &buffer, &vk_offset, &vk_size, &vk_stride);
         });
     } else {
         if (!device.HasNullDescriptor() && buffer == VK_NULL_HANDLE) {
@@ -565,13 +833,55 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset
             buffer = *null_buffer;
             offset = 0;
         }
-        scheduler.Record([index, buffer, offset](vk::CommandBuffer cmdbuf) {
-            cmdbuf.BindVertexBuffer(index, buffer, offset);
+        scheduler.Record([binding = vk_index, buffer, offset](vk::CommandBuffer cmdbuf) {
+            cmdbuf.BindVertexBuffer(binding, buffer, offset);
         });
     }
 }
 
 void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
+    const u32 device_max = device.GetMaxVertexInputBindings();
+    const bool remapped = vertex_binding_remap != nullptr &&
+                          vertex_binding_remap->remapped_vertex_bindings;
+
+    if (remapped) {
+        for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+            const u32 guest_index = bindings.min_index + index;
+            u32 vk_index = guest_index;
+            if (guest_index < vertex_binding_remap->vertex_bindings.size()) {
+                vk_index = vertex_binding_remap->vertex_bindings[guest_index];
+            }
+            if (vk_index >= device_max) {
+                continue;
+            }
+            auto handle = bindings.buffers[index]->Handle();
+            u64 offset = bindings.offsets[index];
+            if (handle == VK_NULL_HANDLE) {
+                offset = 0;
+                if (!device.HasNullDescriptor()) {
+                    ReserveNullBuffer();
+                    handle = *null_buffer;
+                }
+            }
+            if (device.IsExtExtendedDynamicStateSupported()) {
+                const u64 size = bindings.sizes[index];
+                const u64 stride = bindings.strides[index];
+                scheduler.Record([vk_index, handle, offset, size, stride](vk::CommandBuffer cmdbuf) {
+                    const VkDeviceSize vk_offset = handle != VK_NULL_HANDLE ? offset : 0;
+                    const VkDeviceSize vk_size = handle != VK_NULL_HANDLE ? size : VK_WHOLE_SIZE;
+                    const VkDeviceSize vk_stride = stride;
+                    cmdbuf.BindVertexBuffers2EXT(vk_index, 1, &handle, &vk_offset, &vk_size,
+                                                 &vk_stride);
+                });
+            } else {
+                scheduler.Record([vk_index, handle, offset](vk::CommandBuffer cmdbuf) {
+                    cmdbuf.BindVertexBuffer(vk_index, handle, offset);
+                });
+            }
+        }
+        return;
+    }
+
     boost::container::small_vector<VkBuffer, 32> buffer_handles;
     for (u32 index = 0; index < bindings.buffers.size(); ++index) {
         auto handle = bindings.buffers[index]->Handle();
@@ -585,7 +895,6 @@ void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bi
         }
         buffer_handles.push_back(handle);
     }
-    const u32 device_max = device.GetMaxVertexInputBindings();
     const u32 min_binding = std::min(bindings.min_index, device_max);
     const u32 max_binding = std::min(bindings.max_index, device_max);
     const u32 binding_count = max_binding - min_binding;

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "shader_recompiler/runtime_info.h"
 #include "video_core/buffer_cache/buffer_cache_base.h"
 #include "video_core/buffer_cache/memory_tracker_base.h"
 #include "video_core/buffer_cache/usage_tracker.h"
@@ -26,6 +27,7 @@ class BufferCacheRuntime;
 class Buffer : public VideoCommon::BufferBase {
 public:
     explicit Buffer(BufferCacheRuntime&, VideoCommon::NullBufferParams null_params);
+    explicit Buffer(BufferCacheRuntime& runtime, VideoCommon::XfbStreamCounterBufferParams);
     explicit Buffer(BufferCacheRuntime& runtime, VAddr cpu_addr_, u64 size_bytes_);
 
     [[nodiscard]] VkBufferView View(u32 offset, u32 size, VideoCore::Surface::PixelFormat format);
@@ -122,6 +124,35 @@ public:
 
     void BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
+    void SetVertexBindingRemap(const Shader::RuntimeInfo* remap) {
+        vertex_binding_remap = remap;
+    }
+
+    void ClearVertexBindingRemap() {
+        vertex_binding_remap = nullptr;
+    }
+
+    void RegisterXfbEmulationCounterBuffer(VkBuffer buffer);
+
+    [[nodiscard]] VkBuffer GetXfbEmulationCounterBuffer() const {
+        return xfb_emulation_counter_buffer;
+    }
+
+    [[nodiscard]] VkBuffer GetXfbEmulationCounterSnapshotBuffer() const {
+        return xfb_emulation_counter_snapshot_buffer ? *xfb_emulation_counter_snapshot_buffer
+                                                     : VK_NULL_HANDLE;
+    }
+
+    /// Copy the live TF emulation counter after a draw so later query reads are not cleared away.
+    void SnapshotXfbEmulationCounter();
+
+    /// Read the latest emulated stream-out record count from the counter snapshot.
+    [[nodiscard]] u32 ReadXfbEmulationCounterSnapshotRecords();
+
+    /// Emulate VK_EXT_transform_feedback DrawIndirectByteCount using the emulated counter snapshot.
+    void EmulateDrawIndirectByteCount(VkBuffer guest_counter_buffer, u32 guest_counter_offset,
+                                      u32 stride, u32 register_byte_fallback);
+
     void BindTransformFeedbackBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size);
 
     void BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings);
@@ -168,6 +199,12 @@ private:
 
     std::unique_ptr<Uint8Pass> uint8_pass;
     QuadIndexedPass quad_index_pass;
+
+    const Shader::RuntimeInfo* vertex_binding_remap{};
+
+    VkBuffer xfb_emulation_counter_buffer{VK_NULL_HANDLE};
+    vk::Buffer xfb_emulation_counter_snapshot_buffer;
+    vk::Buffer xfb_byte_count_draw_buffer;
 };
 
 struct BufferCacheParams {
@@ -184,6 +221,7 @@ struct BufferCacheParams {
     static constexpr bool USE_MEMORY_MAPS = true;
     static constexpr bool SEPARATE_IMAGE_BUFFER_BINDINGS = false;
     static constexpr bool USE_MEMORY_MAPS_FOR_UPLOADS = true;
+    static constexpr bool HAS_XFB_STREAM_COUNTER_HOST_BUFFER = true;
 };
 
 using BufferCache = VideoCommon::BufferCache<BufferCacheParams>;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -742,6 +742,9 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             if (!IsVertexAttributeMapped(vertex_input_remap, index)) {
                 continue;
             }
+            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+                continue;
+            }
             if (!IsVertexBindingMapped(vertex_input_remap, attribute.buffer)) {
                 continue;
             }
@@ -751,9 +754,6 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             const u32 location = VulkanVertexLocation(vertex_input_remap, index);
             const u32 binding = VulkanVertexBinding(vertex_input_remap, attribute.buffer);
             if (location >= max_vertex_attrs || binding >= max_vertex_bindings) {
-                continue;
-            }
-            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
                 continue;
             }
             if (vertex_attributes.size() >= max_vertex_attrs) {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -21,6 +21,7 @@
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_texture_cache.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/renderer_vulkan/vertex_location_remap.h"
 #include "video_core/shader_notify.h"
 #include "video_core/texture_cache/texture_cache.h"
 #include "video_core/vulkan_common/vulkan_device.h"
@@ -265,6 +266,16 @@ GraphicsPipeline::GraphicsPipeline(
         std::ranges::copy(info->constant_buffer_used_sizes, uniform_buffer_sizes[stage].begin());
         num_textures += Shader::NumDescriptors(info->texture_descriptors);
     }
+    const bool needs_vertex_location_remap =
+        device.GetMaxVertexInputAttributes() <
+        Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes;
+    const bool needs_vertex_binding_remap =
+        device.GetMaxVertexInputBindings() <
+        Tegra::Engines::Maxwell3D::Regs::NumVertexArrays;
+    if (needs_vertex_location_remap || needs_vertex_binding_remap) {
+        PopulateVertexLocationRemap(vertex_input_remap, device.GetMaxVertexInputAttributes(),
+                                    device.GetMaxVertexInputBindings(), key.state, stage_infos[0]);
+    }
     auto func{[this, shader_notify, &render_pass_cache, &descriptor_pool, pipeline_statistics] {
         DescriptorLayoutBuilder builder{MakeBuilder(device, stage_infos)};
         split_descriptor_sets = builder.IsSplit();
@@ -324,11 +335,11 @@ template <typename Spec>
 void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
     // std::array<T, 16384> made CheckFeedbackLoop iterate the full capacity
     // per draw; small_vector lets the span size match the actual write count.
-    thread_local boost::container::small_vector<VideoCommon::ImageViewInOut, 64> views;
-    thread_local boost::container::small_vector<VideoCommon::SamplerId, 64> samplers;
-    thread_local BindlessCache bindless_cache;
-    thread_local size_t bindless_cache_rr{0};
-    thread_local std::vector<u8> bindless_scratch;
+    boost::container::small_vector<VideoCommon::ImageViewInOut, 64> views;
+    boost::container::small_vector<VideoCommon::SamplerId, 64> samplers;
+    BindlessCache bindless_cache;
+    size_t bindless_cache_rr{0};
+    std::vector<u8> bindless_scratch;
     views.clear();
     samplers.clear();
 
@@ -546,7 +557,16 @@ void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
     }
 
     buffer_cache.UpdateGraphicsBuffers(is_indexed);
+    if (vertex_input_remap.remapped_vertex_bindings) {
+        buffer_cache.runtime.SetVertexBindingRemap(&vertex_input_remap);
+    }
+    if (key.state.xfb_emulated != 0 && !device.IsExtTransformFeedbackSupported()) {
+        buffer_cache.ClearXfbStreamCounterForDraw();
+    }
     buffer_cache.BindHostGeometryBuffers(is_indexed);
+    if (vertex_input_remap.remapped_vertex_bindings) {
+        buffer_cache.runtime.ClearVertexBindingRemap();
+    }
 
     guest_descriptor_queue.Acquire();
 
@@ -685,21 +705,32 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
     boost::container::static_vector<VkVertexInputBindingDivisorDescriptionEXT, 32> vertex_binding_divisors;
     boost::container::static_vector<VkVertexInputAttributeDescription, 32> vertex_attributes;
     if (!key.state.dynamic_vertex_input) {
-        const size_t num_vertex_arrays = std::min(
-            Tegra::Engines::Maxwell3D::Regs::NumVertexArrays, static_cast<size_t>(device.GetMaxVertexInputBindings()));
-        for (size_t index = 0; index < num_vertex_arrays; ++index) {
-            const bool instanced = key.state.binding_divisors[index] != 0;
+        const u32 max_vertex_attrs = device.GetMaxVertexInputAttributes();
+        const u32 max_vertex_bindings = device.GetMaxVertexInputBindings();
+        for (size_t guest = 0; guest < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays; ++guest) {
+            if (!IsVertexBindingUsedByMappedAttributes(static_cast<u32>(guest), key.state,
+                                                       stage_infos[0], vertex_input_remap)) {
+                continue;
+            }
+            if (!IsVertexBindingMapped(vertex_input_remap, static_cast<u32>(guest))) {
+                continue;
+            }
+            const u32 vk_binding = VulkanVertexBinding(vertex_input_remap, static_cast<u32>(guest));
+            if (vk_binding >= max_vertex_bindings) {
+                continue;
+            }
+            const bool instanced = key.state.binding_divisors[guest] != 0;
             const auto rate =
                 instanced ? VK_VERTEX_INPUT_RATE_INSTANCE : VK_VERTEX_INPUT_RATE_VERTEX;
             vertex_bindings.push_back({
-                .binding = static_cast<u32>(index),
-                .stride = key.state.vertex_strides[index],
+                .binding = vk_binding,
+                .stride = key.state.vertex_strides[guest],
                 .inputRate = rate,
             });
             if (instanced) {
                 vertex_binding_divisors.push_back({
-                    .binding = static_cast<u32>(index),
-                    .divisor = key.state.binding_divisors[index],
+                    .binding = vk_binding,
+                    .divisor = key.state.binding_divisors[guest],
                 });
             }
         }
@@ -708,13 +739,40 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
             if (!attribute.enabled || !stage_infos[0].loads.Generic(index)) {
                 continue;
             }
+            if (!IsVertexAttributeMapped(vertex_input_remap, index)) {
+                continue;
+            }
+            if (!IsVertexBindingMapped(vertex_input_remap, attribute.buffer)) {
+                continue;
+            }
+            if (index >= max_vertex_attrs && !vertex_input_remap.remapped_vertex_locations) {
+                break;
+            }
+            const u32 location = VulkanVertexLocation(vertex_input_remap, index);
+            const u32 binding = VulkanVertexBinding(vertex_input_remap, attribute.buffer);
+            if (location >= max_vertex_attrs || binding >= max_vertex_bindings) {
+                continue;
+            }
+            if (attribute.buffer >= Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+                continue;
+            }
+            if (vertex_attributes.size() >= max_vertex_attrs) {
+                break;
+            }
             vertex_attributes.push_back({
-                .location = static_cast<u32>(index),
-                .binding = attribute.buffer,
+                .location = location,
+                .binding = binding,
                 .format = MaxwellToVK::VertexFormat(device, attribute.Type(), attribute.Size()),
                 .offset = attribute.offset,
             });
         }
+    }
+    const u32 max_vertex_attrs = device.GetMaxVertexInputAttributes();
+    if (vertex_attributes.size() > max_vertex_attrs) {
+        LOG_ERROR(Render_Vulkan,
+                  "Graphics pipeline uses {} vertex attributes but the Vulkan device reports a "
+                  "maximum of {}; draws may fault (common on MoltenVK).",
+                  vertex_attributes.size(), max_vertex_attrs);
     }
     ASSERT(vertex_attributes.size() <= device.GetMaxVertexInputAttributes());
 
@@ -758,6 +816,9 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
         SupportsPrimitiveRestart(input_assembly_topology) ||
         (input_assembly_topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST &&
          device.IsPatchListPrimitiveRestartSupported());
+    // Metal always applies primitive restart for strip/fan topologies; MoltenVK cannot implement
+    // vkCmdSetPrimitiveRestartEnableEXT(VK_FALSE) (VK_ERROR_FEATURE_NOT_PRESENT). Force restart in
+    // the pipeline for those topologies and omit dynamic toggle (see vk_rasterizer.cpp).
     const bool force_mvk_primitive_restart =
         device.GetDriverID() == VK_DRIVER_ID_MOLTENVK &&
         SupportsPrimitiveRestart(input_assembly_topology);

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -249,7 +249,8 @@ GraphicsPipeline::GraphicsPipeline(
     GuestDescriptorQueue& guest_descriptor_queue_, Common::ThreadWorker* worker_thread,
     PipelineStatistics* pipeline_statistics, RenderPassCache& render_pass_cache,
     const GraphicsPipelineCacheKey& key_, std::array<vk::ShaderModule, NUM_STAGES> stages,
-    const std::array<const Shader::Info*, NUM_STAGES>& infos)
+    const std::array<const Shader::Info*, NUM_STAGES>& infos,
+    std::optional<Shader::RuntimeInfo> compiled_vertex_remap)
     : key{key_}, device{device_}, texture_cache{texture_cache_}, buffer_cache{buffer_cache_},
       pipeline_cache(pipeline_cache_), scheduler{scheduler_},
       guest_descriptor_queue{guest_descriptor_queue_}, spv_modules{std::move(stages)} {
@@ -272,7 +273,14 @@ GraphicsPipeline::GraphicsPipeline(
     const bool needs_vertex_binding_remap =
         device.GetMaxVertexInputBindings() <
         Tegra::Engines::Maxwell3D::Regs::NumVertexArrays;
-    if (needs_vertex_location_remap || needs_vertex_binding_remap) {
+    if (compiled_vertex_remap) {
+        vertex_input_remap.vertex_locations = compiled_vertex_remap->vertex_locations;
+        vertex_input_remap.vertex_bindings = compiled_vertex_remap->vertex_bindings;
+        vertex_input_remap.remapped_vertex_locations =
+            compiled_vertex_remap->remapped_vertex_locations;
+        vertex_input_remap.remapped_vertex_bindings =
+            compiled_vertex_remap->remapped_vertex_bindings;
+    } else if (needs_vertex_location_remap || needs_vertex_binding_remap) {
         PopulateVertexLocationRemap(vertex_input_remap, device.GetMaxVertexInputAttributes(),
                                     device.GetMaxVertexInputBindings(), key.state, stage_infos[0]);
     }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <type_traits>
 
 #include "common/thread_worker.h"
@@ -77,7 +78,8 @@ public:
         GuestDescriptorQueue& guest_descriptor_queue, Common::ThreadWorker* worker_thread,
         PipelineStatistics* pipeline_statistics, RenderPassCache& render_pass_cache,
         const GraphicsPipelineCacheKey& key, std::array<vk::ShaderModule, NUM_STAGES> stages,
-        const std::array<const Shader::Info*, NUM_STAGES>& infos);
+        const std::array<const Shader::Info*, NUM_STAGES>& infos,
+        std::optional<Shader::RuntimeInfo> compiled_vertex_remap = std::nullopt);
 
     GraphicsPipeline& operator=(GraphicsPipeline&&) noexcept = delete;
     GraphicsPipeline(GraphicsPipeline&&) noexcept = delete;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -12,6 +12,7 @@
 
 #include "common/thread_worker.h"
 #include "shader_recompiler/shader_info.h"
+#include "shader_recompiler/runtime_info.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_vulkan/fixed_pipeline_state.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
@@ -113,6 +114,14 @@ public:
         gpu_memory = gpu_memory_;
     }
 
+    [[nodiscard]] const Shader::RuntimeInfo& VertexInputRemap() const noexcept {
+        return vertex_input_remap;
+    }
+
+    [[nodiscard]] bool UsesEmulatedTransformFeedback() const noexcept {
+        return key.state.xfb_emulated != 0;
+    }
+
 private:
     template <typename Spec>
     void ConfigureImpl(bool is_indexed);
@@ -142,6 +151,7 @@ private:
     std::array<vk::ShaderModule, NUM_STAGES> spv_modules;
 
     std::array<Shader::Info, NUM_STAGES> stage_infos;
+    Shader::RuntimeInfo vertex_input_remap{};
     std::array<u32, 5> enabled_uniform_buffer_masks{};
     VideoCommon::UniformBufferSizes uniform_buffer_sizes{};
     u32 num_textures{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -278,8 +278,10 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             ASSERT(false);
             return Shader::TessSpacing::Equal;
         }();
-        if (guest_has_geometry_shader && !geometry_supported) {
-            PopulateXfbRuntimeInfo(info, key);
+        if (!has_geometry) {
+            if (guest_has_geometry_shader && !geometry_supported) {
+                PopulateXfbRuntimeInfo(info, key);
+            }
             info.convert_depth_mode = gl_ndc;
         }
         break;
@@ -344,7 +346,8 @@ void PropagateSkippedGeometryStores(Shader::IR::Program& program,
     if (skipped_geometry_program == nullptr) {
         return;
     }
-    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB) {
+    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB &&
+        program.stage != Shader::Stage::TessellationEval) {
         return;
     }
     if (skipped_geometry_program->is_geometry_passthrough) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -924,6 +924,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     std::array<vk::ShaderModule, Tegra::Engines::Maxwell3D::Regs::MaxShaderStage> modules;
 
     const Shader::IR::Program* previous_stage{};
+    std::optional<Shader::RuntimeInfo> compiled_vertex_remap;
     Shader::Backend::Bindings binding;
     const bool has_geometry_stage =
         geometry_supported && guest_has_geometry_shader &&
@@ -954,6 +955,9 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
             programs, key, program, previous_stage, skipped_geometry_program, has_geometry_stage,
             guest_has_geometry_shader, geometry_supported, uses_tessellation, max_vertex_attributes,
             max_vertex_bindings)};
+        if (program.stage == Shader::Stage::VertexB) {
+            compiled_vertex_remap = runtime_info;
+        }
         if (key.state.xfb_enabled != 0 && runtime_info.xfb_count > 0) {
             LOG_INFO(Render_Vulkan,
                      "Pipeline 0x{:016x} stage={} xfb_count={} xfb_emulated={} gs={} tess={}",
@@ -976,7 +980,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     return std::make_unique<GraphicsPipeline>(
         scheduler, buffer_cache, texture_cache, vulkan_pipeline_cache, &shader_notify, device,
         descriptor_pool, guest_descriptor_queue, thread_worker, statistics, render_pass_cache, key,
-        std::move(modules), infos);
+        std::move(modules), infos, std::move(compiled_vertex_remap));
 
 } catch (const vk::Exception& exception) {
     if (exception.GetResult() == VK_ERROR_OUT_OF_DEVICE_MEMORY) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -34,6 +34,7 @@
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_util.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/renderer_vulkan/vertex_location_remap.h"
 #include "video_core/shader_cache.h"
 #include "video_core/shader_environment.h"
 #include "video_core/shader_notify.h"
@@ -54,7 +55,7 @@ using VideoCommon::FileEnvironment;
 using VideoCommon::GenericEnvironment;
 using VideoCommon::GraphicsEnvironment;
 
-constexpr u32 CACHE_VERSION = 14;
+constexpr u32 CACHE_VERSION = 24;
 constexpr std::array<char, 8> VULKAN_CACHE_MAGIC_NUMBER{'y', 'u', 'z', 'u', 'v', 'k', 'c', 'h'};
 
 template <typename Container>
@@ -159,35 +160,69 @@ Shader::FragmentOutputType GetFragmentOutputType(u8 encoded_format) {
                : Shader::FragmentOutputType::UnsignedInt;
 }
 
+void PopulateXfbRuntimeInfo(Shader::RuntimeInfo& info, const GraphicsPipelineCacheKey& key) {
+    if (key.state.xfb_enabled == 0) {
+        return;
+    }
+    auto [varyings, count] = VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
+    info.xfb_varyings = varyings;
+    info.xfb_count = count;
+    for (size_t i = 0; i < info.xfb_buffer_bytes.size(); ++i) {
+        const s32 size = key.state.xfb_state.buffer_sizes[i];
+        info.xfb_buffer_bytes[i] = size > 0 ? static_cast<u32>(size) : 0U;
+    }
+}
+
 Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> programs,
                                     const GraphicsPipelineCacheKey& key,
                                     const Shader::IR::Program& program,
-                                    const Shader::IR::Program* previous_program) {
+                                    const Shader::IR::Program* previous_program,
+                                    const Shader::IR::Program* skipped_geometry_program,
+                                    bool has_geometry_stage, bool guest_has_geometry_shader,
+                                    bool geometry_supported, bool uses_tessellation,
+                                    u32 max_vertex_attributes, u32 max_vertex_bindings) {
     Shader::RuntimeInfo info;
     if (previous_program) {
-        info.previous_stage_stores = previous_program->info.stores;
-        info.previous_stage_legacy_stores_mapping = previous_program->info.legacy_stores_mapping;
-        if (previous_program->is_geometry_passthrough) {
-            info.previous_stage_stores.mask |= previous_program->info.passthrough.mask;
+        const bool link_through_skipped_geometry = skipped_geometry_program != nullptr &&
+                                                   !geometry_supported &&
+                                                   program.stage == Shader::Stage::Fragment;
+        if (link_through_skipped_geometry) {
+            if (skipped_geometry_program->is_geometry_passthrough) {
+                info.previous_stage_stores = previous_program->info.stores;
+                info.previous_stage_legacy_stores_mapping =
+                    previous_program->info.legacy_stores_mapping;
+                info.previous_stage_stores.mask |= skipped_geometry_program->info.passthrough.mask;
+            } else {
+                info.previous_stage_stores = skipped_geometry_program->info.stores;
+                info.previous_stage_legacy_stores_mapping =
+                    skipped_geometry_program->info.legacy_stores_mapping;
+            }
+        } else {
+            info.previous_stage_stores = previous_program->info.stores;
+            info.previous_stage_legacy_stores_mapping = previous_program->info.legacy_stores_mapping;
+            if (previous_program->is_geometry_passthrough) {
+                info.previous_stage_stores.mask |= previous_program->info.passthrough.mask;
+            }
         }
     } else {
         info.previous_stage_stores.mask.set();
     }
     const Shader::Stage stage{program.stage};
-    const bool has_geometry{key.unique_hashes[4] != 0 && !programs[4].is_geometry_passthrough};
+    const bool has_geometry{has_geometry_stage};
     const bool gl_ndc{key.state.ndc_minus_one_to_one != 0};
     const float point_size{Common::BitCast<float>(key.state.point_size)};
     switch (stage) {
-    case Shader::Stage::VertexB:
+    case Shader::Stage::VertexB: {
+        std::ranges::fill(info.generic_input_types, Shader::AttributeType::Disabled);
         if (!has_geometry) {
             if (key.state.topology == Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology::Points) {
                 info.fixed_state_point_size = point_size;
             }
-            if (key.state.xfb_enabled) {
-                auto [varyings, count] =
-                    VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
-                info.xfb_varyings = varyings;
-                info.xfb_count = count;
+            // When the guest binds a geometry shader but the host cannot run one, stream-out
+            // emulation must run on the last stage before the skipped geometry stage.
+            const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
+            if (!guest_has_geometry_shader || (guest_gs_skipped && !uses_tessellation)) {
+                PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
         }
@@ -197,10 +232,24 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
                 info.generic_input_types[index] = AttributeType(key.state, index);
             }
         } else {
-            std::ranges::transform(key.state.attributes, info.generic_input_types.begin(),
-                                   &CastAttributeType);
+            for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes;
+                 ++index) {
+                info.generic_input_types[index] =
+                    CastAttributeType(key.state.attributes[index]);
+            }
+        }
+        if (max_vertex_attributes < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes ||
+            max_vertex_bindings < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays) {
+            PopulateVertexLocationRemap(info, max_vertex_attributes, max_vertex_bindings, key.state,
+                                        program.info);
+            for (size_t index = 0; index < info.vertex_locations.size(); ++index) {
+                if (info.vertex_locations[index] == Shader::VERTEX_INPUT_DROPPED) {
+                    info.generic_input_types[index] = Shader::AttributeType::Disabled;
+                }
+            }
         }
         break;
+    }
     case Shader::Stage::TessellationEval:
         info.tess_clockwise = key.state.tessellation_clockwise != 0;
         info.tess_primitive = [&key] {
@@ -229,16 +278,17 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             ASSERT(false);
             return Shader::TessSpacing::Equal;
         }();
+        if (guest_has_geometry_shader && !geometry_supported) {
+            PopulateXfbRuntimeInfo(info, key);
+            info.convert_depth_mode = gl_ndc;
+        }
         break;
     case Shader::Stage::Geometry:
         if (program.output_topology == Shader::OutputTopology::PointList) {
             info.fixed_state_point_size = point_size;
         }
-        if (key.state.xfb_enabled != 0) {
-            auto [varyings, count] =
-                VideoCommon::MakeTransformFeedbackVaryings(key.state.xfb_state);
-            info.xfb_varyings = varyings;
-            info.xfb_count = count;
+        if (geometry_supported) {
+            PopulateXfbRuntimeInfo(info, key);
         }
         info.convert_depth_mode = gl_ndc;
         break;
@@ -285,7 +335,23 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
     }
     info.force_early_z = key.state.early_z != 0;
     info.y_negate = key.state.y_negate != 0;
+    info.emulate_transform_feedback = key.state.xfb_emulated != 0;
     return info;
+}
+
+void PropagateSkippedGeometryStores(Shader::IR::Program& program,
+                                    const Shader::IR::Program* skipped_geometry_program) {
+    if (skipped_geometry_program == nullptr) {
+        return;
+    }
+    if (program.stage != Shader::Stage::VertexA && program.stage != Shader::Stage::VertexB) {
+        return;
+    }
+    if (skipped_geometry_program->is_geometry_passthrough) {
+        program.info.stores.mask |= skipped_geometry_program->info.passthrough.mask;
+    } else {
+        program.info.stores.mask |= skipped_geometry_program->info.stores.mask;
+    }
 }
 
 size_t GetTotalPipelineWorkers() {
@@ -340,6 +406,12 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
       serialization_thread(1, "VkPipelineSerialization") {
     const auto& float_control{device.FloatControlProperties()};
     const VkDriverId driver_id{device.GetDriverID()};
+    if (driver_id == VK_DRIVER_ID_MOLTENVK && use_asynchronous_shaders) {
+        LOG_INFO(Render_Vulkan,
+                 "Disabling asynchronous shaders on MoltenVK to avoid prolonged black frames "
+                 "while graphics pipelines compile");
+        use_asynchronous_shaders = false;
+    }
     // OPTIMIZED FOR LOW GPU ACCURACY - enable mediump in fragment shaders for better perf
     const bool low_gpu_accuracy = Settings::IsGPULevelLow();
 
@@ -393,11 +465,12 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
                                        driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE ||
                                        driver_id == VK_DRIVER_ID_MESA_RADV ||
                                        driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS ||
-                                       driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA,
+                                       driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA ||
+                                       driver_id == VK_DRIVER_ID_MOLTENVK,
 
         .has_broken_spirv_clamp = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS,
         .has_broken_spirv_position_input = driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY,
-        .has_broken_unsigned_image_offsets = false,
+        .has_broken_unsigned_image_offsets = driver_id == VK_DRIVER_ID_MOLTENVK,
         .has_broken_signed_operations = false,
         .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY,
         .ignore_nan_fp_comparisons = false,
@@ -452,6 +525,7 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
             allow_eds3 && device.IsExtExtendedDynamicState3EnablesSupported(),
         .has_dynamic_vertex_input = allow_eds3 && device.IsExtVertexInputDynamicStateSupported(),
         .has_transform_feedback = device.IsExtTransformFeedbackSupported(),
+        .emulate_transform_feedback = !device.IsExtTransformFeedbackSupported(),
     };
 }
 
@@ -602,6 +676,9 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
     const auto load_compute{[&](std::ifstream& file, FileEnvironment env) {
         ComputePipelineCacheKey key;
         file.read(reinterpret_cast<char*>(&key), sizeof(key));
+        if (file.gcount() != static_cast<std::streamsize>(sizeof(key))) {
+            throw std::ios_base::failure("truncated compute pipeline key");
+        }
 
         workers.QueueWork([this, key, env_ = std::move(env), &state, &callback]() mutable {
             ShaderPools pools;
@@ -622,7 +699,12 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
     const auto load_graphics{[&](std::ifstream& file, std::vector<FileEnvironment> envs) {
         GraphicsPipelineCacheKey key;
         file.read(reinterpret_cast<char*>(&key), sizeof(key));
+        if (file.gcount() != static_cast<std::streamsize>(sizeof(key))) {
+            throw std::ios_base::failure("truncated graphics pipeline key");
+        }
 
+        const bool host_xfb = dynamic_features.has_transform_feedback ||
+                              dynamic_features.emulate_transform_feedback;
         if ((key.state.extended_dynamic_state != 0) !=
                 dynamic_features.has_extended_dynamic_state ||
             (key.state.extended_dynamic_state_2 != 0) !=
@@ -634,13 +716,32 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
             (key.state.extended_dynamic_state_3_enables != 0) !=
                 dynamic_features.has_extended_dynamic_state_3_enables ||
             (key.state.dynamic_vertex_input != 0) != dynamic_features.has_dynamic_vertex_input ||
-            (key.state.xfb_enabled != 0 && !dynamic_features.has_transform_feedback)) {
+            (key.state.xfb_enabled != 0 && !host_xfb)) {
             // NOTE: xfb_enabled uses a unidirectional check. It encodes both a
             // device capability AND per-pipeline runtime state. We only reject
             // the pipeline if it actively requires XFB but the host device
             // does not support it
             LOG_WARNING(Render_Vulkan, "Skipping cached graphics pipeline: EDS feature mismatch");
             return;
+        }
+        {
+            const bool skip_xfb_pipeline = [&] {
+                if (key.state.xfb_enabled == 0) {
+                    return false;
+                }
+                if (!host_xfb) {
+                    return true;
+                }
+                return (key.state.xfb_emulated != 0) != dynamic_features.emulate_transform_feedback;
+            }();
+            if (skip_xfb_pipeline) {
+                LOG_WARNING(Render_Vulkan,
+                            "Skipping cached XFB pipeline 0x{:016x}: cached xfb_emulated={} host "
+                            "emulate={}",
+                            key.Hash(), key.state.xfb_emulated != 0,
+                            dynamic_features.emulate_transform_feedback);
+                return;
+            }
         }
         workers.QueueWork([this, key, envs_ = std::move(envs), &state, &callback]() mutable {
             ShaderPools pools;
@@ -741,9 +842,20 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     std::array<Shader::IR::Program, Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram> programs;
     const bool uses_vertex_a{key.unique_hashes[0] != 0};
     const bool uses_vertex_b{key.unique_hashes[1] != 0};
+    const size_t geometry_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+    const size_t tess_init_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::TessellationInit);
+    const size_t tess_stage_index = static_cast<size_t>(
+        Tegra::Engines::Maxwell3D::Regs::ShaderType::Tessellation);
+    const bool geometry_supported = device.IsGeometryShaderSupported();
+    const bool guest_has_geometry_shader = key.unique_hashes[geometry_stage_index] != 0;
+    const bool uses_tessellation = key.unique_hashes[tess_init_stage_index] != 0 ||
+                                   key.unique_hashes[tess_stage_index] != 0;
 
     // Layer passthrough generation for devices without VK_EXT_shader_viewport_index_layer
     Shader::IR::Program* layer_source_program{};
+    const Shader::IR::Program* skipped_geometry_program{};
 
     for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
         const bool is_emulated_stage =
@@ -753,6 +865,28 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
             auto topology = MaxwellToOutputTopology(key.state.topology);
             programs[index] = GenerateGeometryPassthrough(pools.inst, pools.block, host_info,
                                                           *layer_source_program, topology);
+            continue;
+        }
+        if (index == geometry_stage_index && !geometry_supported) {
+            if (key.unique_hashes[index] != 0) {
+                Shader::Environment& env{*envs[env_index]};
+                ++env_index;
+
+                const u32 cfg_offset{
+                    static_cast<u32>(env.StartAddress() + sizeof(Shader::ProgramHeader))};
+                Shader::Maxwell::Flow::CFG cfg(env, pools.flow_block, cfg_offset, index == 0);
+                programs[index] =
+                    TranslateProgram(pools.inst, pools.block, env, cfg, host_info);
+                skipped_geometry_program = &programs[index];
+
+                if (Settings::values.dump_shaders) {
+                    env.Dump(hash, key.unique_hashes[index]);
+                }
+
+                LOG_INFO(Render_Vulkan,
+                         "Translated skipped guest geometry shader {:016x} (passthrough={})",
+                         key.unique_hashes[index], programs[index].is_geometry_passthrough);
+            }
             continue;
         }
         if (key.unique_hashes[index] == 0) {
@@ -786,11 +920,23 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
 
     const Shader::IR::Program* previous_stage{};
     Shader::Backend::Bindings binding;
-    for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0;
-         index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
-        const bool is_emulated_stage =
-            layer_source_program != nullptr &&
-            index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+    const bool has_geometry_stage =
+        geometry_supported && guest_has_geometry_shader &&
+        !programs[geometry_stage_index].is_geometry_passthrough;
+    const u32 max_vertex_attributes = device.GetMaxVertexInputAttributes();
+    const u32 max_vertex_bindings = device.GetMaxVertexInputBindings();
+    for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram;
+         ++index) {
+        if (index == geometry_stage_index && !geometry_supported) {
+            const bool is_emulated_stage = layer_source_program != nullptr &&
+                                           index == static_cast<u32>(
+                                               Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
+            if (!is_emulated_stage) {
+                continue;
+            }
+        }
+        const bool is_emulated_stage = layer_source_program != nullptr &&
+                                       index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && !is_emulated_stage) {
             continue;
         }
@@ -800,7 +946,20 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
         const size_t stage_index{index - 1};
         infos[stage_index] = &program.info;
 
-        const auto runtime_info{MakeRuntimeInfo(programs, key, program, previous_stage)};
+        if (!geometry_supported && skipped_geometry_program != nullptr) {
+            PropagateSkippedGeometryStores(program, skipped_geometry_program);
+        }
+
+        const auto runtime_info{MakeRuntimeInfo(
+            programs, key, program, previous_stage, skipped_geometry_program, has_geometry_stage,
+            guest_has_geometry_shader, geometry_supported, uses_tessellation, max_vertex_attributes,
+            max_vertex_bindings)};
+        if (key.state.xfb_enabled != 0 && runtime_info.xfb_count > 0) {
+            LOG_INFO(Render_Vulkan,
+                     "Pipeline 0x{:016x} stage={} xfb_count={} xfb_emulated={} gs={} tess={}",
+                     hash, static_cast<u32>(program.stage), runtime_info.xfb_count,
+                     key.state.xfb_emulated != 0, guest_has_geometry_shader, uses_tessellation);
+        }
         ConvertLegacyToGeneric(program, runtime_info);
         std::vector<u32> code = EmitSPIRV(profile, runtime_info, program, binding);
         // Reserve space to reduce allocations during shader compilation
@@ -824,6 +983,13 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
         LOG_ERROR(Render_Vulkan,
                   "Out of device memory during graphics pipeline creation, attempting recovery");
         EvictOldPipelines();
+        return nullptr;
+    }
+    if (exception.GetResult() == VK_ERROR_INITIALIZATION_FAILED) {
+        LOG_ERROR(Render_Vulkan,
+                  "Graphics pipeline creation failed (0x{:x}): incompatible shader interface, "
+                  "skipping pipeline",
+                  key.Hash());
         return nullptr;
     }
     throw;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -221,7 +221,8 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             // When the guest binds a geometry shader but the host cannot run one, stream-out
             // emulation must run on the last stage before the skipped geometry stage.
             const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
-            if (!guest_has_geometry_shader || (guest_gs_skipped && !uses_tessellation)) {
+            if ((!guest_has_geometry_shader && !uses_tessellation) ||
+                (guest_gs_skipped && !uses_tessellation)) {
                 PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
@@ -279,7 +280,8 @@ Shader::RuntimeInfo MakeRuntimeInfo(std::span<const Shader::IR::Program> program
             return Shader::TessSpacing::Equal;
         }();
         if (!has_geometry) {
-            if (guest_has_geometry_shader && !geometry_supported) {
+            const bool guest_gs_skipped = guest_has_geometry_shader && !geometry_supported;
+            if (uses_tessellation && (!guest_has_geometry_shader || guest_gs_skipped)) {
                 PopulateXfbRuntimeInfo(info, key);
             }
             info.convert_depth_mode = gl_ndc;
@@ -862,7 +864,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
 
     for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram; ++index) {
         const bool is_emulated_stage =
-            layer_source_program != nullptr &&
+            geometry_supported && layer_source_program != nullptr &&
             index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && is_emulated_stage) {
             auto topology = MaxwellToOutputTopology(key.state.topology);
@@ -931,14 +933,9 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     for (size_t index = uses_vertex_a && uses_vertex_b ? 1 : 0; index < Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram;
          ++index) {
         if (index == geometry_stage_index && !geometry_supported) {
-            const bool is_emulated_stage = layer_source_program != nullptr &&
-                                           index == static_cast<u32>(
-                                               Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
-            if (!is_emulated_stage) {
-                continue;
-            }
+            continue;
         }
-        const bool is_emulated_stage = layer_source_program != nullptr &&
+        const bool is_emulated_stage = geometry_supported && layer_source_program != nullptr &&
                                        index == static_cast<u32>(Tegra::Engines::Maxwell3D::Regs::ShaderType::Geometry);
         if (key.unique_hashes[index] == 0 && !is_emulated_stage) {
             continue;

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -262,17 +262,17 @@ void PresentManager::PresentThread(std::stop_token token) {
             return;
         }
 
-        // Take the frame and notify anyone waiting
+        // Take the frame and mark presentation in-flight before the queue appears empty.
         Frame* frame = present_queue.front();
         present_queue.pop();
-        frame_cv.notify_one();
-
-        lock.unlock();
-
         {
             std::lock_guard present_lock{present_state_mutex};
             presenting = true;
         }
+        frame_cv.notify_one();
+
+        lock.unlock();
+
         render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
         {
             std::lock_guard present_lock{present_state_mutex};

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/logging.h"
 #include "common/settings.h"
 #include "common/thread.h"
 #include "core/frontend/emu_window.h"
@@ -154,7 +155,7 @@ Frame* PresentManager::GetRenderFrame() {
 void PresentManager::Present(Frame* frame) {
     if (!use_present_thread) {
         scheduler.WaitWorker();
-        CopyToSwapchain(frame);
+        render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
         free_queue.push(frame);
         return;
     }
@@ -272,7 +273,7 @@ void PresentManager::PresentThread(std::stop_token token) {
         // lock in WaitPresent is guaranteed to occur after here.
         std::exchange(lock, std::unique_lock{swapchain_mutex});
 
-        CopyToSwapchain(frame);
+        render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
 
         // Free the frame for reuse
         std::scoped_lock fl{free_mutex};
@@ -317,6 +318,12 @@ void PresentManager::CopyToSwapchain(Frame* frame) {
 }
 
 void PresentManager::CopyToSwapchainImpl(Frame* frame) {
+    static u32 present_diag_budget = 120;
+    if (present_diag_budget > 0) {
+        --present_diag_budget;
+        LOG_INFO(Render_Vulkan, "Present: frame={}x{} swapchain={}x{}", frame->width, frame->height,
+                 swapchain.GetWidth(), swapchain.GetHeight());
+    }
 
     // If the size of the incoming frames has changed, recreate the swapchain
     // to account for that.

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -268,12 +268,13 @@ void PresentManager::PresentThread(std::stop_token token) {
         present_queue.pop();
         frame_cv.notify_one();
 
-        // By exchanging the lock ownership we take the swapchain lock
-        // before the queue lock goes out of scope. This way the swapchain
-        // lock in WaitPresent is guaranteed to occur after here.
-        std::exchange(lock, std::unique_lock{swapchain_mutex});
+        lock.unlock();
 
         render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
+
+        {
+            std::scoped_lock swapchain_lock{swapchain_mutex};
+        }
 
         // Free the frame for reuse
         std::scoped_lock fl{free_mutex};

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -246,10 +246,9 @@ void PresentManager::WaitPresent() {
         frame_cv.wait(queue_lock, [this] { return present_queue.empty(); });
     }
 
-    // The above condition will be satisfied when the last frame is taken from the queue.
-    // To ensure that frame has been presented as well take hold of the swapchain
-    // mutex.
-    std::scoped_lock swapchain_lock{swapchain_mutex};
+    // The queue can empty before CopyToSwapchain() finishes on the GUI thread.
+    std::unique_lock present_lock{present_state_mutex};
+    present_state_cv.wait(present_lock, [this] { return !presenting; });
 }
 
 void PresentManager::PresentThread(std::stop_token token) {
@@ -270,11 +269,16 @@ void PresentManager::PresentThread(std::stop_token token) {
 
         lock.unlock();
 
-        render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
-
         {
-            std::scoped_lock swapchain_lock{swapchain_mutex};
+            std::lock_guard present_lock{present_state_mutex};
+            presenting = true;
         }
+        render_window.RunPresentationWork([this, frame] { CopyToSwapchain(frame); });
+        {
+            std::lock_guard present_lock{present_state_mutex};
+            presenting = false;
+        }
+        present_state_cv.notify_all();
 
         // Free the frame for reuse
         std::scoped_lock fl{free_mutex};

--- a/src/video_core/renderer_vulkan/vk_present_manager.h
+++ b/src/video_core/renderer_vulkan/vk_present_manager.h
@@ -79,6 +79,9 @@ private:
     std::condition_variable_any frame_cv;
     std::condition_variable free_cv;
     std::mutex swapchain_mutex;
+    std::mutex present_state_mutex;
+    std::condition_variable present_state_cv;
+    bool presenting = false;
     std::mutex queue_mutex;
     std::mutex free_mutex;
     std::jthread present_thread;

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -369,6 +369,7 @@ public:
         {
             std::scoped_lock lk(flush_guard);
             pending_flush_sets.emplace_back(std::move(pending_flush_queries));
+            pending_flush_queries.clear();
         }
     }
 
@@ -909,6 +910,7 @@ public:
         free_queue.clear();
         download_buffers.emplace_back(staging_ref);
         pending_flush_sets.emplace_back(std::move(pending_flush_queries));
+        pending_flush_queries.clear();
     }
 
     void PopUnsyncedQueries() override {
@@ -1065,12 +1067,12 @@ private:
                 .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
             };
             scheduler.RequestOutsideRenderPassOperationContext();
-            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer,
-                              slot](vk::CommandBuffer cmdbuf) {
+            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer, slot,
+                              stream](vk::CommandBuffer cmdbuf) {
                 cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                        VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
                 std::array<VkBufferCopy, 1> copy{VkBufferCopy{
-                    .srcOffset = 0,
+                    .srcOffset = stream * TFBQueryBank::QUERY_SIZE,
                     .dstOffset = slot * TFBQueryBank::QUERY_SIZE,
                     .size = TFBQueryBank::QUERY_SIZE,
                 }};
@@ -1289,8 +1291,9 @@ public:
                     return num_vertices >= 2 ? num_vertices - 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Patches:
                 case Maxwell3D::Regs::PrimitiveTopology::Triangles:
-                case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
                     return num_vertices / 3;
+                case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
+                    return num_vertices / 6;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -1297,8 +1297,6 @@ public:
                     return num_vertices / 3;
                 case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
                     return num_vertices / 6;
-                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
-                    return num_vertices >= 6 ? (num_vertices - 4) / 2 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                     return num_vertices >= 3 ? num_vertices - 2 : 0;

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <map>
@@ -661,17 +662,23 @@ class PrimitivesSucceededStreamer;
 
 class TFBCounterStreamer : public BaseStreamer {
 public:
-    explicit TFBCounterStreamer(size_t id_, QueryCacheRuntime& runtime_, const Device& device_,
-                                Scheduler& scheduler_, const MemoryAllocator& memory_allocator_,
+    explicit TFBCounterStreamer(size_t id_, QueryCacheRuntime& runtime_, BufferCache& buffer_cache_,
+                                const Device& device_, Scheduler& scheduler_,
+                                const MemoryAllocator& memory_allocator_,
                                 StagingBufferPool& staging_pool_)
-        : BaseStreamer(id_), runtime{runtime_}, device{device_}, scheduler{scheduler_},
-          memory_allocator{memory_allocator_}, staging_pool{staging_pool_} {
+        : BaseStreamer(id_), runtime{runtime_}, buffer_cache{buffer_cache_}, device{device_},
+          scheduler{scheduler_}, memory_allocator{memory_allocator_},
+          staging_pool{staging_pool_} {
         buffers_count = 0;
         current_bank = nullptr;
         counter_buffers.fill(VK_NULL_HANDLE);
         offsets.fill(0);
         last_queries.fill(0);
         last_queries_stride.fill(1);
+        streams_mask = 0;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            return;
+        }
         const VkBufferCreateInfo buffer_ci = {
             .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
             .pNext = nullptr,
@@ -737,6 +744,8 @@ public:
     void SyncWrites() override {
         CloseCounter();
         std::unordered_map<size_t, std::vector<HostSyncValues>> sync_values_stash;
+        std::vector<size_t> emulated_pending;
+        std::vector<VideoCommon::SyncValuesStruct> emulated_sync_values;
         for (auto q : pending_sync) {
             auto* query = GetQuery(q);
             if (True(query->flags & VideoCommon::QueryFlagBits::IsRewritten)) {
@@ -745,6 +754,12 @@ public:
             if (True(query->flags & VideoCommon::QueryFlagBits::IsInvalidated)) {
                 continue;
             }
+            if (!device.IsExtTransformFeedbackSupported()) {
+                if (emulated_query_strides.contains(q)) {
+                    emulated_pending.push_back(q);
+                    continue;
+                }
+            }
             query->flags |= VideoCommon::QueryFlagBits::IsHostSynced;
             sync_values_stash.try_emplace(query->start_bank_id);
             sync_values_stash[query->start_bank_id].emplace_back(HostSyncValues{
@@ -752,6 +767,51 @@ public:
                 .size = TFBQueryBank::QUERY_SIZE,
                 .offset = query->start_slot * TFBQueryBank::QUERY_SIZE,
             });
+        }
+        if (!emulated_pending.empty()) {
+            auto staging_ref = staging_pool.Request(
+                emulated_pending.size() * TFBQueryBank::QUERY_SIZE, MemoryUsage::Download, true);
+            size_t offset_base = staging_ref.offset;
+            for (const size_t q : emulated_pending) {
+                auto* query = GetQuery(q);
+                auto& bank = bank_pool.GetBank(query->start_bank_id);
+                bank.Sync(staging_ref, offset_base, query->start_slot, 1);
+                offset_base += TFBQueryBank::QUERY_SIZE;
+            }
+            static constexpr VkMemoryBarrier WRITE_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT,
+            };
+            scheduler.RequestOutsideRenderPassOperationContext();
+            scheduler.Record([](vk::CommandBuffer cmdbuf) {
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, WRITE_BARRIER);
+            });
+            scheduler.Finish();
+            offset_base = staging_ref.offset;
+            emulated_sync_values.reserve(emulated_pending.size());
+            for (const size_t q : emulated_pending) {
+                auto* query = GetQuery(q);
+                u32 records = 0;
+                std::memcpy(&records, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
+                offset_base += TFBQueryBank::QUERY_SIZE;
+                const u32 stride = emulated_query_strides.at(q);
+                emulated_query_strides.erase(q);
+                const u64 byte_value = static_cast<u64>(records) * stride;
+                query->value = byte_value;
+                query->flags |= VideoCommon::QueryFlagBits::IsHostSynced |
+                                VideoCommon::QueryFlagBits::IsFinalValueSynced;
+                emulated_sync_values.push_back(VideoCommon::SyncValuesStruct{
+                    .address = query->guest_address,
+                    .value = byte_value,
+                    .size = TFBQueryBank::QUERY_SIZE,
+                });
+                bank_pool.GetBank(query->start_bank_id).CloseReference();
+            }
+            staging_pool.FreeDeferred(staging_ref);
+            runtime.template SyncValues<VideoCommon::SyncValuesStruct>(emulated_sync_values);
         }
         for (auto& p : sync_values_stash) {
             auto& bank = bank_pool.GetBank(p.first);
@@ -780,12 +840,20 @@ public:
             new_query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             return index;
         }
+        if (!device.IsExtTransformFeedbackSupported()) {
+            // Ensure the emulated TF draw has finished writing the counter SSBO before we copy it.
+            scheduler.Flush();
+        }
         CloseCounter();
         auto [bank_slot, data_slot] = ProduceCounterBuffer(subreport);
         new_query->start_bank_id = static_cast<u32>(bank_slot);
         new_query->size_banks = 1;
         new_query->start_slot = static_cast<u32>(data_slot);
         new_query->size_slots = 1;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            emulated_query_strides[index] =
+                static_cast<u32>(std::max<size_t>(last_queries_stride[subreport], 1));
+        }
         pending_sync.push_back(index);
         pending_flush_queries.push_back(index);
         return index;
@@ -809,6 +877,9 @@ public:
 
     void PushUnsyncedQueries() override {
         CloseCounter();
+        if (!device.IsExtTransformFeedbackSupported() && !pending_flush_queries.empty()) {
+            scheduler.Flush();
+        }
         auto staging_ref = staging_pool.Request(
             pending_flush_queries.size() * TFBQueryBank::QUERY_SIZE, MemoryUsage::Download, true);
         size_t offset_base = staging_ref.offset;
@@ -850,13 +921,24 @@ public:
             download_buffers.pop_front();
             pending_flush_sets.pop_front();
         }
+        if (!device.IsExtTransformFeedbackSupported()) {
+            scheduler.Finish();
+        }
 
         size_t offset_base = staging_ref.offset;
         for (auto q : flushed_queries) {
             auto* query = GetQuery(q);
             u32 result = 0;
             std::memcpy(&result, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
-            query->value = static_cast<u64>(result);
+            u64 value = result;
+            if (!device.IsExtTransformFeedbackSupported()) {
+                if (const auto it = emulated_query_strides.find(q);
+                    it != emulated_query_strides.end()) {
+                    value *= it->second;
+                    emulated_query_strides.erase(it);
+                }
+            }
+            query->value = value;
             query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             offset_base += TFBQueryBank::QUERY_SIZE;
         }
@@ -873,6 +955,10 @@ private:
             return;
         }
         has_flushed_end_pending = true;
+        if (!device.IsExtTransformFeedbackSupported()) {
+            UpdateBuffers();
+            return;
+        }
         if (!has_started || buffers_count == 0) {
             scheduler.Record([](vk::CommandBuffer cmdbuf) {
                 cmdbuf.BeginTransformFeedbackEXT(0, 0, nullptr, nullptr);
@@ -891,6 +977,10 @@ private:
             return;
         }
         has_flushed_end_pending = false;
+
+        if (!device.IsExtTransformFeedbackSupported()) {
+            return;
+        }
 
         // Enhanced query ending with better error handling
         try {
@@ -916,6 +1006,7 @@ private:
     void UpdateBuffers() {
         last_queries.fill(0);
         last_queries_stride.fill(1);
+        streams_mask = 0;
         runtime.View3DRegs([this](Maxwell3D& maxwell3d) {
             buffers_count = 0;
             out_topology = maxwell3d.draw_manager->GetDrawState().topology;
@@ -943,6 +1034,52 @@ private:
         auto [dont_care, other] = current_bank->Reserve();
         const size_t slot = other; // workaround to compile bug.
         current_bank->AddReference();
+
+        if (!device.IsExtTransformFeedbackSupported()) {
+            const VkBuffer snapshot_buffer =
+                buffer_cache.runtime.GetXfbEmulationCounterSnapshotBuffer();
+            const VkBuffer live_buffer = buffer_cache.runtime.GetXfbEmulationCounterBuffer();
+            const VkBuffer src_buffer =
+                snapshot_buffer != VK_NULL_HANDLE ? snapshot_buffer : live_buffer;
+            static constexpr VkMemoryBarrier WRITE_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
+            };
+            if (src_buffer == VK_NULL_HANDLE) {
+                scheduler.RequestOutsideRenderPassOperationContext();
+                scheduler.Record([dst_buffer = current_bank->GetBuffer(),
+                                  slot](vk::CommandBuffer cmdbuf) {
+                    cmdbuf.FillBuffer(dst_buffer, slot * TFBQueryBank::QUERY_SIZE,
+                                      TFBQueryBank::QUERY_SIZE, 0);
+                    cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                           VK_PIPELINE_STAGE_TRANSFER_BIT, 0, WRITE_BARRIER);
+                });
+                return {current_bank_id, slot};
+            }
+            static constexpr VkMemoryBarrier READ_BARRIER{
+                .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                .pNext = nullptr,
+                .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT,
+                .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            };
+            scheduler.RequestOutsideRenderPassOperationContext();
+            scheduler.Record([dst_buffer = current_bank->GetBuffer(), src_buffer,
+                              slot](vk::CommandBuffer cmdbuf) {
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_TRANSFER_BIT, 0, READ_BARRIER);
+                std::array<VkBufferCopy, 1> copy{VkBufferCopy{
+                    .srcOffset = 0,
+                    .dstOffset = slot * TFBQueryBank::QUERY_SIZE,
+                    .size = TFBQueryBank::QUERY_SIZE,
+                }};
+                cmdbuf.CopyBuffer(src_buffer, dst_buffer, copy);
+                cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                       VK_PIPELINE_STAGE_TRANSFER_BIT, 0, WRITE_BARRIER);
+            });
+            return {current_bank_id, slot};
+        }
 
         static constexpr VkMemoryBarrier READ_BARRIER{
             .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
@@ -979,10 +1116,12 @@ private:
     static constexpr size_t NUM_STREAMS = 4;
 
     QueryCacheRuntime& runtime;
+    BufferCache& buffer_cache;
     const Device& device;
     Scheduler& scheduler;
     const MemoryAllocator& memory_allocator;
     StagingBufferPool& staging_pool;
+    std::unordered_map<size_t, u32> emulated_query_strides;
     VideoCommon::BankPool<TFBQueryBank> bank_pool;
     size_t current_bank_id;
     TFBQueryBank* current_bank;
@@ -1125,16 +1264,17 @@ public:
 
             query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
             u64 num_vertices = 0;
+            const u64 stride = std::max<u64>(query->stride, 1);
             if (query->dependant_manage) {
                 auto* dependant_query = tfb_streamer.GetQuery(query->dependant_index);
-                num_vertices = dependant_query->value / query->stride;
+                num_vertices = dependant_query->value / stride;
                 tfb_streamer.Free(query->dependant_index);
             } else {
                 u8* pointer = device_memory.GetPointer<u8>(query->dependant_address);
                 if (pointer != nullptr) {
                     u32 result;
                     std::memcpy(&result, pointer, sizeof(u32));
-                    num_vertices = static_cast<u64>(result) / query->stride;
+                    num_vertices = static_cast<u64>(result) / stride;
                 }
             }
             query->value = [&]() -> u64 {
@@ -1144,9 +1284,9 @@ public:
                 case Maxwell3D::Regs::PrimitiveTopology::Lines:
                     return num_vertices / 2;
                 case Maxwell3D::Regs::PrimitiveTopology::LineLoop:
-                    return (num_vertices / 2) + 1;
+                    return num_vertices >= 2 ? num_vertices : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::LineStrip:
-                    return num_vertices - 1;
+                    return num_vertices >= 2 ? num_vertices - 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Patches:
                 case Maxwell3D::Regs::PrimitiveTopology::Triangles:
                 case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
@@ -1154,11 +1294,11 @@ public:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
-                    return num_vertices - 2;
+                    return num_vertices >= 3 ? num_vertices - 2 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Quads:
                     return num_vertices / 4;
                 case Maxwell3D::Regs::PrimitiveTopology::Polygon:
-                    return 1U;
+                    return num_vertices >= 3 ? 1U : 0U;
                 default:
                     return num_vertices;
                 }
@@ -1196,8 +1336,8 @@ struct QueryCacheRuntimeImpl {
           sample_streamer(static_cast<size_t>(QueryType::ZPassPixelCount64), runtime, rasterizer,
                           device, scheduler, memory_allocator, compute_pass_descriptor_queue,
                           descriptor_pool),
-          tfb_streamer(static_cast<size_t>(QueryType::StreamingByteCount), runtime, device,
-                       scheduler, memory_allocator, staging_pool),
+          tfb_streamer(static_cast<size_t>(QueryType::StreamingByteCount), runtime, buffer_cache_,
+                       device, scheduler, memory_allocator, staging_pool),
           primitives_succeeded_streamer(
               static_cast<size_t>(QueryType::StreamingPrimitivesSucceeded), runtime, tfb_streamer,
               device_memory_),

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -813,8 +813,8 @@ public:
             }
             staging_pool.FreeDeferred(staging_ref);
             runtime.template SyncValues<VideoCommon::SyncValuesStruct>(emulated_sync_values);
-            std::erase_if(pending_flush_queries, [&emulated_pending](size_t q) {
-                return std::ranges::find(emulated_pending, q) != emulated_pending.end();
+            std::erase_if(pending_flush_queries, [&emulated_pending](size_t query_id) {
+                return std::ranges::find(emulated_pending, query_id) != emulated_pending.end();
             });
         }
         for (auto& p : sync_values_stash) {
@@ -1297,6 +1297,8 @@ public:
                     return num_vertices / 3;
                 case Maxwell3D::Regs::PrimitiveTopology::TrianglesAdjacency:
                     return num_vertices / 6;
+                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
+                    return num_vertices >= 6 ? (num_vertices - 4) / 2 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
                     return num_vertices >= 3 ? num_vertices - 2 : 0;

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -813,6 +813,9 @@ public:
             }
             staging_pool.FreeDeferred(staging_ref);
             runtime.template SyncValues<VideoCommon::SyncValuesStruct>(emulated_sync_values);
+            std::erase_if(pending_flush_queries, [&emulated_pending](size_t q) {
+                return std::ranges::find(emulated_pending, q) != emulated_pending.end();
+            });
         }
         for (auto& p : sync_values_stash) {
             auto& bank = bank_pool.GetBank(p.first);
@@ -1296,8 +1299,9 @@ public:
                     return num_vertices / 6;
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleFan:
                 case Maxwell3D::Regs::PrimitiveTopology::TriangleStrip:
-                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
                     return num_vertices >= 3 ? num_vertices - 2 : 0;
+                case Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
+                    return num_vertices >= 6 ? (num_vertices - 6) / 2 + 1 : 0;
                 case Maxwell3D::Regs::PrimitiveTopology::Quads:
                     return num_vertices / 4;
                 case Maxwell3D::Regs::PrimitiveTopology::Polygon:

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -791,13 +791,13 @@ public:
                                        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, WRITE_BARRIER);
             });
             scheduler.Finish();
-            offset_base = staging_ref.offset;
+            size_t download_offset = 0;
             emulated_sync_values.reserve(emulated_pending.size());
             for (const size_t q : emulated_pending) {
                 auto* query = GetQuery(q);
                 u32 records = 0;
-                std::memcpy(&records, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
-                offset_base += TFBQueryBank::QUERY_SIZE;
+                std::memcpy(&records, staging_ref.mapped_span.data() + download_offset, sizeof(u32));
+                download_offset += TFBQueryBank::QUERY_SIZE;
                 const u32 stride = emulated_query_strides.at(q);
                 emulated_query_strides.erase(q);
                 const u64 byte_value = static_cast<u64>(records) * stride;
@@ -930,11 +930,11 @@ public:
             scheduler.Finish();
         }
 
-        size_t offset_base = staging_ref.offset;
+        size_t download_offset = 0;
         for (auto q : flushed_queries) {
             auto* query = GetQuery(q);
             u32 result = 0;
-            std::memcpy(&result, staging_ref.mapped_span.data() + offset_base, sizeof(u32));
+            std::memcpy(&result, staging_ref.mapped_span.data() + download_offset, sizeof(u32));
             u64 value = result;
             if (!device.IsExtTransformFeedbackSupported()) {
                 if (const auto it = emulated_query_strides.find(q);
@@ -945,7 +945,7 @@ public:
             }
             query->value = value;
             query->flags |= VideoCommon::QueryFlagBits::IsFinalValueSynced;
-            offset_base += TFBQueryBank::QUERY_SIZE;
+            download_offset += TFBQueryBank::QUERY_SIZE;
         }
 
         {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -118,6 +118,20 @@ Tegra::Engines::Fermi2D::Surface MakeBlitSurface(
     return surface;
 }
 
+Tegra::RenderTargetFormat ViPixelFormatToRenderTargetFormat(
+    Service::android::PixelFormat pixel_format) {
+    switch (pixel_format) {
+    case Service::android::PixelFormat::Bgra8888:
+        return Tegra::RenderTargetFormat::B8G8R8A8_UNORM;
+    case Service::android::PixelFormat::Rgb565:
+        return Tegra::RenderTargetFormat::R5G6B5_UNORM;
+    case Service::android::PixelFormat::Rgba8888:
+    case Service::android::PixelFormat::Rgbx8888:
+    default:
+        return Tegra::RenderTargetFormat::A8B8G8R8_UNORM;
+    }
+}
+
 void TrackGameRenderTarget(DAddr cpu_addr, GPUVAddr gpu_addr,
                            const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt_config,
                            Tegra::Texture::MsaaMode msaa_mode, u32 num_vertices) {
@@ -542,6 +556,9 @@ void RasterizerVulkan::DrawIndirect() {
                 buffer_cache.runtime.EmulateDrawIndirectByteCount(
                     buffer ? buffer->Handle() : VK_NULL_HANDLE, offset,
                     static_cast<u32>(params.stride), maxwell3d->regs.draw_auto_byte_count);
+                FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
+                                                    pipeline_cache.CurrentGraphicsPipeline(),
+                                                    device);
                 return;
             }
             scheduler.Record([buffer_obj = buffer->Handle(), offset,
@@ -1211,8 +1228,10 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
     src_rt.width = blit_width;
     src_rt.height = blit_height;
     auto dst_rt = g_game_rt0_config;
+    dst_rt.format = ViPixelFormatToRenderTargetFormat(config.pixel_format);
     dst_rt.width = blit_width;
     dst_rt.height = blit_height;
+    dst_rt.tile_mode.is_pitch_linear = true;
     dst_rt.address_high = static_cast<u32>(vi_gpu >> 32);
     dst_rt.address_low = static_cast<u32>(vi_gpu);
 
@@ -1238,7 +1257,10 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
                  "Composite at present: game RT 0x{:x} -> VI 0x{:x} (peak_verts={} size={}x{})",
                  g_game_rt0_cpu_addr, vi_cpu, g_game_rt0_peak_verts, blit_width, blit_height);
     }
-    texture_cache.BlitImage(dst, src, copy_config);
+    {
+        std::scoped_lock lock{texture_cache.mutex};
+        texture_cache.BlitImage(dst, src, copy_config);
+    }
 }
 
 void RasterizerVulkan::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -63,22 +63,12 @@ struct DrawParams {
     bool is_indexed;
 };
 
-// Updated after each emulated XFB capture draw; consume draws read this when vertex count is 0.
-u32 g_last_xfb_snapshot_records = 0;
+// Diagnostic log budgets for MoltenVK bring-up; not shared across rasterizer instances.
 u32 g_xfb_draw_diag_budget = 0;
 u32 g_draw_any_budget = 0;
 u32 g_null_pipeline_budget = 20;
 u32 g_draw_texture_budget = 40;
 u32 g_fb_sample_budget = 60;
-DAddr g_last_rt0_cpu_addr = 0;
-GPUVAddr g_last_rt0_gpu_addr = 0;
-VideoCommon::ImageInfo g_last_rt0_info{};
-DAddr g_game_rt0_cpu_addr = 0;
-GPUVAddr g_game_rt0_gpu_addr = 0;
-VideoCommon::ImageInfo g_game_rt0_info{};
-Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig g_game_rt0_config{};
-u32 g_game_rt0_peak_verts = 0;
-u32 g_vi_overlay_active_frames = 0;
 
 constexpr u32 GAME_RT_MIN_VERTICES = 64;
 // Bedrock sign-in overlays issue fullscreen passes (e.g. 1944 verts) to a transient RT.
@@ -132,33 +122,6 @@ Tegra::RenderTargetFormat ViPixelFormatToRenderTargetFormat(
     }
 }
 
-void TrackGameRenderTarget(DAddr cpu_addr, GPUVAddr gpu_addr,
-                           const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt_config,
-                           Tegra::Texture::MsaaMode msaa_mode, u32 num_vertices) {
-    if (cpu_addr == 0 || gpu_addr == 0 || IsViScanoutCpuAddr(cpu_addr) ||
-        num_vertices < GAME_RT_MIN_VERTICES) {
-        return;
-    }
-    if (cpu_addr != g_game_rt0_cpu_addr && num_vertices >= GAME_RT_OVERLAY_VERT_THRESHOLD) {
-        return;
-    }
-    if (cpu_addr == g_game_rt0_cpu_addr) {
-        g_game_rt0_peak_verts = std::max(g_game_rt0_peak_verts, num_vertices);
-        return;
-    }
-    g_game_rt0_cpu_addr = cpu_addr;
-    g_game_rt0_gpu_addr = gpu_addr;
-    g_game_rt0_config = rt_config;
-    g_game_rt0_info = VideoCommon::ImageInfo{rt_config, msaa_mode};
-    g_game_rt0_peak_verts = num_vertices;
-    static u32 game_rt_track_budget = 30;
-    if (game_rt_track_budget > 0) {
-        --game_rt_track_budget;
-        LOG_INFO(Render_Vulkan, "game RT track: cpu=0x{:x} gpu=0x{:x} verts={}", cpu_addr, gpu_addr,
-                 num_vertices);
-    }
-}
-
 size_t ImageInfoGuestBytes(const VideoCommon::ImageInfo& info) {
     if (info.format == VideoCore::Surface::PixelFormat::Invalid) {
         return 0;
@@ -178,7 +141,8 @@ constexpr VkPipelineStageFlags XfbEmulationWriteStages() {
 }
 
 void FinishEmulatedTransformFeedbackDraw(Scheduler& scheduler, BufferCache& buffer_cache,
-                                         const GraphicsPipeline* pipeline, const Device& device) {
+                                         const GraphicsPipeline* pipeline, const Device& device,
+                                         PresentTrackingState& tracking) {
     if (!pipeline || !pipeline->UsesEmulatedTransformFeedback() ||
         device.IsExtTransformFeedbackSupported()) {
         return;
@@ -198,8 +162,12 @@ void FinishEmulatedTransformFeedbackDraw(Scheduler& scheduler, BufferCache& buff
     });
     buffer_cache.runtime.SnapshotXfbEmulationCounter();
     scheduler.Finish();
-    g_last_xfb_snapshot_records = buffer_cache.runtime.ReadXfbEmulationCounterSnapshotRecords();
-    LOG_INFO(Render_Vulkan, "XFB capture: snapshot_records={}", g_last_xfb_snapshot_records);
+    const u32 snapshot_records = buffer_cache.runtime.ReadXfbEmulationCounterSnapshotRecords();
+    {
+        std::scoped_lock lock{tracking.mutex};
+        tracking.last_xfb_snapshot_records = snapshot_records;
+    }
+    LOG_INFO(Render_Vulkan, "XFB capture: snapshot_records={}", snapshot_records);
 }
 
 VkViewport GetViewportState(const Device& device, const Tegra::Engines::Maxwell3D::Regs& regs,
@@ -323,6 +291,37 @@ DrawParams MakeDrawParams(const MaxwellDrawState& draw_state, u32 num_instances,
 }
 } // Anonymous namespace
 
+void RasterizerVulkan::TrackGameRenderTarget(
+    DAddr cpu_addr, GPUVAddr gpu_addr,
+    const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt_config,
+    Tegra::Texture::MsaaMode msaa_mode, u32 num_vertices) {
+    if (cpu_addr == 0 || gpu_addr == 0 || IsViScanoutCpuAddr(cpu_addr) ||
+        num_vertices < GAME_RT_MIN_VERTICES) {
+        return;
+    }
+    std::scoped_lock lock{present_tracking.mutex};
+    if (cpu_addr != present_tracking.game_rt0_cpu_addr &&
+        num_vertices >= GAME_RT_OVERLAY_VERT_THRESHOLD) {
+        return;
+    }
+    if (cpu_addr == present_tracking.game_rt0_cpu_addr) {
+        present_tracking.game_rt0_peak_verts =
+            std::max(present_tracking.game_rt0_peak_verts, num_vertices);
+        return;
+    }
+    present_tracking.game_rt0_cpu_addr = cpu_addr;
+    present_tracking.game_rt0_gpu_addr = gpu_addr;
+    present_tracking.game_rt0_config = rt_config;
+    present_tracking.game_rt0_info = VideoCommon::ImageInfo{rt_config, msaa_mode};
+    present_tracking.game_rt0_peak_verts = num_vertices;
+    static u32 game_rt_track_budget = 30;
+    if (game_rt_track_budget > 0) {
+        --game_rt_track_budget;
+        LOG_INFO(Render_Vulkan, "game RT track: cpu=0x{:x} gpu=0x{:x} verts={}", cpu_addr, gpu_addr,
+                 num_vertices);
+    }
+}
+
 RasterizerVulkan::RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra::GPU& gpu_,
                                    Tegra::MaxwellDeviceMemoryManager& device_memory_,
                                    const Device& device_, MemoryAllocator& memory_allocator_,
@@ -436,16 +435,21 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
         const bool capture_draw = pipeline && pipeline->UsesEmulatedTransformFeedback();
         if (const GPUVAddr rt_gpu = maxwell3d->regs.rt[0].Address(); rt_gpu != 0) {
             if (const auto rt_cpu = gpu_memory->GpuToCpuAddress(rt_gpu)) {
-                g_last_rt0_cpu_addr = *rt_cpu;
-                g_last_rt0_gpu_addr = rt_gpu;
-                g_last_rt0_info = VideoCommon::ImageInfo{maxwell3d->regs.rt[0],
-                                                          maxwell3d->regs.anti_alias_samples_mode};
-                if (IsViScanoutCpuAddr(*rt_cpu)) {
-                    if (draw_params.num_vertices > 0 &&
-                        draw_params.num_vertices <= VI_OVERLAY_MAX_VERTICES) {
-                        g_vi_overlay_active_frames = VI_OVERLAY_ACTIVE_FRAME_HOLD;
+                {
+                    std::scoped_lock lock{present_tracking.mutex};
+                    present_tracking.last_rt0_cpu_addr = *rt_cpu;
+                    present_tracking.last_rt0_gpu_addr = rt_gpu;
+                    present_tracking.last_rt0_info =
+                        VideoCommon::ImageInfo{maxwell3d->regs.rt[0],
+                                               maxwell3d->regs.anti_alias_samples_mode};
+                    if (IsViScanoutCpuAddr(*rt_cpu)) {
+                        if (draw_params.num_vertices > 0 &&
+                            draw_params.num_vertices <= VI_OVERLAY_MAX_VERTICES) {
+                            present_tracking.vi_overlay_active_frames = VI_OVERLAY_ACTIVE_FRAME_HOLD;
+                        }
                     }
-                } else {
+                }
+                if (!IsViScanoutCpuAddr(*rt_cpu)) {
                     TrackGameRenderTarget(*rt_cpu, rt_gpu, maxwell3d->regs.rt[0],
                                           maxwell3d->regs.anti_alias_samples_mode,
                                           draw_params.num_vertices);
@@ -453,14 +457,19 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
             }
         }
         if (!device.IsExtTransformFeedbackSupported()) {
-            if (!capture_draw && g_last_xfb_snapshot_records > 0 &&
+            u32 last_xfb_snapshot_records = 0;
+            {
+                std::scoped_lock lock{present_tracking.mutex};
+                last_xfb_snapshot_records = present_tracking.last_xfb_snapshot_records;
+            }
+            if (!capture_draw && last_xfb_snapshot_records > 0 &&
                 draw_params.num_vertices == 0) {
                 LOG_INFO(Render_Vulkan,
                          "XFB consume Draw: vertex_count 0 -> {} (tf={}, stride={})",
-                         g_last_xfb_snapshot_records,
+                         last_xfb_snapshot_records,
                          maxwell3d->regs.transform_feedback_enabled,
                          maxwell3d->regs.draw_auto_stride);
-                draw_params.num_vertices = g_last_xfb_snapshot_records;
+                draw_params.num_vertices = last_xfb_snapshot_records;
             }
             const bool interesting = capture_draw ||
                                      maxwell3d->regs.transform_feedback_enabled != 0 ||
@@ -474,7 +483,7 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
                          "rt0_gpu=0x{:x} rt0_cpu=0x{:x} rt_fmt={}",
                          draw_params.num_vertices, is_indexed, capture_draw,
                          maxwell3d->regs.transform_feedback_enabled,
-                         maxwell3d->regs.draw_auto_stride, g_last_xfb_snapshot_records, rt_gpu,
+                         maxwell3d->regs.draw_auto_stride, last_xfb_snapshot_records, rt_gpu,
                          rt_cpu.value_or(0), static_cast<u32>(rt.format));
             } else if (g_xfb_draw_diag_budget > 0) {
                 --g_xfb_draw_diag_budget;
@@ -484,7 +493,7 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
                          draw_params.num_vertices, is_indexed, capture_draw,
                          maxwell3d->regs.transform_feedback_enabled,
                          maxwell3d->regs.draw_auto_stride,
-                         maxwell3d->regs.draw_auto_byte_count, g_last_xfb_snapshot_records);
+                         maxwell3d->regs.draw_auto_byte_count, last_xfb_snapshot_records);
             } else if (g_draw_any_budget > 0) {
                 --g_draw_any_budget;
                 LOG_INFO(Render_Vulkan,
@@ -525,7 +534,8 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
             }
         });
         FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
-                                           pipeline_cache.CurrentGraphicsPipeline(), device);
+                                           pipeline_cache.CurrentGraphicsPipeline(), device,
+                                           present_tracking);
     });
 }
 
@@ -557,8 +567,8 @@ void RasterizerVulkan::DrawIndirect() {
                     buffer ? buffer->Handle() : VK_NULL_HANDLE, offset,
                     static_cast<u32>(params.stride), maxwell3d->regs.draw_auto_byte_count);
                 FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
-                                                    pipeline_cache.CurrentGraphicsPipeline(),
-                                                    device);
+                                                    pipeline_cache.CurrentGraphicsPipeline(), device,
+                                                    present_tracking);
                 return;
             }
             scheduler.Record([buffer_obj = buffer->Handle(), offset,
@@ -567,7 +577,8 @@ void RasterizerVulkan::DrawIndirect() {
                                                 static_cast<u32>(stride));
             });
             FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
-                                               pipeline_cache.CurrentGraphicsPipeline(), device);
+                                               pipeline_cache.CurrentGraphicsPipeline(), device,
+                                               present_tracking);
             return;
         }
         if (params.include_count) {
@@ -588,7 +599,8 @@ void RasterizerVulkan::DrawIndirect() {
                 }
             });
             FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
-                                               pipeline_cache.CurrentGraphicsPipeline(), device);
+                                               pipeline_cache.CurrentGraphicsPipeline(), device,
+                                               present_tracking);
             return;
         }
         scheduler.Record([buffer_obj = buffer->Handle(), offset, params](vk::CommandBuffer cmdbuf) {
@@ -602,7 +614,8 @@ void RasterizerVulkan::DrawIndirect() {
             }
         });
         FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
-                                           pipeline_cache.CurrentGraphicsPipeline(), device);
+                                           pipeline_cache.CurrentGraphicsPipeline(), device,
+                                           present_tracking);
     });
     buffer_cache.SetDrawIndirect(nullptr);
 }
@@ -1205,16 +1218,27 @@ Tegra::Engines::AccelerateDMAInterface& RasterizerVulkan::AccessAccelerateDMA() 
 
 void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConfig& config,
                                                     DAddr vi_cpu) {
-    if (!IsViScanoutCpuAddr(vi_cpu) || g_game_rt0_cpu_addr == 0 ||
-        g_game_rt0_cpu_addr == vi_cpu || g_game_rt0_peak_verts < GAME_RT_MIN_VERTICES) {
+    DAddr game_rt0_cpu_addr = 0;
+    VideoCommon::ImageInfo game_rt0_info{};
+    Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig game_rt0_config{};
+    u32 game_rt0_peak_verts = 0;
+    {
+        std::scoped_lock lock{present_tracking.mutex};
+        game_rt0_cpu_addr = present_tracking.game_rt0_cpu_addr;
+        game_rt0_info = present_tracking.game_rt0_info;
+        game_rt0_config = present_tracking.game_rt0_config;
+        game_rt0_peak_verts = present_tracking.game_rt0_peak_verts;
+    }
+    if (!IsViScanoutCpuAddr(vi_cpu) || game_rt0_cpu_addr == 0 || game_rt0_cpu_addr == vi_cpu ||
+        game_rt0_peak_verts < GAME_RT_MIN_VERTICES) {
         return;
     }
-    const size_t src_bytes = ImageInfoGuestBytes(g_game_rt0_info);
+    const size_t src_bytes = ImageInfoGuestBytes(game_rt0_info);
     if (src_bytes == 0) {
         return;
     }
     std::scoped_lock lock{texture_cache.mutex};
-    if (!texture_cache.IsRegionGpuModified(g_game_rt0_cpu_addr, src_bytes)) {
+    if (!texture_cache.IsRegionGpuModified(game_rt0_cpu_addr, src_bytes)) {
         return;
     }
     auto [vi_view, ignored] = texture_cache.TryFindFramebufferImageView(config, vi_cpu);
@@ -1222,13 +1246,13 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
         return;
     }
     const GPUVAddr vi_gpu = vi_view->gpu_addr;
-    const u32 blit_width = std::min(config.width, g_game_rt0_config.width);
-    const u32 blit_height = std::min(config.height, g_game_rt0_config.height);
+    const u32 blit_width = std::min(config.width, game_rt0_config.width);
+    const u32 blit_height = std::min(config.height, game_rt0_config.height);
     if (blit_width == 0 || blit_height == 0) {
         return;
     }
 
-    auto src_rt = g_game_rt0_config;
+    auto src_rt = game_rt0_config;
     src_rt.width = blit_width;
     src_rt.height = blit_height;
     Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig dst_rt{};
@@ -1259,7 +1283,7 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
         --composite_log_budget;
         LOG_INFO(Render_Vulkan,
                  "Composite at present: game RT 0x{:x} -> VI 0x{:x} (peak_verts={} size={}x{})",
-                 g_game_rt0_cpu_addr, vi_cpu, g_game_rt0_peak_verts, blit_width, blit_height);
+                 game_rt0_cpu_addr, vi_cpu, game_rt0_peak_verts, blit_width, blit_height);
     }
     texture_cache.BlitImage(dst, src, copy_config);
 }
@@ -1321,6 +1345,22 @@ std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
     DAddr present_addr = framebuffer_addr;
     size_t present_bytes = static_cast<size_t>(fb_bytes);
     if (IsViScanoutCpuAddr(framebuffer_addr)) {
+        DAddr game_rt0_cpu_addr = 0;
+        GPUVAddr game_rt0_gpu_addr = 0;
+        VideoCommon::ImageInfo game_rt0_info{};
+        u32 game_rt0_peak_verts = 0;
+        u32 vi_overlay_active_frames = 0;
+        {
+            std::scoped_lock tracking_lock{present_tracking.mutex};
+            game_rt0_cpu_addr = present_tracking.game_rt0_cpu_addr;
+            game_rt0_gpu_addr = present_tracking.game_rt0_gpu_addr;
+            game_rt0_info = present_tracking.game_rt0_info;
+            game_rt0_peak_verts = present_tracking.game_rt0_peak_verts;
+            if (present_tracking.vi_overlay_active_frames > 0) {
+                --present_tracking.vi_overlay_active_frames;
+            }
+            vi_overlay_active_frames = present_tracking.vi_overlay_active_frames;
+        }
         const size_t vi_bytes = static_cast<size_t>(fb_bytes);
         const bool vi_gpu_modified =
             vi_bytes > 0 && texture_cache.IsRegionGpuModified(framebuffer_addr, vi_bytes);
@@ -1353,7 +1393,7 @@ std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
                     LOG_INFO(Render_Vulkan,
                              "AccelerateDisplay: remap VI 0x{:x} -> game RT 0x{:x} "
                              "(rt0_gpu=0x{:x} peak_verts={})",
-                             framebuffer_addr, rt_cpu, rt_gpu, g_game_rt0_peak_verts);
+                             framebuffer_addr, rt_cpu, rt_gpu, game_rt0_peak_verts);
                 }
             }
             if (!offscreen_modified || !offscreen_view) {
@@ -1371,9 +1411,6 @@ std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
             present_bytes = rt_bytes;
             return true;
         };
-        if (g_vi_overlay_active_frames > 0) {
-            --g_vi_overlay_active_frames;
-        }
         // Present VI overlays directly when they carry UI. When VI is GPU-touched but CPU-empty
         // and the game is rendering to an offscreen RT, scan out from the game RT instead.
         bool vi_effectively_empty = !vi_gpu_modified;
@@ -1381,14 +1418,14 @@ std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
             if (const u8* const host_ptr = device_memory.GetPointer<u8>(framebuffer_addr)) {
                 u32 guest_px{};
                 std::memcpy(&guest_px, host_ptr, sizeof(guest_px));
-                if (guest_px == 0 && g_vi_overlay_active_frames == 0 &&
-                    g_game_rt0_peak_verts >= GAME_RT_MIN_VERTICES) {
+                if (guest_px == 0 && vi_overlay_active_frames == 0 &&
+                    game_rt0_peak_verts >= GAME_RT_MIN_VERTICES) {
                     vi_effectively_empty = true;
                 }
             }
         }
         if (vi_effectively_empty) {
-            try_remap_to_offscreen(g_game_rt0_cpu_addr, g_game_rt0_gpu_addr, g_game_rt0_info);
+            try_remap_to_offscreen(game_rt0_cpu_addr, game_rt0_gpu_addr, game_rt0_info);
         }
     }
     const bool gpu_modified =

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -122,7 +122,7 @@ Tegra::RenderTargetFormat ViPixelFormatToRenderTargetFormat(
     Service::android::PixelFormat pixel_format) {
     switch (pixel_format) {
     case Service::android::PixelFormat::Bgra8888:
-        return Tegra::RenderTargetFormat::B8G8R8A8_UNORM;
+        return Tegra::RenderTargetFormat::X8B8G8R8_UNORM;
     case Service::android::PixelFormat::Rgb565:
         return Tegra::RenderTargetFormat::R5G6B5_UNORM;
     case Service::android::PixelFormat::Rgba8888:
@@ -1210,7 +1210,11 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
         return;
     }
     const size_t src_bytes = ImageInfoGuestBytes(g_game_rt0_info);
-    if (src_bytes == 0 || !texture_cache.IsRegionGpuModified(g_game_rt0_cpu_addr, src_bytes)) {
+    if (src_bytes == 0) {
+        return;
+    }
+    std::scoped_lock lock{texture_cache.mutex};
+    if (!texture_cache.IsRegionGpuModified(g_game_rt0_cpu_addr, src_bytes)) {
         return;
     }
     auto [vi_view, ignored] = texture_cache.TryFindFramebufferImageView(config, vi_cpu);
@@ -1227,11 +1231,11 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
     auto src_rt = g_game_rt0_config;
     src_rt.width = blit_width;
     src_rt.height = blit_height;
-    auto dst_rt = g_game_rt0_config;
+    Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig dst_rt{};
     dst_rt.format = ViPixelFormatToRenderTargetFormat(config.pixel_format);
     dst_rt.width = blit_width;
     dst_rt.height = blit_height;
-    dst_rt.tile_mode.is_pitch_linear = true;
+    dst_rt.tile_mode.is_pitch_linear.Assign(1);
     dst_rt.address_high = static_cast<u32>(vi_gpu >> 32);
     dst_rt.address_low = static_cast<u32>(vi_gpu);
 
@@ -1257,10 +1261,7 @@ void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConf
                  "Composite at present: game RT 0x{:x} -> VI 0x{:x} (peak_verts={} size={}x{})",
                  g_game_rt0_cpu_addr, vi_cpu, g_game_rt0_peak_verts, blit_width, blit_height);
     }
-    {
-        std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.BlitImage(dst, src, copy_config);
-    }
+    texture_cache.BlitImage(dst, src, copy_config);
 }
 
 void RasterizerVulkan::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -4,8 +4,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include "video_core/renderer_vulkan/renderer_vulkan.h"
 
@@ -26,6 +28,7 @@
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_compute_pipeline.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
+#include "video_core/renderer_vulkan/vk_graphics_pipeline.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
 #include "video_core/renderer_vulkan/vk_query_cache.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
@@ -33,9 +36,14 @@
 #include "video_core/renderer_vulkan/vk_staging_buffer_pool.h"
 #include "video_core/renderer_vulkan/vk_state_tracker.h"
 #include "video_core/renderer_vulkan/vk_texture_cache.h"
+#include "video_core/renderer_vulkan/vertex_location_remap.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
 #include "video_core/shader_cache.h"
+#include "video_core/surface.h"
+#include "video_core/texture_cache/image_info.h"
 #include "video_core/texture_cache/texture_cache_base.h"
+#include "video_core/texture_cache/types.h"
+#include "video_core/textures/decoders.h"
 #include "video_core/vulkan_common/vulkan_device.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -54,6 +62,131 @@ struct DrawParams {
     u32 first_index;
     bool is_indexed;
 };
+
+// Updated after each emulated XFB capture draw; consume draws read this when vertex count is 0.
+u32 g_last_xfb_snapshot_records = 0;
+u32 g_xfb_draw_diag_budget = 0;
+u32 g_draw_any_budget = 0;
+u32 g_null_pipeline_budget = 20;
+u32 g_draw_texture_budget = 40;
+u32 g_fb_sample_budget = 60;
+DAddr g_last_rt0_cpu_addr = 0;
+GPUVAddr g_last_rt0_gpu_addr = 0;
+VideoCommon::ImageInfo g_last_rt0_info{};
+DAddr g_game_rt0_cpu_addr = 0;
+GPUVAddr g_game_rt0_gpu_addr = 0;
+VideoCommon::ImageInfo g_game_rt0_info{};
+Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig g_game_rt0_config{};
+u32 g_game_rt0_peak_verts = 0;
+u32 g_vi_overlay_active_frames = 0;
+
+constexpr u32 GAME_RT_MIN_VERTICES = 64;
+// Bedrock sign-in overlays issue fullscreen passes (e.g. 1944 verts) to a transient RT.
+// Do not let those steal the tracked menu/world RT used for VI remap/composite.
+constexpr u32 GAME_RT_OVERLAY_VERT_THRESHOLD = 1500;
+constexpr u32 VI_OVERLAY_MAX_VERTICES = 32;
+constexpr u32 VI_OVERLAY_ACTIVE_FRAME_HOLD = 8;
+
+bool IsViScanoutCpuAddr(DAddr addr) {
+    const u32 region = static_cast<u32>(addr & 0xFFF0000);
+    return region == 0xABB0000 || region == 0xB420000 || region == 0xBC90000;
+}
+
+Tegra::Engines::Fermi2D::Surface MakeBlitSurface(
+    const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt, u32 width, u32 height) {
+    using VideoCore::Surface::BytesPerBlock;
+    using VideoCore::Surface::PixelFormatFromRenderTargetFormat;
+
+    Tegra::Engines::Fermi2D::Surface surface{};
+    surface.format = rt.format;
+    surface.width = width;
+    surface.height = height;
+    surface.depth = 1;
+    surface.layer = 0;
+    const GPUVAddr addr = rt.Address();
+    surface.addr_upper = static_cast<u32>(addr >> 32);
+    surface.addr_lower = static_cast<u32>(addr);
+    surface.block_width = rt.tile_mode.block_width;
+    surface.block_height = rt.tile_mode.block_height;
+    surface.block_depth = rt.tile_mode.block_depth;
+    if (rt.tile_mode.is_pitch_linear) {
+        surface.linear = Tegra::Engines::Fermi2D::MemoryLayout::Pitch;
+        surface.pitch = rt.width * BytesPerBlock(PixelFormatFromRenderTargetFormat(rt.format));
+    } else {
+        surface.linear = Tegra::Engines::Fermi2D::MemoryLayout::BlockLinear;
+    }
+    return surface;
+}
+
+void TrackGameRenderTarget(DAddr cpu_addr, GPUVAddr gpu_addr,
+                           const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt_config,
+                           Tegra::Texture::MsaaMode msaa_mode, u32 num_vertices) {
+    if (cpu_addr == 0 || gpu_addr == 0 || IsViScanoutCpuAddr(cpu_addr) ||
+        num_vertices < GAME_RT_MIN_VERTICES) {
+        return;
+    }
+    if (cpu_addr != g_game_rt0_cpu_addr && num_vertices >= GAME_RT_OVERLAY_VERT_THRESHOLD) {
+        return;
+    }
+    if (cpu_addr == g_game_rt0_cpu_addr) {
+        g_game_rt0_peak_verts = std::max(g_game_rt0_peak_verts, num_vertices);
+        return;
+    }
+    g_game_rt0_cpu_addr = cpu_addr;
+    g_game_rt0_gpu_addr = gpu_addr;
+    g_game_rt0_config = rt_config;
+    g_game_rt0_info = VideoCommon::ImageInfo{rt_config, msaa_mode};
+    g_game_rt0_peak_verts = num_vertices;
+    static u32 game_rt_track_budget = 30;
+    if (game_rt_track_budget > 0) {
+        --game_rt_track_budget;
+        LOG_INFO(Render_Vulkan, "game RT track: cpu=0x{:x} gpu=0x{:x} verts={}", cpu_addr, gpu_addr,
+                 num_vertices);
+    }
+}
+
+size_t ImageInfoGuestBytes(const VideoCommon::ImageInfo& info) {
+    if (info.format == VideoCore::Surface::PixelFormat::Invalid) {
+        return 0;
+    }
+    if (info.type == VideoCommon::ImageType::Linear) {
+        return static_cast<size_t>(info.pitch) * info.size.height;
+    }
+    const u32 bpp = VideoCore::Surface::BytesPerBlock(info.format);
+    return Tegra::Texture::CalculateSize(true, bpp, info.size.width, info.size.height,
+                                         info.size.depth, info.block.width, info.block.height);
+}
+
+constexpr VkPipelineStageFlags XfbEmulationWriteStages() {
+    return VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+           VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT |
+           VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+}
+
+void FinishEmulatedTransformFeedbackDraw(Scheduler& scheduler, BufferCache& buffer_cache,
+                                         const GraphicsPipeline* pipeline, const Device& device) {
+    if (!pipeline || !pipeline->UsesEmulatedTransformFeedback() ||
+        device.IsExtTransformFeedbackSupported()) {
+        return;
+    }
+    LOG_DEBUG(Render_Vulkan, "XFB capture draw finished; snapshotting stream counter");
+    static constexpr VkMemoryBarrier xfb_emulated_barrier{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT |
+                         VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
+    };
+    scheduler.RequestOutsideRenderPassOperationContext();
+    scheduler.Record([](vk::CommandBuffer cmdbuf) {
+        cmdbuf.PipelineBarrier(XfbEmulationWriteStages(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
+                               xfb_emulated_barrier);
+    });
+    buffer_cache.runtime.SnapshotXfbEmulationCounter();
+    scheduler.Finish();
+    g_last_xfb_snapshot_records = buffer_cache.runtime.ReadXfbEmulationCounterSnapshotRecords();
+    LOG_INFO(Render_Vulkan, "XFB capture: snapshot_records={}", g_last_xfb_snapshot_records);
+}
 
 VkViewport GetViewportState(const Device& device, const Tegra::Engines::Maxwell3D::Regs& regs,
                             size_t index, float scale) {
@@ -201,6 +334,10 @@ RasterizerVulkan::RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra
       fence_manager(*this, gpu, texture_cache, buffer_cache, query_cache, device, scheduler),
       wfi_event(device.GetLogical().CreateEvent()) {
     scheduler.SetQueryCache(query_cache);
+    if (!device.IsExtTransformFeedbackSupported()) {
+        g_xfb_draw_diag_budget = 40;
+        g_draw_any_budget = 60;
+    }
 
     memory_allocator.SetMemoryPressureCallback([this]() {
         pipeline_cache.TriggerPipelineEviction();
@@ -255,6 +392,12 @@ void RasterizerVulkan::PrepareDraw(bool is_indexed, Func&& draw_func) {
 
     GraphicsPipeline* const pipeline{pipeline_cache.CurrentGraphicsPipeline()};
     if (!pipeline) {
+        if (g_null_pipeline_budget > 0) {
+            --g_null_pipeline_budget;
+            LOG_WARNING(Render_Vulkan,
+                        "PrepareDraw: no graphics pipeline (indexed={} tf_enabled={})",
+                        is_indexed, maxwell3d->regs.transform_feedback_enabled);
+        }
         return;
     }
     std::scoped_lock lock{buffer_cache.mutex, texture_cache.mutex};
@@ -274,7 +417,89 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
     PrepareDraw(is_indexed, [this, is_indexed, instance_count] {
         const auto& draw_state = maxwell3d->draw_manager->GetDrawState();
         const u32 num_instances{instance_count};
-        const DrawParams draw_params{MakeDrawParams(draw_state, num_instances, is_indexed)};
+        DrawParams draw_params{MakeDrawParams(draw_state, num_instances, is_indexed)};
+        const GraphicsPipeline* const pipeline = pipeline_cache.CurrentGraphicsPipeline();
+        const bool capture_draw = pipeline && pipeline->UsesEmulatedTransformFeedback();
+        if (const GPUVAddr rt_gpu = maxwell3d->regs.rt[0].Address(); rt_gpu != 0) {
+            if (const auto rt_cpu = gpu_memory->GpuToCpuAddress(rt_gpu)) {
+                g_last_rt0_cpu_addr = *rt_cpu;
+                g_last_rt0_gpu_addr = rt_gpu;
+                g_last_rt0_info = VideoCommon::ImageInfo{maxwell3d->regs.rt[0],
+                                                          maxwell3d->regs.anti_alias_samples_mode};
+                if (IsViScanoutCpuAddr(*rt_cpu)) {
+                    if (draw_params.num_vertices > 0 &&
+                        draw_params.num_vertices <= VI_OVERLAY_MAX_VERTICES) {
+                        g_vi_overlay_active_frames = VI_OVERLAY_ACTIVE_FRAME_HOLD;
+                    }
+                } else {
+                    TrackGameRenderTarget(*rt_cpu, rt_gpu, maxwell3d->regs.rt[0],
+                                          maxwell3d->regs.anti_alias_samples_mode,
+                                          draw_params.num_vertices);
+                }
+            }
+        }
+        if (!device.IsExtTransformFeedbackSupported()) {
+            if (!capture_draw && g_last_xfb_snapshot_records > 0 &&
+                draw_params.num_vertices == 0) {
+                LOG_INFO(Render_Vulkan,
+                         "XFB consume Draw: vertex_count 0 -> {} (tf={}, stride={})",
+                         g_last_xfb_snapshot_records,
+                         maxwell3d->regs.transform_feedback_enabled,
+                         maxwell3d->regs.draw_auto_stride);
+                draw_params.num_vertices = g_last_xfb_snapshot_records;
+            }
+            const bool interesting = capture_draw ||
+                                     maxwell3d->regs.transform_feedback_enabled != 0 ||
+                                     draw_params.num_vertices >= 256;
+            if (interesting) {
+                const auto& rt = maxwell3d->regs.rt[0];
+                const GPUVAddr rt_gpu = rt.Address();
+                const auto rt_cpu = gpu_memory->GpuToCpuAddress(rt_gpu);
+                LOG_INFO(Render_Vulkan,
+                         "Draw: verts={} indexed={} capture={} tf={} stride={} snapshot={} "
+                         "rt0_gpu=0x{:x} rt0_cpu=0x{:x} rt_fmt={}",
+                         draw_params.num_vertices, is_indexed, capture_draw,
+                         maxwell3d->regs.transform_feedback_enabled,
+                         maxwell3d->regs.draw_auto_stride, g_last_xfb_snapshot_records, rt_gpu,
+                         rt_cpu.value_or(0), static_cast<u32>(rt.format));
+            } else if (g_xfb_draw_diag_budget > 0) {
+                --g_xfb_draw_diag_budget;
+                LOG_INFO(Render_Vulkan,
+                         "Draw diag: verts={} indexed={} capture={} tf={} stride={} "
+                         "byte_count={} snapshot={}",
+                         draw_params.num_vertices, is_indexed, capture_draw,
+                         maxwell3d->regs.transform_feedback_enabled,
+                         maxwell3d->regs.draw_auto_stride,
+                         maxwell3d->regs.draw_auto_byte_count, g_last_xfb_snapshot_records);
+            } else if (g_draw_any_budget > 0) {
+                --g_draw_any_budget;
+                LOG_INFO(Render_Vulkan,
+                         "Draw any: verts={} indexed={} capture={} tf={} stride={}",
+                         draw_params.num_vertices, is_indexed, capture_draw,
+                         maxwell3d->regs.transform_feedback_enabled,
+                         maxwell3d->regs.draw_auto_stride);
+            }
+        }
+        const bool uses_generated_quad_indices =
+            draw_state.topology == Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology::Quads ||
+            draw_state.topology == Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology::QuadStrip;
+        if (draw_params.is_indexed && !uses_generated_quad_indices) {
+            const auto& ib = draw_state.index_buffer;
+            const u64 start = ib.StartAddress();
+            const u64 end = ib.EndAddress();
+            const u64 index_size = std::max<u64>(ib.FormatSizeInBytes(), 1ULL);
+            const u64 index_span = end > start ? (end - start) : 0ULL;
+            const u64 max_indices = index_span / index_size;
+            if (draw_params.first_index >= max_indices) {
+                return;
+            }
+            const u64 remaining_indices = max_indices - draw_params.first_index;
+            draw_params.num_vertices =
+                static_cast<u32>(std::min<u64>(draw_params.num_vertices, remaining_indices));
+            if (draw_params.num_vertices == 0) {
+                return;
+            }
+        }
         scheduler.Record([draw_params](vk::CommandBuffer cmdbuf) {
             if (draw_params.is_indexed) {
                 cmdbuf.DrawIndexed(draw_params.num_vertices, draw_params.num_instances,
@@ -285,22 +510,47 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
                             draw_params.base_vertex, draw_params.base_instance);
             }
         });
+        FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
+                                           pipeline_cache.CurrentGraphicsPipeline(), device);
     });
 }
 
 void RasterizerVulkan::DrawIndirect() {
-    const auto& params = maxwell3d->draw_manager->GetIndirectParams();
+    auto& params = maxwell3d->draw_manager->GetIndirectParams();
+
+    if (params.is_byte_count) {
+        LOG_INFO(Render_Vulkan,
+                 "DrawIndirect byte-count: stride={} register_byte_count={} xfb_ext={}",
+                 params.stride, maxwell3d->regs.draw_auto_byte_count,
+                 device.IsExtTransformFeedbackSupported());
+    }
+
     buffer_cache.SetDrawIndirect(&params);
     PrepareDraw(params.is_indexed, [this, &params] {
+        if (const GPUVAddr rt_gpu = maxwell3d->regs.rt[0].Address(); rt_gpu != 0) {
+            if (const auto rt_cpu = gpu_memory->GpuToCpuAddress(rt_gpu)) {
+                TrackGameRenderTarget(*rt_cpu, rt_gpu, maxwell3d->regs.rt[0],
+                                      maxwell3d->regs.anti_alias_samples_mode, 512);
+            }
+        }
         const auto indirect_buffer = buffer_cache.GetDrawIndirectBuffer();
         const auto& buffer = indirect_buffer.first;
         const auto& offset = indirect_buffer.second;
         if (params.is_byte_count) {
+            if (!device.IsExtTransformFeedbackSupported()) {
+                LOG_INFO(Render_Vulkan, "DrawIndirect byte-count: using emulated path");
+                buffer_cache.runtime.EmulateDrawIndirectByteCount(
+                    buffer ? buffer->Handle() : VK_NULL_HANDLE, offset,
+                    static_cast<u32>(params.stride), maxwell3d->regs.draw_auto_byte_count);
+                return;
+            }
             scheduler.Record([buffer_obj = buffer->Handle(), offset,
                               stride = params.stride](vk::CommandBuffer cmdbuf) {
                 cmdbuf.DrawIndirectByteCountEXT(1, 0, buffer_obj, offset, 0,
                                                 static_cast<u32>(stride));
             });
+            FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
+                                               pipeline_cache.CurrentGraphicsPipeline(), device);
             return;
         }
         if (params.include_count) {
@@ -320,6 +570,8 @@ void RasterizerVulkan::DrawIndirect() {
                                              static_cast<u32>(params.stride));
                 }
             });
+            FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
+                                               pipeline_cache.CurrentGraphicsPipeline(), device);
             return;
         }
         scheduler.Record([buffer_obj = buffer->Handle(), offset, params](vk::CommandBuffer cmdbuf) {
@@ -332,6 +584,8 @@ void RasterizerVulkan::DrawIndirect() {
                                     static_cast<u32>(params.stride));
             }
         });
+        FinishEmulatedTransformFeedbackDraw(scheduler, buffer_cache,
+                                           pipeline_cache.CurrentGraphicsPipeline(), device);
     });
     buffer_cache.SetDrawIndirect(nullptr);
 }
@@ -380,6 +634,15 @@ void RasterizerVulkan::DrawTexture() {
                                     .y = ScaleSrc(draw_texture_state.src_y1)}};
     Extent3D src_size = {static_cast<u32>(ScaleSrc(texture.size.width)),
                          static_cast<u32>(ScaleSrc(texture.size.height)), texture.size.depth};
+    if (g_draw_texture_budget > 0) {
+        --g_draw_texture_budget;
+        LOG_INFO(Render_Vulkan,
+                 "DrawTexture: dst=({},{})-({},{}) src=({},{})-({},{}) src_size={}x{}",
+                 draw_texture_state.dst_x0, draw_texture_state.dst_y0, draw_texture_state.dst_x1,
+                 draw_texture_state.dst_y1, draw_texture_state.src_x0, draw_texture_state.src_y0,
+                 draw_texture_state.src_x1, draw_texture_state.src_y1, src_size.width,
+                 src_size.height);
+    }
     blit_image.BlitColor(framebuffer, texture.RenderTarget(), texture.ImageHandle(),
                          sampler->Handle(), dst_region, src_region, src_size);
 }
@@ -923,6 +1186,61 @@ Tegra::Engines::AccelerateDMAInterface& RasterizerVulkan::AccessAccelerateDMA() 
     return accelerate_dma;
 }
 
+void RasterizerVulkan::CompositeGameRtToViAtPresent(const Tegra::FramebufferConfig& config,
+                                                    DAddr vi_cpu) {
+    if (!IsViScanoutCpuAddr(vi_cpu) || g_game_rt0_cpu_addr == 0 ||
+        g_game_rt0_cpu_addr == vi_cpu || g_game_rt0_peak_verts < GAME_RT_MIN_VERTICES) {
+        return;
+    }
+    const size_t src_bytes = ImageInfoGuestBytes(g_game_rt0_info);
+    if (src_bytes == 0 || !texture_cache.IsRegionGpuModified(g_game_rt0_cpu_addr, src_bytes)) {
+        return;
+    }
+    auto [vi_view, ignored] = texture_cache.TryFindFramebufferImageView(config, vi_cpu);
+    if (!vi_view || vi_view->gpu_addr == 0) {
+        return;
+    }
+    const GPUVAddr vi_gpu = vi_view->gpu_addr;
+    const u32 blit_width = std::min(config.width, g_game_rt0_config.width);
+    const u32 blit_height = std::min(config.height, g_game_rt0_config.height);
+    if (blit_width == 0 || blit_height == 0) {
+        return;
+    }
+
+    auto src_rt = g_game_rt0_config;
+    src_rt.width = blit_width;
+    src_rt.height = blit_height;
+    auto dst_rt = g_game_rt0_config;
+    dst_rt.width = blit_width;
+    dst_rt.height = blit_height;
+    dst_rt.address_high = static_cast<u32>(vi_gpu >> 32);
+    dst_rt.address_low = static_cast<u32>(vi_gpu);
+
+    const Tegra::Engines::Fermi2D::Surface src = MakeBlitSurface(src_rt, blit_width, blit_height);
+    const Tegra::Engines::Fermi2D::Surface dst = MakeBlitSurface(dst_rt, blit_width, blit_height);
+    const Tegra::Engines::Fermi2D::Config copy_config{
+        .operation = Tegra::Engines::Fermi2D::Operation::SrcCopy,
+        .filter = Tegra::Engines::Fermi2D::Filter::Bilinear,
+        .must_accelerate = true,
+        .dst_x0 = 0,
+        .dst_y0 = 0,
+        .dst_x1 = static_cast<s32>(blit_width),
+        .dst_y1 = static_cast<s32>(blit_height),
+        .src_x0 = 0,
+        .src_y0 = 0,
+        .src_x1 = static_cast<s32>(blit_width),
+        .src_y1 = static_cast<s32>(blit_height),
+    };
+    static u32 composite_log_budget = 30;
+    if (composite_log_budget > 0) {
+        --composite_log_budget;
+        LOG_INFO(Render_Vulkan,
+                 "Composite at present: game RT 0x{:x} -> VI 0x{:x} (peak_verts={} size={}x{})",
+                 g_game_rt0_cpu_addr, vi_cpu, g_game_rt0_peak_verts, blit_width, blit_height);
+    }
+    texture_cache.BlitImage(dst, src, copy_config);
+}
+
 void RasterizerVulkan::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                                 std::span<const u8> memory) {
     std::shared_lock shared_guard{shutdown_mutex};
@@ -952,11 +1270,122 @@ void RasterizerVulkan::AccelerateInlineToMemory(GPUVAddr address, size_t copy_si
 std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
     const Tegra::FramebufferConfig& config, DAddr framebuffer_addr, u32 pixel_stride) {
     if (!framebuffer_addr) {
+        static std::once_flag null_addr_once;
+        std::call_once(null_addr_once, [] {
+            LOG_WARNING(Render_Vulkan, "AccelerateDisplay: null framebuffer address");
+        });
         return {};
     }
+    scheduler.Finish();
     std::scoped_lock lock{texture_cache.mutex};
-    const auto [image_view, scaled] =
-        texture_cache.TryFindFramebufferImageView(config, framebuffer_addr);
+    const auto find_view = [&]() {
+        return texture_cache.TryFindFramebufferImageView(config, framebuffer_addr);
+    };
+    auto [image_view, scaled] = find_view();
+    const u32 bytes_per_pixel = [&] {
+        switch (config.pixel_format) {
+        case Service::android::PixelFormat::Rgb565:
+            return 2U;
+        default:
+            return 4U;
+        }
+    }();
+    const u64 fb_bytes = static_cast<u64>(pixel_stride) * config.height * bytes_per_pixel;
+    if (!image_view && fb_bytes > 0) {
+        texture_cache.DownloadMemory(framebuffer_addr, static_cast<size_t>(fb_bytes));
+        std::tie(image_view, scaled) = find_view();
+    }
+    DAddr present_addr = framebuffer_addr;
+    size_t present_bytes = static_cast<size_t>(fb_bytes);
+    if (IsViScanoutCpuAddr(framebuffer_addr)) {
+        const size_t vi_bytes = static_cast<size_t>(fb_bytes);
+        const bool vi_gpu_modified =
+            vi_bytes > 0 && texture_cache.IsRegionGpuModified(framebuffer_addr, vi_bytes);
+        const auto try_remap_to_offscreen = [&](DAddr rt_cpu, GPUVAddr rt_gpu,
+                                                const VideoCommon::ImageInfo& rt_info) {
+            if (rt_gpu == 0 || rt_cpu == 0 || IsViScanoutCpuAddr(rt_cpu) ||
+                rt_info.format == VideoCore::Surface::PixelFormat::Invalid) {
+                return false;
+            }
+            const size_t rt_bytes = ImageInfoGuestBytes(rt_info);
+            const bool offscreen_modified =
+                rt_bytes > 0 && texture_cache.IsRegionGpuModified(rt_cpu, rt_bytes);
+            auto [offscreen_view, offscreen_scaled] =
+                texture_cache.TryFindRenderTargetImageView(rt_info, rt_gpu);
+            static u32 remap_diag_budget = 60;
+            if (remap_diag_budget > 0) {
+                --remap_diag_budget;
+                if (!offscreen_modified) {
+                    LOG_INFO(Render_Vulkan,
+                             "AccelerateDisplay: skip remap VI 0x{:x} -> game RT 0x{:x} "
+                             "(rt0_gpu=0x{:x}): rt_not_modified",
+                             framebuffer_addr, rt_cpu, rt_gpu);
+                } else if (!offscreen_view) {
+                    LOG_INFO(Render_Vulkan,
+                             "AccelerateDisplay: skip remap VI 0x{:x} -> game RT 0x{:x} "
+                             "(rt0_gpu=0x{:x} fmt={}): rt_view_not_found",
+                             framebuffer_addr, rt_cpu, rt_gpu,
+                             static_cast<u32>(rt_info.format));
+                } else {
+                    LOG_INFO(Render_Vulkan,
+                             "AccelerateDisplay: remap VI 0x{:x} -> game RT 0x{:x} "
+                             "(rt0_gpu=0x{:x} peak_verts={})",
+                             framebuffer_addr, rt_cpu, rt_gpu, g_game_rt0_peak_verts);
+                }
+            }
+            if (!offscreen_modified || !offscreen_view) {
+                return false;
+            }
+            if (auto [display_view, display_scaled] =
+                    texture_cache.TryFindFramebufferImageView(config, rt_cpu);
+                display_view) {
+                offscreen_view = display_view;
+                offscreen_scaled = display_scaled;
+            }
+            image_view = offscreen_view;
+            scaled = offscreen_scaled;
+            present_addr = rt_cpu;
+            present_bytes = rt_bytes;
+            return true;
+        };
+        if (g_vi_overlay_active_frames > 0) {
+            --g_vi_overlay_active_frames;
+        }
+        // Present VI overlays directly when they carry UI. When VI is GPU-touched but CPU-empty
+        // and the game is rendering to an offscreen RT, scan out from the game RT instead.
+        bool vi_effectively_empty = !vi_gpu_modified;
+        if (!vi_effectively_empty) {
+            if (const u8* const host_ptr = device_memory.GetPointer<u8>(framebuffer_addr)) {
+                u32 guest_px{};
+                std::memcpy(&guest_px, host_ptr, sizeof(guest_px));
+                if (guest_px == 0 && g_vi_overlay_active_frames == 0 &&
+                    g_game_rt0_peak_verts >= GAME_RT_MIN_VERTICES) {
+                    vi_effectively_empty = true;
+                }
+            }
+        }
+        if (vi_effectively_empty) {
+            try_remap_to_offscreen(g_game_rt0_cpu_addr, g_game_rt0_gpu_addr, g_game_rt0_info);
+        }
+    }
+    const bool gpu_modified =
+        present_bytes > 0 && texture_cache.IsRegionGpuModified(present_addr, present_bytes);
+    static u32 accelerate_diag_budget = 120;
+    if (accelerate_diag_budget > 0) {
+        --accelerate_diag_budget;
+        u32 guest_px_raw = 0;
+        if (g_fb_sample_budget > 0) {
+            --g_fb_sample_budget;
+            if (const u8* const host_ptr = device_memory.GetPointer<u8>(framebuffer_addr)) {
+                std::memcpy(&guest_px_raw, host_ptr, sizeof(guest_px_raw));
+            }
+        }
+        LOG_INFO(Render_Vulkan,
+                 "AccelerateDisplay: addr=0x{:x} {}x{} stride={} accelerated={} "
+                 "gpu_modified={} guest_px_raw={:08x}",
+                 framebuffer_addr, config.width, config.height, pixel_stride, image_view != nullptr,
+                 gpu_modified, guest_px_raw);
+    }
     if (!image_view) {
         return {};
     }
@@ -971,6 +1400,8 @@ std::optional<FramebufferTextureInfo> RasterizerVulkan::AccelerateDisplay(
     info.height = image_view->size.height;
     info.scaled_width = scaled ? resolution.ScaleUp(info.width) : info.width;
     info.scaled_height = scaled ? resolution.ScaleUp(info.height) : info.height;
+    info.guest_addr = present_addr;
+    info.guest_bytes = present_bytes;
     return info;
 }
 
@@ -1106,11 +1537,19 @@ void RasterizerVulkan::UpdateDynamicStates() {
 void RasterizerVulkan::HandleTransformFeedback() {
     static std::once_flag warn_unsupported;
 
-    const auto& regs = maxwell3d->regs;
+    auto& regs = maxwell3d->regs;
     if (!device.IsExtTransformFeedbackSupported()) {
-        std::call_once(warn_unsupported, [&] {
-            LOG_ERROR(Render_Vulkan, "Transform feedbacks used but not supported");
-        });
+        if (regs.transform_feedback_enabled != 0) {
+            std::call_once(warn_unsupported, [&] {
+                LOG_WARNING(Render_Vulkan,
+                            "Transform feedback is enabled in GPU state but "
+                            "VK_EXT_transform_feedback is unavailable (e.g. MoltenVK); using "
+                            "software emulation");
+                g_xfb_draw_diag_budget = 40;
+            });
+        }
+        query_cache.CounterEnable(VideoCommon::QueryType::StreamingByteCount,
+                                  regs.transform_feedback_enabled);
         return;
     }
     query_cache.CounterEnable(VideoCommon::QueryType::StreamingByteCount,
@@ -1431,6 +1870,8 @@ void RasterizerVulkan::UpdatePrimitiveRestartEnable(Tegra::Engines::Maxwell3D::R
     if (!state_tracker.TouchPrimitiveRestartEnable()) {
         return;
     }
+    // MoltenVK: Metal does not support disabling primitive restart; dynamic VK_FALSE returns
+    // VK_ERROR_FEATURE_NOT_PRESENT. Restart is forced on in the pipeline for strip/fan topologies.
     if (device.GetDriverID() == VK_DRIVER_ID_MOLTENVK) {
         return;
     }
@@ -1659,46 +2100,91 @@ void RasterizerVulkan::UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs) 
 
     boost::container::static_vector<VkVertexInputBindingDescription2EXT, 32> bindings;
     boost::container::static_vector<VkVertexInputAttributeDescription2EXT, 32> attributes;
+    const size_t max_vertex_attrs = static_cast<size_t>(device.GetMaxVertexInputAttributes());
+    const size_t max_vertex_bindings = static_cast<size_t>(device.GetMaxVertexInputBindings());
+    const GraphicsPipeline* const pipeline = pipeline_cache.CurrentGraphicsPipeline();
+    const Shader::RuntimeInfo* vertex_remap =
+        pipeline ? &pipeline->VertexInputRemap() : nullptr;
 
     // There seems to be a bug on Nvidia's driver where updating only higher attributes ends up
     // generating dirty state. Track the highest dirty attribute and update all attributes until
-    // that one.
-    size_t highest_dirty_attr{};
+    // that one (inclusive).
+    std::optional<size_t> highest_dirty_attr;
     for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes; ++index) {
         if (dirty[Dirty::VertexAttribute0 + index]) {
             highest_dirty_attr = index;
         }
     }
-    for (size_t index = 0; index < highest_dirty_attr; ++index) {
-        const Tegra::Engines::Maxwell3D::Regs::VertexAttribute attribute{
-            regs.vertex_attrib_format[index]};
-        const u32 binding{attribute.buffer};
-        dirty[Dirty::VertexAttribute0 + index] = false;
-        dirty[Dirty::VertexBinding0 + static_cast<size_t>(binding)] = true;
-        if (!attribute.constant) {
-            attributes.push_back({
-                .sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
-                .pNext = nullptr,
-                .location = static_cast<u32>(index),
-                .binding = binding,
-                .format = MaxwellToVK::VertexFormat(device, attribute.type, attribute.size),
-                .offset = attribute.offset,
-            });
+    if (highest_dirty_attr && max_vertex_attrs > 0) {
+        const size_t last_dirty_attr =
+            std::min(*highest_dirty_attr, max_vertex_attrs - 1);
+        for (size_t index = 0; index <= last_dirty_attr; ++index) {
+            const Tegra::Engines::Maxwell3D::Regs::VertexAttribute attribute{
+                regs.vertex_attrib_format[index]};
+            const u32 guest_binding{attribute.buffer};
+            dirty[Dirty::VertexAttribute0 + index] = false;
+            dirty[Dirty::VertexBinding0 + static_cast<size_t>(guest_binding)] = true;
+            if (!attribute.constant) {
+                if (vertex_remap && !IsVertexAttributeMapped(*vertex_remap, index)) {
+                    continue;
+                }
+                if (guest_binding >= max_vertex_bindings) {
+                    continue;
+                }
+                u32 location = static_cast<u32>(index);
+                u32 binding = guest_binding;
+                if (vertex_remap) {
+                    location = VulkanVertexLocation(*vertex_remap, index);
+                    if (location >= max_vertex_attrs) {
+                        continue;
+                    }
+                    if (!IsVertexBindingMapped(*vertex_remap, guest_binding)) {
+                        continue;
+                    }
+                    binding = VulkanVertexBinding(*vertex_remap, guest_binding);
+                    if (binding >= max_vertex_bindings) {
+                        continue;
+                    }
+                } else if (location >= max_vertex_attrs) {
+                    continue;
+                }
+                attributes.push_back({
+                    .sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
+                    .pNext = nullptr,
+                    .location = location,
+                    .binding = binding,
+                    .format = MaxwellToVK::VertexFormat(device, attribute.type, attribute.size),
+                    .offset = attribute.offset,
+                });
+            }
         }
     }
-    for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes; ++index) {
-        if (!dirty[Dirty::VertexBinding0 + index]) {
+    for (size_t guest = 0; guest < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays; ++guest) {
+        if (guest >= max_vertex_bindings) {
+            break;
+        }
+        if (!dirty[Dirty::VertexBinding0 + guest]) {
             continue;
         }
-        dirty[Dirty::VertexBinding0 + index] = false;
+        dirty[Dirty::VertexBinding0 + guest] = false;
 
-        const u32 binding{static_cast<u32>(index)};
-        const auto& input_binding{regs.vertex_streams[binding]};
-        const bool is_instanced{regs.vertex_stream_instances.IsInstancingEnabled(binding)};
+        if (vertex_remap && !IsVertexBindingMapped(*vertex_remap, static_cast<u32>(guest))) {
+            continue;
+        }
+        u32 vk_binding = static_cast<u32>(guest);
+        if (vertex_remap) {
+            vk_binding = VulkanVertexBinding(*vertex_remap, static_cast<u32>(guest));
+            if (vk_binding >= max_vertex_bindings) {
+                continue;
+            }
+        }
+        const auto& input_binding{regs.vertex_streams[guest]};
+        const bool is_instanced{regs.vertex_stream_instances.IsInstancingEnabled(
+            static_cast<u32>(guest))};
         bindings.push_back({
             .sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT,
             .pNext = nullptr,
-            .binding = binding,
+            .binding = vk_binding,
             .stride = input_binding.stride,
             .inputRate = is_instanced ? VK_VERTEX_INPUT_RATE_INSTANCE : VK_VERTEX_INPUT_RATE_VERTEX,
             .divisor = is_instanced ? input_binding.frequency : 1,
@@ -1745,6 +2231,12 @@ void RasterizerVulkan::ReleaseChannel(s32 channel_id) {
     }
     pipeline_cache.EraseChannel(channel_id);
     query_cache.EraseChannel(channel_id);
+}
+
+bool RasterizerVulkan::HasDrawTransformFeedback() {
+    // Force the HLE DrawIndirectByteCount path on MoltenVK; software XFB emulation replaces
+    // VK_EXT_transform_feedback but still relies on the same macro/query flow.
+    return true;
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -5,15 +5,17 @@
 
 #include <array>
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 
 #include <boost/container/static_vector.hpp>
 
 #include "common/common_types.h"
 #include "video_core/control/channel_state_cache.h"
-#include "video_core/engines/maxwell_dma.h"
+#include "video_core/engines/maxwell_3d.h"
 #include "video_core/host1x/gpu_device_memory_manager.h"
 #include "video_core/rasterizer_interface.h"
+#include "video_core/texture_cache/image_info.h"
 #include "video_core/renderer_vulkan/blit_image.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
@@ -46,6 +48,20 @@ class Maxwell3D;
 namespace Vulkan {
 
 struct FramebufferTextureInfo;
+
+struct PresentTrackingState {
+    std::mutex mutex;
+    u32 last_xfb_snapshot_records = 0;
+    DAddr last_rt0_cpu_addr = 0;
+    GPUVAddr last_rt0_gpu_addr = 0;
+    VideoCommon::ImageInfo last_rt0_info{};
+    DAddr game_rt0_cpu_addr = 0;
+    GPUVAddr game_rt0_gpu_addr = 0;
+    VideoCommon::ImageInfo game_rt0_info{};
+    Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig game_rt0_config{};
+    u32 game_rt0_peak_verts = 0;
+    u32 vi_overlay_active_frames = 0;
+};
 
 class StateTracker;
 
@@ -199,6 +215,10 @@ private:
 
     void UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs);
 
+    void TrackGameRenderTarget(DAddr cpu_addr, GPUVAddr gpu_addr,
+                               const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& rt_config,
+                               Tegra::Texture::MsaaMode msaa_mode, u32 num_vertices);
+
     Tegra::GPU& gpu;
     Tegra::MaxwellDeviceMemoryManager& device_memory;
 
@@ -231,6 +251,8 @@ private:
     boost::container::static_vector<VkSampler, MAX_TEXTURES> sampler_handles;
 
     u32 draw_counter = 0;
+
+    PresentTrackingState present_tracking;
 
     std::shared_mutex shutdown_mutex;
     std::atomic_bool is_shutting_down{false};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -149,9 +149,13 @@ public:
 
     void ReleaseChannel(s32 channel_id) override;
 
+    bool HasDrawTransformFeedback() override;
+
     std::optional<FramebufferTextureInfo> AccelerateDisplay(const Tegra::FramebufferConfig& config,
                                                             VAddr framebuffer_addr,
                                                             u32 pixel_stride);
+
+    void CompositeGameRtToViAtPresent(const Tegra::FramebufferConfig& config, DAddr vi_cpu);
 
 private:
     static constexpr size_t MAX_TEXTURES = 192;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -83,8 +83,10 @@ public:
     }
 
     bool CanUploadMSAA() const noexcept {
-        // TODO: Implement buffer to MSAA uploads
-        return false;
+        // Multisampled VkImages use reduced extent (see MakeImageCreateInfo) and standard
+        // buffer-image copies; guest unswizzle already accounts for sample layout.
+        // MoltenVK accepts this path; returning false breaks MSAA texture uploads (e.g. Minecraft).
+        return true;
     }
 
     void AccelerateImageUpload(Image&, const StagingBufferRef&,

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 
@@ -28,6 +29,36 @@
 namespace VideoCommon {
 
 constexpr std::array<char, 8> MAGIC_NUMBER{'y', 'u', 'z', 'u', 'c', 'a', 'c', 'h'};
+
+namespace {
+
+constexpr u64 MAX_SHADER_CODE_BYTES = 16 * 1024 * 1024;
+constexpr u64 MAX_MAP_ENTRIES = 4096;
+
+void DeletePipelineCacheFile(const std::filesystem::path& filename, std::string_view reason) {
+    LOG_ERROR(Common_Filesystem, "Invalid pipeline cache ({}): deleting \"{}\"", reason,
+              Common::FS::PathToUTF8String(filename));
+    if (!Common::FS::RemoveFile(filename)) {
+        LOG_ERROR(Common_Filesystem, "Failed to delete pipeline cache file \"{}\"",
+                  Common::FS::PathToUTF8String(filename));
+    }
+}
+
+template<typename T>
+bool ReadPod(std::ifstream& file, T& value) {
+    file.read(reinterpret_cast<char*>(&value), sizeof(T));
+    return file.gcount() == static_cast<std::streamsize>(sizeof(T));
+}
+
+bool ReadBytes(std::ifstream& file, void* dst, std::size_t size) {
+    if (size == 0) {
+        return true;
+    }
+    file.read(static_cast<char*>(dst), static_cast<std::streamsize>(size));
+    return file.gcount() == static_cast<std::streamsize>(size);
+}
+
+} // namespace
 
 constexpr size_t INST_SIZE = sizeof(u64);
 
@@ -522,76 +553,113 @@ u32 ComputeEnvironment::ReadViewportTransformState() {
 }
 
 void FileEnvironment::Deserialize(std::ifstream& file) {
+    if (!TryDeserialize(file)) {
+        throw std::ios_base::failure("Failed to deserialize shader environment");
+    }
+}
+
+bool FileEnvironment::TryDeserialize(std::ifstream& file) {
+    const auto prev_exceptions = file.exceptions();
+    file.exceptions(std::ifstream::goodbit);
+
+    const auto restore = [&] { file.exceptions(prev_exceptions); };
+
     u64 code_size{};
     u64 num_texture_types{};
     u64 num_texture_pixel_formats{};
     u64 num_cbuf_values{};
     u64 num_cbuf_replacement_values{};
     u64 num_cbuf_sizes{};
-    file.read(reinterpret_cast<char*>(&code_size), sizeof(code_size))
-        .read(reinterpret_cast<char*>(&num_texture_types), sizeof(num_texture_types))
-        .read(reinterpret_cast<char*>(&num_texture_pixel_formats),
-              sizeof(num_texture_pixel_formats))
-        .read(reinterpret_cast<char*>(&num_cbuf_values), sizeof(num_cbuf_values))
-        .read(reinterpret_cast<char*>(&num_cbuf_replacement_values),
-              sizeof(num_cbuf_replacement_values))
-        .read(reinterpret_cast<char*>(&num_cbuf_sizes), sizeof(num_cbuf_sizes))
-        .read(reinterpret_cast<char*>(&local_memory_size), sizeof(local_memory_size))
-        .read(reinterpret_cast<char*>(&texture_bound), sizeof(texture_bound))
-        .read(reinterpret_cast<char*>(&start_address), sizeof(start_address))
-        .read(reinterpret_cast<char*>(&read_lowest), sizeof(read_lowest))
-        .read(reinterpret_cast<char*>(&read_highest), sizeof(read_highest))
-        .read(reinterpret_cast<char*>(&viewport_transform_state), sizeof(viewport_transform_state))
-        .read(reinterpret_cast<char*>(&stage), sizeof(stage));
+    if (!ReadPod(file, code_size) || !ReadPod(file, num_texture_types) ||
+        !ReadPod(file, num_texture_pixel_formats) || !ReadPod(file, num_cbuf_values) ||
+        !ReadPod(file, num_cbuf_replacement_values) || !ReadPod(file, num_cbuf_sizes) ||
+        !ReadPod(file, local_memory_size) || !ReadPod(file, texture_bound) ||
+        !ReadPod(file, start_address) || !ReadPod(file, read_lowest) ||
+        !ReadPod(file, read_highest) || !ReadPod(file, viewport_transform_state) ||
+        !ReadPod(file, stage)) {
+        restore();
+        return false;
+    }
+    if (code_size == 0 || code_size > MAX_SHADER_CODE_BYTES ||
+        num_texture_types > MAX_MAP_ENTRIES || num_texture_pixel_formats > MAX_MAP_ENTRIES ||
+        num_cbuf_values > MAX_MAP_ENTRIES || num_cbuf_replacement_values > MAX_MAP_ENTRIES ||
+        num_cbuf_sizes > MAX_MAP_ENTRIES || read_highest < read_lowest ||
+        static_cast<u64>(read_highest) - read_lowest + INST_SIZE > code_size) {
+        restore();
+        return false;
+    }
     code.resize(Common::DivCeil(code_size, sizeof(u64)));
-    file.read(reinterpret_cast<char*>(code.data()), code_size);
+    if (!ReadBytes(file, code.data(), code_size)) {
+        restore();
+        return false;
+    }
     for (size_t i = 0; i < num_texture_types; ++i) {
         u32 key;
         Shader::TextureType type;
-        file.read(reinterpret_cast<char*>(&key), sizeof(key))
-            .read(reinterpret_cast<char*>(&type), sizeof(type));
+        if (!ReadPod(file, key) || !ReadPod(file, type)) {
+            restore();
+            return false;
+        }
         texture_types.emplace(key, type);
     }
     for (size_t i = 0; i < num_texture_pixel_formats; ++i) {
         u32 key;
         Shader::TexturePixelFormat format;
-        file.read(reinterpret_cast<char*>(&key), sizeof(key))
-            .read(reinterpret_cast<char*>(&format), sizeof(format));
+        if (!ReadPod(file, key) || !ReadPod(file, format)) {
+            restore();
+            return false;
+        }
         texture_pixel_formats.emplace(key, format);
     }
     for (size_t i = 0; i < num_cbuf_values; ++i) {
         u64 key;
         u32 value;
-        file.read(reinterpret_cast<char*>(&key), sizeof(key))
-            .read(reinterpret_cast<char*>(&value), sizeof(value));
+        if (!ReadPod(file, key) || !ReadPod(file, value)) {
+            restore();
+            return false;
+        }
         cbuf_values.emplace(key, value);
     }
     for (size_t i = 0; i < num_cbuf_replacement_values; ++i) {
         u64 key;
         Shader::ReplaceConstant value;
-        file.read(reinterpret_cast<char*>(&key), sizeof(key))
-            .read(reinterpret_cast<char*>(&value), sizeof(value));
+        if (!ReadPod(file, key) || !ReadPod(file, value)) {
+            restore();
+            return false;
+        }
         cbuf_replacements.emplace(key, value);
     }
     for (size_t i = 0; i < num_cbuf_sizes; ++i) {
         u32 key;
         u32 size;
-        file.read(reinterpret_cast<char*>(&key), sizeof(key))
-            .read(reinterpret_cast<char*>(&size), sizeof(size));
+        if (!ReadPod(file, key) || !ReadPod(file, size)) {
+            restore();
+            return false;
+        }
         cbuf_sizes.emplace(key, size);
     }
     if (stage == Shader::Stage::Compute) {
-        file.read(reinterpret_cast<char*>(&workgroup_size), sizeof(workgroup_size))
-            .read(reinterpret_cast<char*>(&shared_memory_size), sizeof(shared_memory_size));
+        if (!ReadPod(file, workgroup_size) || !ReadPod(file, shared_memory_size)) {
+            restore();
+            return false;
+        }
         initial_offset = 0;
     } else {
-        file.read(reinterpret_cast<char*>(&sph), sizeof(sph));
+        if (!ReadPod(file, sph)) {
+            restore();
+            return false;
+        }
         initial_offset = sizeof(sph);
         if (stage == Shader::Stage::Geometry) {
-            file.read(reinterpret_cast<char*>(&gp_passthrough_mask), sizeof(gp_passthrough_mask));
+            if (!ReadPod(file, gp_passthrough_mask)) {
+                restore();
+                return false;
+            }
         }
     }
     is_proprietary_driver = texture_bound == 2;
+    restore();
+    return true;
 }
 
 void FileEnvironment::Dump(u64 pipeline_hash, u64 shader_hash) {
@@ -709,14 +777,15 @@ void LoadPipelines(
     if (!file.is_open()) {
         return;
     }
-    file.exceptions(std::ifstream::failbit);
     const auto end{file.tellg()};
     file.seekg(0, std::ios::beg);
 
     std::array<char, 8> magic_number;
     u32 cache_version;
-    file.read(magic_number.data(), magic_number.size())
-        .read(reinterpret_cast<char*>(&cache_version), sizeof(cache_version));
+    if (!ReadPod(file, magic_number) || !ReadPod(file, cache_version)) {
+        DeletePipelineCacheFile(filename, "truncated header");
+        return;
+    }
     if (magic_number != MAGIC_NUMBER || cache_version != expected_cache_version) {
         file.close();
         if (Common::FS::RemoveFile(filename)) {
@@ -738,16 +807,23 @@ void LoadPipelines(
             return;
         }
         u32 num_envs{};
-        file.read(reinterpret_cast<char*>(&num_envs), sizeof(num_envs));
+        if (!ReadPod(file, num_envs)) {
+            DeletePipelineCacheFile(filename, "truncated pipeline entry header");
+            return;
+        }
 
-        if (num_envs == 0 || num_envs > 64) {
+        if (num_envs == 0 || num_envs > 5) {
             LOG_ERROR(Common_Filesystem, "Corrupted shader cache detected: num_envs={}", num_envs);
-            throw std::ios_base::failure("Corrupted num_envs");
+            DeletePipelineCacheFile(filename, "invalid num_envs");
+            return;
         }
 
         std::vector<FileEnvironment> envs(num_envs);
         for (FileEnvironment& env : envs) {
-            env.Deserialize(file);
+            if (!env.TryDeserialize(file)) {
+                DeletePipelineCacheFile(filename, "corrupt shader environment");
+                return;
+            }
         }
 
         if (envs.front().ShaderStage() == Shader::Stage::Compute) {
@@ -757,12 +833,12 @@ void LoadPipelines(
         }
     }
 
-} catch (const std::ios_base::failure& e) {
+} catch (const std::exception& e) {
     LOG_ERROR(Common_Filesystem, "{}", e.what());
-    if (!Common::FS::RemoveFile(filename)) {
-        LOG_ERROR(Common_Filesystem, "Failed to delete pipeline cache file {}",
-                  Common::FS::PathToUTF8String(filename));
-    }
+    DeletePipelineCacheFile(filename, "unexpected read failure");
+} catch (...) {
+    LOG_ERROR(Common_Filesystem, "Unknown error while loading pipeline cache");
+    DeletePipelineCacheFile(filename, "unknown read failure");
 }
 
 } // namespace VideoCommon

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -588,6 +588,19 @@ bool FileEnvironment::TryDeserialize(std::ifstream& file) {
         restore();
         return false;
     }
+    switch (stage) {
+    case Shader::Stage::VertexB:
+    case Shader::Stage::TessellationControl:
+    case Shader::Stage::TessellationEval:
+    case Shader::Stage::Geometry:
+    case Shader::Stage::Fragment:
+    case Shader::Stage::Compute:
+    case Shader::Stage::VertexA:
+        break;
+    default:
+        restore();
+        return false;
+    }
     code.resize(Common::DivCeil(code_size, sizeof(u64)));
     if (!ReadBytes(file, code.data(), code_size)) {
         restore();
@@ -779,11 +792,15 @@ void LoadPipelines(
     }
     const auto end{file.tellg()};
     file.seekg(0, std::ios::beg);
+    const auto delete_cache = [&](std::string_view reason) {
+        file.close();
+        DeletePipelineCacheFile(filename, reason);
+    };
 
     std::array<char, 8> magic_number;
     u32 cache_version;
     if (!ReadPod(file, magic_number) || !ReadPod(file, cache_version)) {
-        DeletePipelineCacheFile(filename, "truncated header");
+        delete_cache("truncated header");
         return;
     }
     if (magic_number != MAGIC_NUMBER || cache_version != expected_cache_version) {
@@ -808,20 +825,20 @@ void LoadPipelines(
         }
         u32 num_envs{};
         if (!ReadPod(file, num_envs)) {
-            DeletePipelineCacheFile(filename, "truncated pipeline entry header");
+            delete_cache("truncated pipeline entry header");
             return;
         }
 
         if (num_envs == 0 || num_envs > 5) {
             LOG_ERROR(Common_Filesystem, "Corrupted shader cache detected: num_envs={}", num_envs);
-            DeletePipelineCacheFile(filename, "invalid num_envs");
+            delete_cache("invalid num_envs");
             return;
         }
 
         std::vector<FileEnvironment> envs(num_envs);
         for (FileEnvironment& env : envs) {
             if (!env.TryDeserialize(file)) {
-                DeletePipelineCacheFile(filename, "corrupt shader environment");
+                delete_cache("corrupt shader environment");
                 return;
             }
         }

--- a/src/video_core/shader_environment.h
+++ b/src/video_core/shader_environment.h
@@ -173,6 +173,9 @@ public:
 
     void Deserialize(std::ifstream& file);
 
+    /// @returns false if the stream ends early or contains invalid sizes.
+    [[nodiscard]] bool TryDeserialize(std::ifstream& file);
+
     [[nodiscard]] u64 ReadInstruction(u32 address) override;
 
     [[nodiscard]] u32 ReadCbufValue(u32 cbuf_index, u32 cbuf_offset) override;

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -136,8 +136,9 @@ bool ImageBase::IsSafeDownload() const noexcept {
         return false;
     }
     if (info.num_samples > 1) {
-        LOG_WARNING(HW_GPU, "MSAA image downloads are not implemented");
-        return false;
+        // On MoltenVK, rejecting MSAA downloads can leave stale CPU-visible image state and lead
+        // to black output in some titles. Prefer a best-effort download path here.
+        return true;
     }
     return true;
 }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1000,6 +1000,7 @@ bool TextureCache<P>::BlitImage(const Tegra::Engines::Fermi2D::Surface& dst,
         runtime.BlitImage(dst_framebuffer, dst_view, src_view, dst_region, src_region, copy.filter,
                           copy.operation);
     }
+    MarkModification(dst_id);
     return true;
 }
 
@@ -1060,6 +1061,21 @@ std::pair<typename P::ImageView*, bool> TextureCache<P>::TryFindFramebufferImage
     }
 
     return {};
+}
+
+template <class P>
+std::pair<typename P::ImageView*, bool> TextureCache<P>::TryFindRenderTargetImageView(
+    const ImageInfo& info, GPUVAddr gpu_addr) {
+    if (gpu_addr == 0 || info.format == PixelFormat::Invalid) {
+        return {};
+    }
+    const ImageViewId view_id = FindRenderTargetView(info, gpu_addr);
+    if (view_id == NULL_IMAGE_VIEW_ID) {
+        return {};
+    }
+    ImageView& image_view = slot_image_views[view_id];
+    Image& image = slot_images[image_view.image_id];
+    return {&image_view, image.IsRescaled()};
 }
 
 template <class P>

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -231,6 +231,10 @@ public:
     [[nodiscard]] std::pair<ImageView*, bool> TryFindFramebufferImageView(
         const Tegra::FramebufferConfig& config, DAddr cpu_addr);
 
+    /// Find or create a render target image view from guest RT register state
+    [[nodiscard]] std::pair<ImageView*, bool> TryFindRenderTargetImageView(
+        const ImageInfo& info, GPUVAddr gpu_addr);
+
     /// Return true when there are uncommitted images to be downloaded
     [[nodiscard]] bool HasUncommittedFlushes() const noexcept;
 

--- a/src/video_core/transform_feedback.h
+++ b/src/video_core/transform_feedback.h
@@ -19,6 +19,7 @@ struct TransformFeedbackState {
         u32 stride;
     };
     std::array<Layout, Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers> layouts;
+    std::array<s32, Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers> buffer_sizes;
     std::array<std::array<Tegra::Engines::Maxwell3D::Regs::StreamOutLayout, 32>,
                Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers>
         varyings;

--- a/src/video_core/vulkan_common/vulkan.h
+++ b/src/video_core/vulkan_common/vulkan.h
@@ -8,6 +8,7 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__APPLE__)
 #define VK_USE_PLATFORM_METAL_EXT
+#define VK_ENABLE_BETA_EXTENSIONS
 #elif defined(__ANDROID__)
 #define VK_USE_PLATFORM_ANDROID_KHR
 #else

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -189,6 +189,8 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
         VK_FORMAT_B8G8R8A8_UNORM,
         VK_FORMAT_BC1_RGBA_SRGB_BLOCK,
         VK_FORMAT_BC1_RGBA_UNORM_BLOCK,
+        VK_FORMAT_BC1_RGB_SRGB_BLOCK,
+        VK_FORMAT_BC1_RGB_UNORM_BLOCK,
         VK_FORMAT_BC2_SRGB_BLOCK,
         VK_FORMAT_BC2_UNORM_BLOCK,
         VK_FORMAT_BC3_SRGB_BLOCK,
@@ -208,6 +210,17 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
         VK_FORMAT_D32_SFLOAT,
         VK_FORMAT_D32_SFLOAT_S8_UINT,
         VK_FORMAT_E5B9G9R9_UFLOAT_PACK32,
+        VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK,
+        VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK,
+        // EAC (often used with ETC2; queried by texture / format checks on Metal/MoltenVK)
+        VK_FORMAT_EAC_R11_UNORM_BLOCK,
+        VK_FORMAT_EAC_R11_SNORM_BLOCK,
+        VK_FORMAT_EAC_R11G11_UNORM_BLOCK,
+        VK_FORMAT_EAC_R11G11_SNORM_BLOCK,
         VK_FORMAT_R16G16B16A16_SFLOAT,
         VK_FORMAT_R16G16B16A16_SINT,
         VK_FORMAT_R16G16B16A16_SNORM,
@@ -730,12 +743,20 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     if (is_mvk) {
-        LOG_WARNING(Render_Vulkan,
-                    "MVK driver breaks when using more than 16 vertex attributes/bindings");
+        // Older MoltenVK builds fault above 16; Metal supports 31. Use the reported limit capped at
+        // 31 instead of forcing 16 so titles like Minecraft can use >16 streams when supported.
+        constexpr u32 MVK_VERTEX_INPUT_LIMIT = 31;
+        const u32 reported_attrs = properties.properties.limits.maxVertexInputAttributes;
+        const u32 reported_bindings = properties.properties.limits.maxVertexInputBindings;
         properties.properties.limits.maxVertexInputAttributes =
-            std::min(properties.properties.limits.maxVertexInputAttributes, 16U);
+            std::min(reported_attrs, MVK_VERTEX_INPUT_LIMIT);
         properties.properties.limits.maxVertexInputBindings =
-            std::min(properties.properties.limits.maxVertexInputBindings, 16U);
+            std::min(reported_bindings, MVK_VERTEX_INPUT_LIMIT);
+        LOG_INFO(Render_Vulkan,
+                 "MoltenVK vertex input limits: attributes={} bindings={} (reported {}/{})",
+                 properties.properties.limits.maxVertexInputAttributes,
+                 properties.properties.limits.maxVertexInputBindings, reported_attrs,
+                 reported_bindings);
     }
 
     if (is_turnip) {
@@ -934,11 +955,9 @@ bool Device::TestDepthStencilBlits(VkFormat format) const {
 bool Device::IsFormatSupported(VkFormat wanted_format, VkFormatFeatureFlags wanted_usage,
                                FormatType format_type) const {
     const auto it = format_properties.find(wanted_format);
-    if (it == format_properties.end()) {
-        UNIMPLEMENTED_MSG("Unimplemented format query={}", wanted_format);
-        return true;
-    }
-    const auto supported_usage = GetFormatFeatures(it->second, format_type);
+    const VkFormatProperties& props =
+        it != format_properties.end() ? it->second : physical.GetFormatProperties(wanted_format);
+    const auto supported_usage = GetFormatFeatures(props, format_type);
     return (supported_usage & wanted_usage) == wanted_usage;
 }
 
@@ -1072,6 +1091,13 @@ bool Device::GetSuitability(bool requires_swapchain) {
     FOR_EACH_VK_FEATURE_EXT(FEATURE_EXTENSION);
     FOR_EACH_VK_EXTENSION(EXTENSION);
 
+#ifdef __APPLE__
+    if (supported_extensions.contains(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        loaded_extensions.insert(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+        extensions.portability_subset = true;
+    }
+#endif
+
 #undef FEATURE_EXTENSION
 #undef EXTENSION
 
@@ -1129,6 +1155,14 @@ bool Device::GetSuitability(bool requires_swapchain) {
     } else {
         FOR_EACH_VK_FEATURE_1_3(EXT_FEATURE);
     }
+
+#ifdef __APPLE__
+    if (extensions.portability_subset) {
+        features.portability_subset_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR;
+        SetNext(next, features.portability_subset_features);
+    }
+#endif
 
 #undef EXT_FEATURE
 #undef FEATURE

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -418,6 +418,11 @@ public:
         return extensions.geometry_shader_passthrough;
     }
 
+    /// Returns true if core Vulkan geometry shaders are supported.
+    bool IsGeometryShaderSupported() const {
+        return features.features.geometryShader;
+    }
+
     /// Returns true if the device supports VK_NV_low_latency2.
     bool IsNvLowLatency2Supported() const {
         return extensions.low_latency2;
@@ -812,6 +817,10 @@ private:
         FOR_EACH_VK_FEATURE_EXT(FEATURE);
         FOR_EACH_VK_EXTENSION(EXTENSION);
 
+#ifdef __APPLE__
+        bool portability_subset{};
+#endif
+
 #undef EXTENSION
 #undef FEATURE
     };
@@ -826,6 +835,10 @@ private:
         FOR_EACH_VK_FEATURE_1_2(FEATURE_CORE);
         FOR_EACH_VK_FEATURE_1_3(FEATURE_CORE);
         FOR_EACH_VK_FEATURE_EXT(FEATURE_EXT);
+
+#ifdef __APPLE__
+        VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features{};
+#endif
 
 #undef FEATURE_CORE
 #undef FEATURE_EXT

--- a/src/video_core/vulkan_common/vulkan_instance.cpp
+++ b/src/video_core/vulkan_common/vulkan_instance.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2020 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstring>
 #include <future>
 #include <optional>
-#include <span>
 #include <vector>
 
 #include "common/common_types.h"
@@ -17,28 +17,23 @@
 namespace Vulkan {
 namespace {
 
-[[nodiscard]] bool AreExtensionsSupported(const vk::InstanceDispatch& dld,
-                                          std::span<const char* const> extensions) {
-    const std::optional properties = vk::EnumerateInstanceExtensionProperties(dld);
-    if (!properties) {
-        LOG_ERROR(Render_Vulkan, "Failed to query extension properties");
-        return false;
-    }
-    for (const char* extension : extensions) {
-        const auto it = std::ranges::find_if(*properties, [extension](const auto& prop) {
-            return std::strcmp(extension, prop.extensionName) == 0;
-        });
-        if (it == properties->end()) {
-            LOG_ERROR(Render_Vulkan, "Required instance extension {} is not available", extension);
-            return false;
-        }
-    }
-    return true;
+[[nodiscard]] bool HasInstanceExtension(const std::vector<VkExtensionProperties>& properties,
+                                        const char* extension) {
+    return std::ranges::any_of(properties, [extension](const VkExtensionProperties& prop) {
+        return std::strcmp(extension, prop.extensionName) == 0;
+    });
 }
 
-[[nodiscard]] std::vector<const char*> RequiredExtensions(
-    const vk::InstanceDispatch& dld, Core::Frontend::WindowSystemType window_type,
-    bool enable_validation) {
+[[nodiscard]] std::vector<const char*> BuildRequiredExtensions(
+    const std::vector<VkExtensionProperties>& available,
+    Core::Frontend::WindowSystemType window_type, bool enable_validation) {
+    const auto require_ext = [&](const char* name) {
+        if (!HasInstanceExtension(available, name)) {
+            LOG_ERROR(Render_Vulkan, "Required instance extension {} is not available", name);
+            throw vk::Exception(VK_ERROR_EXTENSION_NOT_PRESENT);
+        }
+    };
+
     std::vector<const char*> extensions;
     extensions.reserve(6);
     switch (window_type) {
@@ -46,40 +41,53 @@ namespace {
         break;
 #ifdef _WIN32
     case Core::Frontend::WindowSystemType::Windows:
+        require_ext(VK_KHR_SURFACE_EXTENSION_NAME);
+        require_ext(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
         break;
 #elif defined(__APPLE__)
     case Core::Frontend::WindowSystemType::Cocoa:
+        require_ext(VK_KHR_SURFACE_EXTENSION_NAME);
+        require_ext(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
         extensions.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
         break;
 #elif defined(__ANDROID__)
     case Core::Frontend::WindowSystemType::Android:
+        require_ext(VK_KHR_SURFACE_EXTENSION_NAME);
+        require_ext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
         break;
 #else
     case Core::Frontend::WindowSystemType::X11:
+        require_ext(VK_KHR_SURFACE_EXTENSION_NAME);
+        require_ext(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
         break;
     case Core::Frontend::WindowSystemType::Wayland:
+        require_ext(VK_KHR_SURFACE_EXTENSION_NAME);
+        require_ext(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
         break;
 #endif
     default:
         LOG_ERROR(Render_Vulkan, "Presentation not supported on this platform");
-        break;
-    }
-    if (window_type != Core::Frontend::WindowSystemType::Headless) {
-        extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+        throw vk::Exception(VK_ERROR_INITIALIZATION_FAILED);
     }
 #ifdef __APPLE__
-    if (AreExtensionsSupported(dld, std::array{VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME})) {
+    if (HasInstanceExtension(available, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
     }
 #endif
     if (enable_validation &&
-        AreExtensionsSupported(dld, std::array{VK_EXT_DEBUG_UTILS_EXTENSION_NAME})) {
+        HasInstanceExtension(available, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     }
+
     return extensions;
 }
 
@@ -126,11 +134,14 @@ vk::Instance CreateInstance(const Common::DynamicLibrary& library, vk::InstanceD
         LOG_ERROR(Render_Vulkan, "Failed to load Vulkan function pointers");
         throw vk::Exception(VK_ERROR_INITIALIZATION_FAILED);
     }
-    const std::vector<const char*> extensions =
-        RequiredExtensions(dld, window_type, enable_validation);
-    if (!AreExtensionsSupported(dld, extensions)) {
-        throw vk::Exception(VK_ERROR_EXTENSION_NOT_PRESENT);
+    const std::optional<std::vector<VkExtensionProperties>> available =
+        vk::EnumerateInstanceExtensionProperties(dld);
+    if (!available) {
+        LOG_ERROR(Render_Vulkan, "Failed to query instance extension properties");
+        throw vk::Exception(VK_ERROR_INITIALIZATION_FAILED);
     }
+    std::vector<const char*> extensions =
+        BuildRequiredExtensions(*available, window_type, enable_validation);
     std::vector<const char*> layers = Layers(enable_validation);
     RemoveUnavailableLayers(dld, layers);
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -424,7 +425,18 @@ VkResult Free(VkDevice device, VkCommandPool handle, Span<VkCommandBuffer> buffe
 Instance Instance::Create(u32 version, Span<const char*> layers, Span<const char*> extensions,
                           InstanceDispatch& dispatch) {
 #ifdef __APPLE__
-    constexpr VkFlags ci_flags{VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR};
+    // Vulkan 1.3: ENUMERATE_PORTABILITY may only be set if VK_KHR_portability_enumeration
+    // is enabled. MoltenVK may not advertise the extension via incomplete enumeration lists.
+    bool enable_portability_enumeration = false;
+    for (const char* name : extensions) {
+        if (std::strcmp(name, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) {
+            enable_portability_enumeration = true;
+            break;
+        }
+    }
+    const VkFlags ci_flags = enable_portability_enumeration
+                                 ? VkFlags{VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR}
+                                 : VkFlags{};
 #else
     constexpr VkFlags ci_flags{};
 #endif
@@ -976,15 +988,20 @@ u32 AvailableVersion(const InstanceDispatch& dld) noexcept {
 
 std::optional<std::vector<VkExtensionProperties>> EnumerateInstanceExtensionProperties(
     const InstanceDispatch& dld) {
-    u32 num;
-    if (dld.vkEnumerateInstanceExtensionProperties(nullptr, &num, nullptr) != VK_SUCCESS) {
+    u32 count = 0;
+    if (dld.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr) != VK_SUCCESS) {
         return std::nullopt;
     }
-    std::vector<VkExtensionProperties> properties(num);
-    if (dld.vkEnumerateInstanceExtensionProperties(nullptr, &num, properties.data()) !=
-        VK_SUCCESS) {
-        return std::nullopt;
-    }
+    std::vector<VkExtensionProperties> properties;
+    VkResult result;
+    do {
+        properties.resize(count);
+        result = dld.vkEnumerateInstanceExtensionProperties(nullptr, &count, properties.data());
+        if (result != VK_SUCCESS && result != VK_INCOMPLETE) {
+            return std::nullopt;
+        }
+    } while (result == VK_INCOMPLETE);
+    properties.resize(count);
     return properties;
 }
 


### PR DESCRIPTION
## Summary
Presentation/VI compositing and macOS shutdown fixes for Bedrock on MoltenVK.

**Merge order:** after #235 (`split/moltenvk-xfb-core`). For a minimal diff review, see stacked PR theromis/emulator#1.

## Test plan
- [ ] Bedrock menu renders after Maybe later / Play offline
- [ ] Exit Citron without hang

Depends on #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transform-feedback emulation and transform-feedback byte-count-driven indirect draw support.
  * Improved Vulkan rendering compatibility with automatic vertex input remapping on stricter devices.
  * Enhanced presentation dispatch with a GUI-thread execution hook for smoother frame output.

* **Bug Fixes**
  * Strengthened shutdown/teardown and thread stopping to reduce hangs during GPU/Vulkan cleanup.
  * Improved mouse/wheel/touch event routing for embedded render surfaces and more reliable child-surface forwarding.
  * Hardened shader cache loading and improved handling for unmapped memory pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->