### PR TITLE
fix: resolve Android and (theoretically) macOS arm64 OpenSSL build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ CMAKE_DEPENDENT_OPTION(CITRON_USE_FASTER_LD "Check if a faster linker is availab
 CMAKE_DEPENDENT_OPTION(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF "APPLE" OFF)
 
 set(DEFAULT_ENABLE_OPENSSL ON)
-if (ANDROID OR WIN32 OR APPLE)
+if (WIN32 OR APPLE)
     set(DEFAULT_ENABLE_OPENSSL OFF)
 endif()
 option(ENABLE_OPENSSL "Enable OpenSSL backend for ISslConnection" ${DEFAULT_ENABLE_OPENSSL})

--- a/CMakeModules/openssl_build.cmake
+++ b/CMakeModules/openssl_build.cmake
@@ -227,26 +227,30 @@ message(STATUS "[OpenSSL] Building OpenSSL ${_OPENSSL_VERSION} from source (stat
 file(MAKE_DIRECTORY "${_OPENSSL_BUILD_DIR}")
 
 # AES-NI / assembly: OpenSSL's x86_64 assembly (aesni-x86_64.pl, sha256-x86_64.pl, etc.)
-# requires NASM as a host tool.  Both build scripts already install nasm, so we
-# enable assembly unconditionally here.  If NASM is not found we emit a clear
-# fatal error rather than silently falling back to the slow pure-C AES path.
+# requires NASM as a host tool.  NASM is only needed for x86_64 targets; arm64
+# targets (darwin64-arm64-cc on Apple Silicon, linux-aarch64 on native aarch64)
+# use OpenSSL's own Perl-generated ARM assembly and have no NASM dependency.
 #
 # Note: for the Linux→Windows cross-compile (Case 2), OpenSSL's mingw64 target
 # generates x86_64 NASM object files using the *host* nasm binary — not a
 # prefixed cross-tool — so the same nasm package used for FFmpeg works here too.
-find_program(_OPENSSL_NASM nasm)
-if (NOT _OPENSSL_NASM)
-    message(FATAL_ERROR
-        "[OpenSSL] NASM not found in PATH.  OpenSSL's AES-NI / SHA-NI assembly "
-        "optimisations require NASM.\n"
-        "  Ubuntu/Debian : sudo apt-get install nasm\n"
-        "  Fedora/RHEL   : sudo dnf install nasm\n"
-        "  openSUSE      : sudo zypper install nasm\n"
-        "  MSYS2         : pacman -S mingw-w64-clang-x86_64-nasm\n"
-        "Both build scripts (build-citron-linux.sh, build-clangtron-windows.sh) "
-        "already install nasm as part of their dependency setup.")
+if (_OPENSSL_TARGET STREQUAL "mingw64" OR
+    (NOT _OPENSSL_TARGET AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64"))
+    find_program(_OPENSSL_NASM nasm)
+    if (NOT _OPENSSL_NASM)
+        message(FATAL_ERROR
+            "[OpenSSL] NASM not found in PATH.  OpenSSL's AES-NI / SHA-NI assembly "
+            "optimisations require NASM.\n"
+            "  Ubuntu/Debian : sudo apt-get install nasm\n"
+            "  Fedora/RHEL   : sudo dnf install nasm\n"
+            "  openSUSE      : sudo zypper install nasm\n"
+            "  MSYS2         : pacman -S mingw-w64-clang-x86_64-nasm\n"
+            "  macOS (Intel) : brew install nasm\n"
+            "Both build scripts (build-citron-linux.sh, build-clangtron-windows.sh) "
+            "already install nasm as part of their dependency setup.")
+    endif()
+    message(STATUS "[OpenSSL] NASM found: ${_OPENSSL_NASM}")
 endif()
-message(STATUS "[OpenSSL] NASM found: ${_OPENSSL_NASM}")
 
 # Build Configure argument list
 set(_OPENSSL_CONFIGURE_ARGS

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -164,7 +164,7 @@ android {
                     "-DENABLE_QT=0", // Don't use QT
                     "-DENABLE_SDL2=0", // Don't use SDL
                     "-DENABLE_WEB_SERVICE=0", // Don't use telemetry
-                    "-DENABLE_OPENSSL=0", // Don't use OpenSSL
+                    "-DENABLE_OPENSSL=1",
                     "-DBUNDLE_SPEEX=ON",
                     "-DANDROID_ARM_NEON=true", // cryptopp requires Neon to work
                     "-DCITRON_USE_BUNDLED_VCPKG=ON",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,7 @@
     "openal-soft",
     {
       "name": "openssl",
-      "platform": "!linux & !osx & !android"
+      "platform": "!linux & !osx"
     },
     {
       "name": "opus",
@@ -56,7 +56,7 @@
       "dependencies": [
         {
           "name": "openssl",
-          "platform": "!linux & !osx & !android"
+          "platform": "!linux & !osx"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Based on work done by @Splaser

Fixes two build system gaps that prevent Citron from building on Android
and (probably) natively on macOS Apple Silicon. Both failures stem from the same
root cause: OpenSSL not being wired up correctly for non-x86_64 ARM
targets.

---

## Android (`arm64-v8a`)

### Problem

`ENABLE_OPENSSL` defaulted `OFF` on Android, so `find_package(OpenSSL)`
never ran and `OpenSSL::Crypto` was never defined as a CMake imported
target. `core` and `web_service` both link `OpenSSL::Crypto`
unconditionally, producing a CMake generator error repeated for `core`,
`audio_core`, `video_core`, `hid_core`, `input_common`, and `web_service`.

### Root cause

Three independent paths can create the `OpenSSL::Crypto` imported target,
and Android missed all three:

| Path | Why it fails on Android |
|------|------------------------|
| `openssl_build.cmake` via CPM | `CITRON_USE_CPM=OFF` on Android |
| vcpkg | `openssl` platform-excluded with `!android` in `vcpkg.json` |
| `find_package(OpenSSL)` directly | Only called when `ENABLE_OPENSSL=ON` |

### Fix

- Remove `!android` from the `openssl` platform expression in `vcpkg.json`
  (top-level dependency and `web-service` feature)
- Remove `ANDROID` from the `DEFAULT_ENABLE_OPENSSL=OFF` condition in
  `CMakeLists.txt` — Android now defaults `ON` alongside Linux
- Remove hardcoded `-DENABLE_OPENSSL=0` override in `build.gradle.kts`

With real OpenSSL provided by vcpkg, `ENABLE_OPENSSL=ON` triggers the
existing `find_package` path. OpenSSL's `android-arm64` build target uses
the ARMv8 Crypto Extension, so `aes_util.cpp`'s non-x86_64 EVP fallback
paths (ECB, CTR, and XTS via `EVP_aes_128_xts`) are hardware-accelerated
on all 64-bit Android devices.

---

## macOS Apple Silicon (`arm64`)

### Problem

`openssl_build.cmake` called `find_program(nasm)` with `FATAL_ERROR`
unconditionally for all platforms that go through the CPM path, including
macOS. On Apple Silicon, OpenSSL's `darwin64-arm64-cc` configure target
uses Perl-generated ARM assembly and has no NASM dependency whatsoever.
Native arm64 macOS builds failed at CMake configure time with a spurious
missing-NASM error regardless of whether NASM was installed.

### Fix

Gate the NASM check on targets that actually need it:

```cmake
if (_OPENSSL_TARGET STREQUAL "mingw64" OR
    (NOT _OPENSSL_TARGET AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64"))
    find_program(_OPENSSL_NASM nasm)
    ...
endif()
```

`_OPENSSL_TARGET` is `"mingw64"` for both Windows build cases. For the
Case 3 fallthrough (Linux and macOS native), the processor check
distinguishes x86_64 from arm64. Apple Silicon now configures cleanly
with no NASM dependency. macOS Intel still requires `brew install nasm`,
which is now documented in the error message.

---

## Files changed

| File | Repo path | Change |
|------|-----------|--------|
| `CMakeLists.txt` | root | Remove `ANDROID` from `DEFAULT_ENABLE_OPENSSL=OFF` |
| `CMakeModules/openssl_build.cmake` | `CMakeModules/` | Gate NASM check on x86_64 targets |
| `vcpkg.json` | root | Remove `!android` from openssl platform expression (×2) |
| `build.gradle.kts` | `src/android/app/` | `-DENABLE_OPENSSL=0` → `1` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build support by allowing OpenSSL to remain enabled instead of being forced off.
  * Relaxed native build dependency checks so missing NASM no longer blocks unsupported architectures.
  * Updated package platform rules so OpenSSL is available on Android where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->