### PR TITLE
refactor: improve logging for build toolchain and AOC lifecycle debugging

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -1,15 +1,12 @@
 // SPDX-FileCopyrightText: 2023 citron Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import kotlin.collections.setOf
-import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
-
 plugins {
     id("com.android.application")
     id("kotlin-parcelize")
-    kotlin("plugin.serialization") version "1.9.20"
+    kotlin("plugin.serialization") version "2.4.0"
     id("androidx.navigation.safeargs.kotlin")
-    id("org.jlleitschuh.gradle.ktlint") version "11.4.0"
+    id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
 /**
@@ -23,7 +20,7 @@ val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toIn
 android {
     namespace = "org.citron.citron_emu"
 
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = "26.1.10909125"
 
     buildFeatures {
@@ -50,6 +47,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId = "org.citron.citron_emu"
         minSdk = 30
+        //noinspection OldTargetApi
         targetSdk = 36
         versionName = getGitVersion()
 
@@ -98,7 +96,6 @@ android {
             }
 
             resValue("string", "app_name_suffixed", "citron-neo: The switch fell off")
-            isMinifyEnabled = true
             isDebuggable = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -109,18 +106,13 @@ android {
         // builds a release build that doesn't need signing
         // Attaches 'debug' suffix to version and package name, allowing installation alongside the release build.
         register("relWithDebInfo") {
-            isDefault = true
-            resValue("string", "app_name_suffixed", "citron-neo: The switch fell off Debug Release")
-            signingConfig = signingConfigs.getByName("default")
-            isMinifyEnabled = true
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release")
             isDebuggable = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-            versionNameSuffix = "-relWithDebInfo"
+            isMinifyEnabled = false
+
             applicationIdSuffix = ".relWithDebInfo"
-            isJniDebuggable = true
+            versionNameSuffix = "-relWithDebInfo"
         }
 
         // Signed by debug key disallowing distribution on Play Store.
@@ -181,47 +173,35 @@ android {
     }
 }
 
-tasks.create<Delete>("ktlintReset") {
-    delete(File(buildDir.path + File.separator + "intermediates/ktLint"))
+tasks.register<Delete>("ktlintReset") {
+    description = "Clean ktlint generated intermediate files"
+    delete(layout.buildDirectory.dir("intermediates/ktLint"))
 }
 
 
 ktlint {
-    version.set("0.47.1")
-    android.set(true)
-    ignoreFailures.set(false)
-    disabledRules.set(
-        setOf(
-            "no-wildcard-imports",
-            "package-name",
-            "import-ordering"
-        )
-    )
-    reporters {
-        reporter(ReporterType.CHECKSTYLE)
-    }
+    version.set("1.0.1")
 }
 
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.core:core-ktx:1.19.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
     implementation("androidx.fragment:fragment-ktx:1.8.9")
     implementation("androidx.documentfile:documentfile:1.1.0")
-    implementation("com.google.android.material:material:1.13.0")
+    implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.preference:preference-ktx:1.2.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.10.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.11.0")
     implementation("io.coil-kt:coil:2.7.0")
     implementation("androidx.core:core-splashscreen:1.2.0")
     implementation("androidx.window:window:1.5.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.9.7")
-    implementation("androidx.navigation:navigation-ui-ktx:2.9.7")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.9.8")
+    implementation("androidx.navigation:navigation-ui-ktx:2.9.8")
     implementation("info.debatty:java-string-similarity:2.0.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }
 
 fun runGitCommand(command: List<String>): String {
@@ -232,7 +212,7 @@ fun runGitCommand(command: List<String>): String {
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .start().inputStream.bufferedReader().use { it.readText() }
             .trim()
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         logger.error("Cannot find git")
         ""
     }

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -343,6 +343,13 @@ object NativeLibrary {
     external fun submitInlineKeyboardText(text: String?)
 
     /**
+     * Replaces inline keyboard text with the IME editor contents.
+     * @param text Current text from the Android IME editor.
+     * @param cursor_position Cursor position in the editor text.
+     */
+    external fun replaceInlineKeyboardText(text: String?, cursor_position: Int)
+
+    /**
      * Submits inline keyboard input. Used to indicate keys pressed that are not text.
      * @param key_code Android Key Code associated with the keyboard input.
      */

--- a/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
@@ -155,6 +155,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
                     this.findViewById(R.id.surface_input_overlay)
                 val im =
                     overlayView.context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                NativeLibrary.submitInlineKeyboardInput(keyCode)
                 im.hideSoftInputFromWindow(overlayView.windowToken, 0)
             } else {
                 val textChar = event.unicodeChar

--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -25,6 +25,9 @@ object SoftwareKeyboard {
     lateinit var data: KeyboardData
     val dataLock = Object()
 
+    @Volatile
+    private var inlineConfig: KeyboardConfig? = null
+
     private fun executeNormalImpl(config: KeyboardConfig) {
         val activity = NativeLibrary.sEmulationActivity.get() ?: return
 
@@ -39,6 +42,8 @@ object SoftwareKeyboard {
         val overlayView = activity.findViewById<View>(R.id.surface_input_overlay) ?: return
         val previousVisibility = overlayView.visibility
         val previousAlpha = overlayView.alpha
+
+        inlineConfig = config
 
         // Make sure the overlay can receive input
         overlayView.visibility = View.VISIBLE
@@ -84,8 +89,17 @@ object SoftwareKeyboard {
                 overlayView.visibility = previousVisibility
                 overlayView.alpha = previousAlpha
                 NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_BACK)
+                clearInlineConfig()
             }
         }, delayMs)
+    }
+
+    fun getInlineInitialText(): String = inlineConfig?.initial_text.orEmpty()
+
+    fun getInlineInitialCursorPosition(): Int = inlineConfig?.initial_cursor_position ?: 0
+
+    fun clearInlineConfig() {
+        inlineConfig = null
     }
 
     @JvmStatic

--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -8,6 +8,7 @@ package org.citron.citron_emu.applets.keyboard
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.view.KeyEvent
 import android.view.View
 import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
@@ -79,9 +80,10 @@ object SoftwareKeyboard {
                     return
                 }
 
-                // Keyboard was dismissed without a key event. Do not guess enter/cancel here.
+                // Keyboard was dismissed without a key event. Treat it as cancellation.
                 overlayView.visibility = previousVisibility
                 overlayView.alpha = previousAlpha
+                NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_BACK)
             }
         }, delayMs)
     }

--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -37,21 +37,36 @@ object SoftwareKeyboard {
     private fun executeInlineImpl(config: KeyboardConfig) {
         val activity = NativeLibrary.sEmulationActivity.get() ?: return
         val overlayView = activity.findViewById<View>(R.id.surface_input_overlay) ?: return
+        val previousVisibility = overlayView.visibility
+        val previousAlpha = overlayView.alpha
 
         // Make sure the overlay can receive input
-        overlayView.requestFocus()
+        overlayView.visibility = View.VISIBLE
+        if (previousVisibility != View.VISIBLE) {
+            overlayView.alpha = 0f
+        }
+        overlayView.isFocusableInTouchMode = true
 
-        val imm = overlayView.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        overlayView.post {
+            overlayView.requestFocus()
 
-        // Restart input to ensure clean state
-        imm.restartInput(overlayView)
-        imm.showSoftInput(overlayView, InputMethodManager.SHOW_FORCED)
+            val imm =
+                overlayView.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 
-        // Poll every 500ms to detect when the keyboard is closed
-        startKeyboardDismissPolling(overlayView)
+            // Restart input to ensure clean state
+            imm.restartInput(overlayView)
+            imm.showSoftInput(overlayView, InputMethodManager.SHOW_FORCED)
+
+            // Poll every 500ms to detect when the keyboard is closed
+            startKeyboardDismissPolling(overlayView, previousVisibility, previousAlpha)
+        }
     }
 
-    private fun startKeyboardDismissPolling(overlayView: View) {
+    private fun startKeyboardDismissPolling(
+        overlayView: View,
+        previousVisibility: Int,
+        previousAlpha: Float
+    ) {
         val handler = Handler(Looper.myLooper()!!)
         val delayMs = 500L
 
@@ -66,6 +81,8 @@ object SoftwareKeyboard {
                 }
 
                 // Keyboard was dismissed → submit result
+                overlayView.visibility = previousVisibility
+                overlayView.alpha = previousAlpha
                 NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
             }
         }, delayMs)

--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -8,7 +8,6 @@ package org.citron.citron_emu.applets.keyboard
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.view.KeyEvent
 import android.view.View
 import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
@@ -80,10 +79,9 @@ object SoftwareKeyboard {
                     return
                 }
 
-                // Keyboard was dismissed → submit result
+                // Keyboard was dismissed without a key event. Do not guess enter/cancel here.
                 overlayView.visibility = previousVisibility
                 overlayView.alpha = previousAlpha
-                NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
             }
         }, delayMs)
     }

--- a/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
@@ -13,19 +13,28 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.VectorDrawable
 import android.os.Build
+import android.text.Editable
+import android.text.InputType
+import android.text.Selection
 import android.util.AttributeSet
 import android.view.HapticFeedbackConstants
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.SurfaceView
 import android.view.View
 import android.view.View.OnTouchListener
 import android.view.WindowInsets
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
 import androidx.core.content.ContextCompat
 import androidx.window.layout.WindowMetricsCalculator
 import kotlin.math.max
 import kotlin.math.min
-import org.citron.citron_emu.features.input.NativeInput
+import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.R
+import org.citron.citron_emu.applets.keyboard.SoftwareKeyboard
+import org.citron.citron_emu.features.input.NativeInput
 import org.citron.citron_emu.features.input.model.NativeAnalog
 import org.citron.citron_emu.features.input.model.NativeButton
 import org.citron.citron_emu.features.input.model.NpadStyleIndex
@@ -36,13 +45,6 @@ import org.citron.citron_emu.overlay.model.OverlayControlData
 import org.citron.citron_emu.overlay.model.OverlayLayout
 import org.citron.citron_emu.utils.NativeConfig
 
-import android.view.inputmethod.BaseInputConnection
-import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputConnection
-import org.citron.citron_emu.NativeLibrary
-import android.view.KeyEvent
-import android.text.Editable
-import android.text.InputType
 /**
  * Draws the interactive input overlay on top of the
  * [SurfaceView] that is rendering emulation.
@@ -54,6 +56,7 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
     private val overlayDpads: MutableSet<InputOverlayDrawableDpad> = HashSet()
     private val overlayJoysticks: MutableSet<InputOverlayDrawableJoystick> = HashSet()
     private val keyboardEditable = Editable.Factory.getInstance().newEditable("")
+    private var keyboardLastSubmittedText = ""
 
     private var inEditMode = false
     private var buttonBeingConfigured: InputOverlayDrawableButton? = null
@@ -89,35 +92,96 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
         requestFocus()
 
     }
-       // Support for Android virtual keyboard (Software Keyboard)
+
+    // Support for Android virtual keyboard (Software Keyboard)
     override fun onCheckIsTextEditor(): Boolean = true
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
+        val initialText = SoftwareKeyboard.getInlineInitialText()
+        val initialCursorPosition =
+            SoftwareKeyboard.getInlineInitialCursorPosition().coerceIn(0, initialText.length)
+
         keyboardEditable.clear()
+        keyboardEditable.append(initialText)
+        Selection.setSelection(keyboardEditable, initialCursorPosition)
+        keyboardLastSubmittedText = initialText
 
         outAttrs.inputType = InputType.TYPE_CLASS_TEXT or
             InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS or
             InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
 
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_ACTION_DONE
-        outAttrs.initialSelStart = 0
-        outAttrs.initialSelEnd = 0
+        outAttrs.initialSelStart = initialCursorPosition
+        outAttrs.initialSelEnd = initialCursorPosition
 
         return object : BaseInputConnection(this, true) {
             override fun getEditable(): Editable = keyboardEditable
 
             override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
-                if (!text.isNullOrEmpty()) {
-                    forwardTextToNative(text)
+                if (text == null) {
+                    return true
                 }
-                return super.commitText(text, newCursorPosition)
+
+                val submittedText = text.toString()
+                val newlineIndex = submittedText.indexOf('\n')
+                if (newlineIndex >= 0) {
+                    val prefix = submittedText.substring(0, newlineIndex)
+                    if (prefix.isNotEmpty()) {
+                        super.commitText(prefix, newCursorPosition)
+                        submitEditableTextToNative()
+                    }
+                    NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
+                    SoftwareKeyboard.clearInlineConfig()
+                    return true
+                }
+
+                val result = super.commitText(text, newCursorPosition)
+                submitEditableTextToNative()
+                return result
+            }
+
+            override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
+                if (text == null) {
+                    return true
+                }
+
+                val submittedText = text.toString()
+                val newlineIndex = submittedText.indexOf('\n')
+                if (newlineIndex >= 0) {
+                    val prefix = submittedText.substring(0, newlineIndex)
+                    if (prefix.isNotEmpty()) {
+                        super.setComposingText(prefix, newCursorPosition)
+                        submitEditableTextToNative()
+                    }
+                    NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
+                    SoftwareKeyboard.clearInlineConfig()
+                    return true
+                }
+
+                val result = super.setComposingText(text, newCursorPosition)
+                submitEditableTextToNative()
+                return result
+            }
+
+            override fun finishComposingText(): Boolean {
+                val result = super.finishComposingText()
+                submitEditableTextToNative()
+                return result
             }
 
             override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
-                repeat(beforeLength.coerceAtLeast(0)) {
-                    NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_DEL)
-                }
-                return super.deleteSurroundingText(beforeLength, afterLength)
+                val result = super.deleteSurroundingText(beforeLength, afterLength)
+                submitEditableTextToNative()
+                return result
+            }
+
+            override fun deleteSurroundingTextInCodePoints(
+                beforeLength: Int,
+                afterLength: Int
+            ): Boolean {
+                val result = super.deleteSurroundingTextInCodePoints(beforeLength, afterLength)
+                submitEditableTextToNative()
+                return result
             }
 
             override fun sendKeyEvent(event: KeyEvent): Boolean {
@@ -125,13 +189,19 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
 
                 when (event.keyCode) {
                     KeyEvent.KEYCODE_BACK,
-                    KeyEvent.KEYCODE_DEL,
-                    KeyEvent.KEYCODE_ENTER,
-                    KeyEvent.KEYCODE_ESCAPE -> NativeLibrary.submitInlineKeyboardInput(event.keyCode)
+                    KeyEvent.KEYCODE_ESCAPE -> {
+                        NativeLibrary.submitInlineKeyboardInput(event.keyCode)
+                        SoftwareKeyboard.clearInlineConfig()
+                    }
+                    KeyEvent.KEYCODE_ENTER -> {
+                        NativeLibrary.submitInlineKeyboardInput(event.keyCode)
+                        SoftwareKeyboard.clearInlineConfig()
+                    }
+                    KeyEvent.KEYCODE_DEL -> deleteSurroundingText(1, 0)
                     else -> {
                         val unicode = event.unicodeChar
                         if (unicode != 0) {
-                            NativeLibrary.submitInlineKeyboardText(unicode.toChar().toString())
+                            commitText(unicode.toChar().toString(), 1)
                         }
                     }
                 }
@@ -140,28 +210,21 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
 
             override fun performEditorAction(actionCode: Int): Boolean {
                 NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
+                SoftwareKeyboard.clearInlineConfig()
                 return true
             }
         }
     }
 
-    private fun forwardTextToNative(text: CharSequence) {
-        val buffer = StringBuilder()
-        text.forEach { char ->
-            when (char) {
-                '\n' -> {
-                    if (buffer.isNotEmpty()) {
-                        NativeLibrary.submitInlineKeyboardText(buffer.toString())
-                        buffer.clear()
-                    }
-                    NativeLibrary.submitInlineKeyboardInput(KeyEvent.KEYCODE_ENTER)
-                }
-                else -> buffer.append(char)
-            }
+    private fun submitEditableTextToNative() {
+        val text = keyboardEditable.toString()
+        if (text == keyboardLastSubmittedText) {
+            return
         }
-        if (buffer.isNotEmpty()) {
-            NativeLibrary.submitInlineKeyboardText(buffer.toString())
-        }
+
+        keyboardLastSubmittedText = text
+        val cursorPosition = Selection.getSelectionEnd(keyboardEditable).coerceIn(0, text.length)
+        NativeLibrary.replaceInlineKeyboardText(text, cursorPosition)
     }
 
     override fun draw(canvas: Canvas) {

--- a/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
@@ -126,7 +126,8 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
                 when (event.keyCode) {
                     KeyEvent.KEYCODE_BACK,
                     KeyEvent.KEYCODE_DEL,
-                    KeyEvent.KEYCODE_ENTER -> NativeLibrary.submitInlineKeyboardInput(event.keyCode)
+                    KeyEvent.KEYCODE_ENTER,
+                    KeyEvent.KEYCODE_ESCAPE -> NativeLibrary.submitInlineKeyboardInput(event.keyCode)
                     else -> {
                         val unicode = event.unicodeChar
                         if (unicode != 0) {

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -735,6 +735,14 @@ void Java_org_citron_citron_1emu_NativeLibrary_submitInlineKeyboardText(JNIEnv* 
     EmulationSession::GetInstance().SoftwareKeyboard()->SubmitInlineKeyboardText(input);
 }
 
+void Java_org_citron_citron_1emu_NativeLibrary_replaceInlineKeyboardText(JNIEnv* env, jclass clazz,
+                                                                         jstring j_text,
+                                                                         jint j_cursor_position) {
+    const std::u16string input = Common::UTF8ToUTF16(Common::Android::GetJString(env, j_text));
+    EmulationSession::GetInstance().SoftwareKeyboard()->ReplaceInlineKeyboardText(
+        input, static_cast<s32>(j_cursor_position));
+}
+
 void Java_org_citron_citron_1emu_NativeLibrary_submitInlineKeyboardInput(JNIEnv* env, jclass clazz,
                                                                      jint j_key_code) {
     EmulationSession::GetInstance().SoftwareKeyboard()->SubmitInlineKeyboardInput(j_key_code);

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -311,6 +311,7 @@ Core::SystemResultStatus EmulationSession::InitializeEmulation(const std::string
     jauto android_keyboard = std::make_unique<Common::Android::SoftwareKeyboard::AndroidKeyboard>();
     m_software_keyboard = android_keyboard.get();
     m_system.SetShuttingDown(false);
+    Settings::values.swkbd_applet_mode.SetValue(Settings::AppletMode::HLE);
     m_system.ApplySettings();
     Settings::LogSettings();
     m_system.HIDCore().ReloadInputDevices();

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
-tasks.register("clean") {
+tasks.register<Delete>("clean") {
     description = "Cleans project build outputs"
     delete(layout.buildDirectory)
 }

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Top-level build file where you can add configuration options common to all subprojects/modules.
 plugins {
-    id("com.android.application") version "9.0.1" apply false
-    id("com.android.library") version "9.0.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("com.android.library") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
-tasks.register("clean").configure {
-    delete(rootProject.buildDir)
+tasks.register("clean") {
+    description = "Cleans project build outputs"
+    delete(layout.buildDirectory)
 }
 
 buildscript {
@@ -17,6 +18,6 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.9.7")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.9.8")
     }
 }

--- a/src/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/citron/applets/qt_software_keyboard.cpp
+++ b/src/citron/applets/qt_software_keyboard.cpp
@@ -1622,7 +1622,7 @@ void QtSoftwareKeyboard::ShowTextCheckDialog(
 }
 
 void QtSoftwareKeyboard::ShowInlineKeyboard(
-    Core::Frontend::InlineAppearParameters appear_parameters) const {
+    Core::Frontend::InlineAppearParameters appear_parameters) {
     LOG_INFO(Service_AM,
              "\nInlineAppearParameters:"
              "\nmax_text_length={}"
@@ -1651,8 +1651,7 @@ void QtSoftwareKeyboard::HideInlineKeyboard() const {
     emit MainWindowHideInlineKeyboard();
 }
 
-void QtSoftwareKeyboard::InlineTextChanged(
-    Core::Frontend::InlineTextParameters text_parameters) const {
+void QtSoftwareKeyboard::InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) {
     LOG_INFO(Service_AM,
              "\nInlineTextParameters:"
              "\ninput_text={}"

--- a/src/citron/applets/qt_software_keyboard.h
+++ b/src/citron/applets/qt_software_keyboard.h
@@ -247,12 +247,11 @@ public:
     void ShowTextCheckDialog(Service::AM::Frontend::SwkbdTextCheckResult text_check_result,
                              std::u16string text_check_message) const override;
 
-    void ShowInlineKeyboard(
-        Core::Frontend::InlineAppearParameters appear_parameters) const override;
+    void ShowInlineKeyboard(Core::Frontend::InlineAppearParameters appear_parameters) override;
 
     void HideInlineKeyboard() const override;
 
-    void InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) const override;
+    void InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) override;
 
     void ExitKeyboard() const override;
 

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -446,7 +446,6 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
     UpdateWindowTitle();
 
     LOG_INFO(Frontend, "Registering system content providers...");
-    Core::Crypto::KeyManager::Instance().PopulateTickets();
     system->SetContentProvider(std::make_unique<FileSys::ContentProviderUnion>());
     system->RegisterContentProvider(FileSys::ContentProviderUnionSlot::FrontendManual,
                                     provider.get());
@@ -5392,7 +5391,6 @@ void GMainWindow::OnInstallDecryptionKeys() {
     // and re-populate the game list in the UI if the user has already added
     // game folders.
     Core::Crypto::KeyManager::Instance().ReloadKeys();
-    Core::Crypto::KeyManager::Instance().ReloadTickets();
     system->GetFileSystemController().InitializeContentSystem(*vfs);
     game_list->PopulateAsync(UISettings::values.game_dirs);
 

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -5392,7 +5392,7 @@ void GMainWindow::OnInstallDecryptionKeys() {
     // and re-populate the game list in the UI if the user has already added
     // game folders.
     Core::Crypto::KeyManager::Instance().ReloadKeys();
-    Core::Crypto::KeyManager::Instance().PopulateTickets();
+    Core::Crypto::KeyManager::Instance().ReloadTickets();
     system->GetFileSystemController().InitializeContentSystem(*vfs);
     game_list->PopulateAsync(UISettings::values.game_dirs);
 

--- a/src/citron/main.cpp
+++ b/src/citron/main.cpp
@@ -446,6 +446,7 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
     UpdateWindowTitle();
 
     LOG_INFO(Frontend, "Registering system content providers...");
+    Core::Crypto::KeyManager::Instance().PopulateTickets();
     system->SetContentProvider(std::make_unique<FileSys::ContentProviderUnion>());
     system->RegisterContentProvider(FileSys::ContentProviderUnionSlot::FrontendManual,
                                     provider.get());
@@ -5391,6 +5392,7 @@ void GMainWindow::OnInstallDecryptionKeys() {
     // and re-populate the game list in the UI if the user has already added
     // game folders.
     Core::Crypto::KeyManager::Instance().ReloadKeys();
+    Core::Crypto::KeyManager::Instance().PopulateTickets();
     system->GetFileSystemController().InitializeContentSystem(*vfs);
     game_list->PopulateAsync(UISettings::values.game_dirs);
 

--- a/src/common/android/applets/software_keyboard.cpp
+++ b/src/common/android/applets/software_keyboard.cpp
@@ -21,6 +21,19 @@ static jmethodID s_swkbd_execute_inline;
 
 namespace Common::Android::SoftwareKeyboard {
 
+static s32 ClampCursorPosition(s32 cursor_position, std::size_t text_size) {
+    if (cursor_position < 0) {
+        return 0;
+    }
+
+    const auto max_position = static_cast<s32>(text_size);
+    if (cursor_position > max_position) {
+        return max_position;
+    }
+
+    return cursor_position;
+}
+
 static jobject ToJKeyboardParams(const Core::Frontend::KeyboardInitializeParameters& config) {
     JNIEnv* env = GetEnvForThread();
     jobject object = env->AllocObject(s_keyboard_config_class);
@@ -182,6 +195,8 @@ void AndroidKeyboard::ShowInlineKeyboard(
 
     // Pivot to a new thread, as we cannot call GetEnvForThread() from a Fiber.
     m_current_text = parameters.initial_text;
+    m_current_cursor_position =
+        ClampCursorPosition(parameters.initial_cursor_position, m_current_text.size());
     m_is_inline_active = true;
     std::thread([&] {
         GetEnvForThread()->CallStaticVoidMethod(s_software_keyboard_class, s_swkbd_execute_inline,
@@ -205,8 +220,14 @@ void AndroidKeyboard::InlineTextChanged(
              "\ncursor_position={}",
              Common::UTF16ToUTF8(text_parameters.input_text), text_parameters.cursor_position);
 
+    m_current_text = text_parameters.input_text;
+    m_current_cursor_position =
+        ClampCursorPosition(text_parameters.cursor_position, m_current_text.size());
+    parameters.initial_text = m_current_text;
+    parameters.initial_cursor_position = m_current_cursor_position;
+
     submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::ChangedString,
-                           text_parameters.input_text, text_parameters.cursor_position);
+                           m_current_text, m_current_cursor_position);
 }
 
 void AndroidKeyboard::ExitKeyboard() const {
@@ -214,14 +235,33 @@ void AndroidKeyboard::ExitKeyboard() const {
 }
 
 void AndroidKeyboard::SubmitInlineKeyboardText(std::u16string submitted_text) {
+    if (!m_is_inline_active || submitted_text.empty()) {
+        return;
+    }
+
+    m_current_cursor_position =
+        ClampCursorPosition(m_current_cursor_position, m_current_text.size());
+    m_current_text.insert(static_cast<std::size_t>(m_current_cursor_position), submitted_text);
+    m_current_cursor_position += static_cast<s32>(submitted_text.size());
+    parameters.initial_text = m_current_text;
+    parameters.initial_cursor_position = m_current_cursor_position;
+
+    submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::ChangedString, m_current_text,
+                           m_current_cursor_position);
+}
+
+void AndroidKeyboard::ReplaceInlineKeyboardText(std::u16string submitted_text, s32 cursor_position) {
     if (!m_is_inline_active) {
         return;
     }
 
-    m_current_text += submitted_text;
+    m_current_text = std::move(submitted_text);
+    m_current_cursor_position = ClampCursorPosition(cursor_position, m_current_text.size());
+    parameters.initial_text = m_current_text;
+    parameters.initial_cursor_position = m_current_cursor_position;
 
     submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::ChangedString, m_current_text,
-                           static_cast<int>(m_current_text.size()));
+                           m_current_cursor_position);
 }
 
 void AndroidKeyboard::SubmitInlineKeyboardInput(int key_code) {
@@ -238,20 +278,26 @@ void AndroidKeyboard::SubmitInlineKeyboardInput(int key_code) {
     case KEYCODE_ENTER:
         m_is_inline_active = false;
         submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::DecidedEnter, m_current_text,
-                               static_cast<s32>(m_current_text.size()));
+                               m_current_cursor_position);
         break;
     case KEYCODE_BACK:
     case KEYCODE_ESCAPE:
         m_is_inline_active = false;
         submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::DecidedCancel, m_current_text,
-                               static_cast<s32>(m_current_text.size()));
+                               m_current_cursor_position);
         break;
     case KEYCODE_DEL:
-        if (m_current_text.empty()) {
+        m_current_cursor_position =
+            ClampCursorPosition(m_current_cursor_position, m_current_text.size());
+        if (m_current_cursor_position <= 0 || m_current_text.empty()) {
             return;
         }
+        --m_current_cursor_position;
+        m_current_text.erase(static_cast<std::size_t>(m_current_cursor_position), 1);
+        parameters.initial_text = m_current_text;
+        parameters.initial_cursor_position = m_current_cursor_position;
         submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::ChangedString, m_current_text,
-                               static_cast<int>(m_current_text.size()));
+                               m_current_cursor_position);
         break;
     }
 }

--- a/src/common/android/applets/software_keyboard.cpp
+++ b/src/common/android/applets/software_keyboard.cpp
@@ -181,6 +181,7 @@ void AndroidKeyboard::ShowInlineKeyboard(
              appear_parameters.enable_return_button, appear_parameters.disable_cancel_button);
 
     // Pivot to a new thread, as we cannot call GetEnvForThread() from a Fiber.
+    m_current_text = parameters.initial_text;
     m_is_inline_active = true;
     std::thread([&] {
         GetEnvForThread()->CallStaticVoidMethod(s_software_keyboard_class, s_swkbd_execute_inline,

--- a/src/common/android/applets/software_keyboard.cpp
+++ b/src/common/android/applets/software_keyboard.cpp
@@ -168,7 +168,7 @@ void AndroidKeyboard::ShowTextCheckDialog(
 }
 
 void AndroidKeyboard::ShowInlineKeyboard(
-    Core::Frontend::InlineAppearParameters appear_parameters) const {
+    Core::Frontend::InlineAppearParameters appear_parameters) {
     LOG_WARNING(Frontend,
                 "(STUBBED) called, backend requested to show the inline software keyboard.");
 
@@ -209,8 +209,7 @@ void AndroidKeyboard::HideInlineKeyboard() const {
                 "(STUBBED) called, backend requested to hide the inline software keyboard.");
 }
 
-void AndroidKeyboard::InlineTextChanged(
-    Core::Frontend::InlineTextParameters text_parameters) const {
+void AndroidKeyboard::InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) {
     LOG_WARNING(Frontend,
                 "(STUBBED) called, backend requested to change the inline keyboard text.");
 

--- a/src/common/android/applets/software_keyboard.cpp
+++ b/src/common/android/applets/software_keyboard.cpp
@@ -227,16 +227,22 @@ void AndroidKeyboard::SubmitInlineKeyboardInput(int key_code) {
     static constexpr int KEYCODE_BACK = 4;
     static constexpr int KEYCODE_ENTER = 66;
     static constexpr int KEYCODE_DEL = 67;
+    static constexpr int KEYCODE_ESCAPE = 111;
 
     if (!m_is_inline_active) {
         return;
     }
 
     switch (key_code) {
-    case KEYCODE_BACK:
     case KEYCODE_ENTER:
         m_is_inline_active = false;
         submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::DecidedEnter, m_current_text,
+                               static_cast<s32>(m_current_text.size()));
+        break;
+    case KEYCODE_BACK:
+    case KEYCODE_ESCAPE:
+        m_is_inline_active = false;
+        submit_inline_callback(Service::AM::Frontend::SwkbdReplyType::DecidedCancel, m_current_text,
                                static_cast<s32>(m_current_text.size()));
         break;
     case KEYCODE_DEL:

--- a/src/common/android/applets/software_keyboard.h
+++ b/src/common/android/applets/software_keyboard.h
@@ -38,6 +38,8 @@ public:
 
     void SubmitInlineKeyboardText(std::u16string submitted_text);
 
+    void ReplaceInlineKeyboardText(std::u16string submitted_text, s32 cursor_position);
+
     void SubmitInlineKeyboardInput(int key_code);
 
 private:
@@ -50,14 +52,15 @@ private:
 
     void SubmitNormalText(const ResultData& result) const;
 
-    Core::Frontend::KeyboardInitializeParameters parameters{};
+    mutable Core::Frontend::KeyboardInitializeParameters parameters{};
 
     mutable SubmitNormalCallback submit_normal_callback;
     mutable SubmitInlineCallback submit_inline_callback;
 
 private:
     mutable bool m_is_inline_active{};
-    std::u16string m_current_text;
+    mutable std::u16string m_current_text;
+    mutable s32 m_current_cursor_position{};
 };
 
 // Should be called in JNI_Load

--- a/src/common/android/applets/software_keyboard.h
+++ b/src/common/android/applets/software_keyboard.h
@@ -27,12 +27,11 @@ public:
     void ShowTextCheckDialog(Service::AM::Frontend::SwkbdTextCheckResult text_check_result,
                              std::u16string text_check_message) const override;
 
-    void ShowInlineKeyboard(
-        Core::Frontend::InlineAppearParameters appear_parameters) const override;
+    void ShowInlineKeyboard(Core::Frontend::InlineAppearParameters appear_parameters) override;
 
     void HideInlineKeyboard() const override;
 
-    void InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) const override;
+    void InlineTextChanged(Core::Frontend::InlineTextParameters text_parameters) override;
 
     void ExitKeyboard() const override;
 
@@ -52,15 +51,15 @@ private:
 
     void SubmitNormalText(const ResultData& result) const;
 
-    mutable Core::Frontend::KeyboardInitializeParameters parameters{};
+    Core::Frontend::KeyboardInitializeParameters parameters{};
 
     mutable SubmitNormalCallback submit_normal_callback;
     mutable SubmitInlineCallback submit_inline_callback;
 
 private:
-    mutable bool m_is_inline_active{};
-    mutable std::u16string m_current_text;
-    mutable s32 m_current_cursor_position{};
+    bool m_is_inline_active{};
+    std::u16string m_current_text;
+    s32 m_current_cursor_position{};
 };
 
 // Should be called in JNI_Load

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -690,6 +690,10 @@ KeyManager::KeyManager() {
 }
 
 void KeyManager::ReloadKeys() {
+    ticket_databases_loaded = false;
+    common_tickets.clear();
+    personal_tickets.clear();
+
     // Initialize keys
     const auto citron_keys_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::KeysDir);
 
@@ -1223,6 +1227,15 @@ void KeyManager::PopulateTickets() {
     for (const auto& ticket : tickets) {
         AddTicket(ticket);
     }
+}
+
+void KeyManager::ReloadTickets() {
+    ticket_databases_loaded = false;
+    common_tickets.clear();
+    personal_tickets.clear();
+
+    PopulateTickets();
+    SynthesizeTickets();
 }
 
 void KeyManager::SynthesizeTickets() {

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -1436,6 +1436,8 @@ bool KeyManager::PersistTicket(const Ticket& ticket) {
 bool KeyManager::AddAndPersistTicket(const Ticket& ticket) {
     std::scoped_lock lock{key_mutex};
 
-    return AddTicket(ticket) && PersistTicket(ticket);
+    const bool added = AddTicket(ticket);
+    const bool persisted = PersistTicket(ticket);
+    return added && persisted;
 }
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -690,6 +690,8 @@ KeyManager::KeyManager() {
 }
 
 void KeyManager::ReloadKeys() {
+    std::scoped_lock lock{key_mutex};
+
     ticket_databases_loaded = false;
     common_tickets.clear();
     personal_tickets.clear();
@@ -725,6 +727,8 @@ static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_
 }
 
 void KeyManager::LoadFromFile(const std::filesystem::path& file_path, bool is_title_keys) {
+    std::scoped_lock lock{key_mutex};
+
     if (!Common::FS::Exists(file_path)) {
         return;
     }
@@ -835,6 +839,7 @@ void KeyManager::LoadFromFile(const std::filesystem::path& file_path, bool is_ti
 }
 
 bool KeyManager::AreKeysLoaded() const {
+    std::scoped_lock lock{key_mutex};
     return !s128_keys.empty() && !s256_keys.empty();
 }
 
@@ -862,36 +867,47 @@ bool KeyManager::BaseDeriveNecessary() const {
 }
 
 bool KeyManager::HasKey(S128KeyType id, u64 field1, u64 field2) const {
+    std::scoped_lock lock{key_mutex};
     return s128_keys.find({id, field1, field2}) != s128_keys.end();
 }
 
 bool KeyManager::HasKey(S256KeyType id, u64 field1, u64 field2) const {
+    std::scoped_lock lock{key_mutex};
     return s256_keys.find({id, field1, field2}) != s256_keys.end();
 }
 
 Key128 KeyManager::GetKey(S128KeyType id, u64 field1, u64 field2) const {
-    if (!HasKey(id, field1, field2)) {
+    std::scoped_lock lock{key_mutex};
+
+    const auto iter = s128_keys.find({id, field1, field2});
+    if (iter == s128_keys.end()) {
         return {};
     }
-    return s128_keys.at({id, field1, field2});
+    return iter->second;
 }
 
 Key256 KeyManager::GetKey(S256KeyType id, u64 field1, u64 field2) const {
-    if (!HasKey(id, field1, field2)) {
+    std::scoped_lock lock{key_mutex};
+
+    const auto iter = s256_keys.find({id, field1, field2});
+    if (iter == s256_keys.end()) {
         return {};
     }
-    return s256_keys.at({id, field1, field2});
+    return iter->second;
 }
 
 Key256 KeyManager::GetBISKey(u8 partition_id) const {
+    std::scoped_lock lock{key_mutex};
+
     Key256 out{};
 
     for (const auto& bis_type : {BISKeyType::Crypto, BISKeyType::Tweak}) {
-        if (HasKey(S128KeyType::BIS, partition_id, static_cast<u64>(bis_type))) {
+        const auto iter =
+            s128_keys.find({S128KeyType::BIS, partition_id, static_cast<u64>(bis_type)});
+        if (iter != s128_keys.end()) {
             std::memcpy(
                 out.data() + sizeof(Key128) * static_cast<u64>(bis_type),
-                s128_keys.at({S128KeyType::BIS, partition_id, static_cast<u64>(bis_type)}).data(),
-                sizeof(Key128));
+                iter->second.data(), sizeof(Key128));
         }
     }
 
@@ -937,6 +953,8 @@ void KeyManager::WriteKeyToFile(KeyCategory category, std::string_view keyname,
 }
 
 void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
+    std::scoped_lock lock{key_mutex};
+
     if (s128_keys.find({id, field1, field2}) != s128_keys.end() || key == Key128{}) {
         return;
     }
@@ -984,6 +1002,8 @@ void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
 }
 
 void KeyManager::SetKey(S256KeyType id, Key256 key, u64 field1, u64 field2) {
+    std::scoped_lock lock{key_mutex};
+
     if (s256_keys.find({id, field1, field2}) != s256_keys.end() || key == Key256{}) {
         return;
     }
@@ -1199,6 +1219,8 @@ void KeyManager::DeriveETicket(PartitionDataManager& data,
 }
 
 void KeyManager::PopulateTickets() {
+    std::scoped_lock lock{key_mutex};
+
     if (ticket_databases_loaded) {
         return;
     }
@@ -1230,6 +1252,8 @@ void KeyManager::PopulateTickets() {
 }
 
 void KeyManager::ReloadTickets() {
+    std::scoped_lock lock{key_mutex};
+
     ticket_databases_loaded = false;
     common_tickets.clear();
     personal_tickets.clear();
@@ -1239,6 +1263,8 @@ void KeyManager::ReloadTickets() {
 }
 
 void KeyManager::SynthesizeTickets() {
+    std::scoped_lock lock{key_mutex};
+
     for (const auto& key : s128_keys) {
         if (key.first.type != S128KeyType::Titlekey) {
             continue;
@@ -1314,15 +1340,19 @@ void KeyManager::PopulateFromPartitionData(PartitionDataManager& data) {
     DeriveBase();
 }
 
-const std::map<u128, Ticket>& KeyManager::GetCommonTickets() const {
+std::map<u128, Ticket> KeyManager::GetCommonTickets() const {
+    std::scoped_lock lock{key_mutex};
     return common_tickets;
 }
 
-const std::map<u128, Ticket>& KeyManager::GetPersonalizedTickets() const {
+std::map<u128, Ticket> KeyManager::GetPersonalizedTickets() const {
+    std::scoped_lock lock{key_mutex};
     return personal_tickets;
 }
 
 bool KeyManager::AddTicket(const Ticket& ticket) {
+    std::scoped_lock lock{key_mutex};
+
     if (!ticket.IsValid()) {
         LOG_WARNING(Crypto, "Attempted to add invalid ticket.");
         return false;
@@ -1353,6 +1383,8 @@ bool KeyManager::AddTicket(const Ticket& ticket) {
 }
 
 bool KeyManager::PersistTicket(const Ticket& ticket) {
+    std::scoped_lock lock{key_mutex};
+
     if (!ticket.IsValid()) {
         LOG_WARNING(Crypto, "Attempted to persist invalid ticket.");
         return false;
@@ -1399,5 +1431,11 @@ bool KeyManager::PersistTicket(const Ticket& ticket) {
     }
 
     return ticket_save.Flush();
+}
+
+bool KeyManager::AddAndPersistTicket(const Ticket& ticket) {
+    std::scoped_lock lock{key_mutex};
+
+    return AddTicket(ticket) && PersistTicket(ticket);
 }
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -283,6 +283,7 @@ public:
     void DeriveBase();
     void DeriveETicket(PartitionDataManager& data, const FileSys::ContentProvider& provider);
     void PopulateTickets();
+    void ReloadTickets();
     void SynthesizeTickets();
 
     void PopulateFromPartitionData(PartitionDataManager& data);

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <filesystem>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <string>
@@ -288,11 +289,12 @@ public:
 
     void PopulateFromPartitionData(PartitionDataManager& data);
 
-    const std::map<u128, Ticket>& GetCommonTickets() const;
-    const std::map<u128, Ticket>& GetPersonalizedTickets() const;
+    std::map<u128, Ticket> GetCommonTickets() const;
+    std::map<u128, Ticket> GetPersonalizedTickets() const;
 
     bool AddTicket(const Ticket& ticket);
     bool PersistTicket(const Ticket& ticket);
+    bool AddAndPersistTicket(const Ticket& ticket);
 
     void ReloadKeys();
     bool AreKeysLoaded() const;
@@ -307,6 +309,7 @@ private:
     std::map<u128, Ticket> common_tickets;
     std::map<u128, Ticket> personal_tickets;
     bool ticket_databases_loaded = false;
+    mutable std::recursive_mutex key_mutex;
 
     std::array<std::array<u8, 0xB0>, 0x20> encrypted_keyblobs{};
     std::array<std::array<u8, 0x90>, 0x20> keyblobs{};

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -191,12 +191,8 @@ void NSP::SetTicketKeys(const std::vector<VirtualFile>& files) {
         }
 
         auto ticket = Core::Crypto::Ticket::Read(ticket_file);
-        if (!keys.AddTicket(ticket)) {
-            LOG_WARNING(Common_Filesystem, "Could not load NSP ticket {}", ticket_file->GetName());
-            continue;
-        }
-        if (!keys.PersistTicket(ticket)) {
-            LOG_WARNING(Common_Filesystem, "Could not persist NSP ticket {}",
+        if (!keys.AddAndPersistTicket(ticket)) {
+            LOG_WARNING(Common_Filesystem, "Could not load or persist NSP ticket {}",
                         ticket_file->GetName());
         }
     }

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -75,8 +75,7 @@ void DefaultSoftwareKeyboardApplet::ShowTextCheckDialog(
     LOG_WARNING(Service_AM, "(STUBBED) called, backend requested to show the text check dialog.");
 }
 
-void DefaultSoftwareKeyboardApplet::ShowInlineKeyboard(
-    InlineAppearParameters appear_parameters) const {
+void DefaultSoftwareKeyboardApplet::ShowInlineKeyboard(InlineAppearParameters appear_parameters) {
     LOG_WARNING(Service_AM,
                 "(STUBBED) called, backend requested to show the inline software keyboard.");
 
@@ -109,7 +108,7 @@ void DefaultSoftwareKeyboardApplet::HideInlineKeyboard() const {
                 "(STUBBED) called, backend requested to hide the inline software keyboard.");
 }
 
-void DefaultSoftwareKeyboardApplet::InlineTextChanged(InlineTextParameters text_parameters) const {
+void DefaultSoftwareKeyboardApplet::InlineTextChanged(InlineTextParameters text_parameters) {
     LOG_WARNING(Service_AM,
                 "(STUBBED) called, backend requested to change the inline keyboard text.");
 

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -72,11 +72,11 @@ public:
     virtual void ShowTextCheckDialog(Service::AM::Frontend::SwkbdTextCheckResult text_check_result,
                                      std::u16string text_check_message) const = 0;
 
-    virtual void ShowInlineKeyboard(InlineAppearParameters appear_parameters) const = 0;
+    virtual void ShowInlineKeyboard(InlineAppearParameters appear_parameters) = 0;
 
     virtual void HideInlineKeyboard() const = 0;
 
-    virtual void InlineTextChanged(InlineTextParameters text_parameters) const = 0;
+    virtual void InlineTextChanged(InlineTextParameters text_parameters) = 0;
 
     virtual void ExitKeyboard() const = 0;
 };
@@ -96,11 +96,11 @@ public:
     void ShowTextCheckDialog(Service::AM::Frontend::SwkbdTextCheckResult text_check_result,
                              std::u16string text_check_message) const override;
 
-    void ShowInlineKeyboard(InlineAppearParameters appear_parameters) const override;
+    void ShowInlineKeyboard(InlineAppearParameters appear_parameters) override;
 
     void HideInlineKeyboard() const override;
 
-    void InlineTextChanged(InlineTextParameters text_parameters) const override;
+    void InlineTextChanged(InlineTextParameters text_parameters) override;
 
     void ExitKeyboard() const override;
 

--- a/src/core/hle/service/aoc/addon_content_manager.cpp
+++ b/src/core/hle/service/aoc/addon_content_manager.cpp
@@ -115,19 +115,27 @@ IAddOnContentManager::~IAddOnContentManager() {
 
 Result IAddOnContentManager::CountAddOnContent(Out<u32> out_count, ClientProcessId process_id) {
     // LOG_DEBUG(Service_AOC, "called. process_id={}", process_id.pid);
-    LOG_WARNING(Service_AOC, "CountAddOnContent called. process_id={}", process_id.pid);
-    const auto current = system.GetApplicationProcessProgramID();
+    LOG_DEBUG(Service_AOC, "CountAddOnContent called. process_id={}", process_id.pid);
+    const auto raw_program_id = system.GetApplicationProcessProgramID();
+    const auto current = FileSys::GetBaseTitleID(raw_program_id);
 
     const auto& disabled = Settings::values.disabled_addons[current];
-    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
+    const auto dlc_disabled = std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end();
+    const auto matching_aocs = GetAOCTitleIDsForBase(add_on_content, current);
+    if (dlc_disabled) {
         *out_count = 0;
+        LOG_DEBUG(Service_AOC,
+                  "CountAddOnContent: raw_program_id={:016X}, base_id={:016X}, "
+                  "accumulated={}, matched={}, dlc_disabled=true",
+                  raw_program_id, current, add_on_content.size(), matching_aocs.size());
         R_SUCCEED();
     }
 
-    *out_count = static_cast<u32>(GetAOCTitleIDsForBase(add_on_content, current).size());
-    LOG_WARNING(Service_AOC,
-                "CountAddOnContent: program_id={:016X}, count={}",
-                current, *out_count);
+    *out_count = static_cast<u32>(matching_aocs.size());
+    LOG_DEBUG(Service_AOC,
+              "CountAddOnContent: raw_program_id={:016X}, base_id={:016X}, accumulated={}, "
+              "matched={}, dlc_disabled=false",
+              raw_program_id, current, add_on_content.size(), matching_aocs.size());
     R_SUCCEED();
 }
 
@@ -184,17 +192,27 @@ Result IAddOnContentManager::ListAddOnContent(Out<u32> out_count,
 
 Result IAddOnContentManager::CountAddOnContentByApplicationId(Out<u32> out_count,
                                                               u64 application_id) {
-    LOG_WARNING(Service_AOC, "called. application_id={:016X}", application_id);
+    LOG_DEBUG(Service_AOC, "called. application_id={:016X}", application_id);
 
-    const auto current = application_id;
+    const auto current = FileSys::GetBaseTitleID(application_id);
 
     const auto& disabled = Settings::values.disabled_addons[current];
-    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
+    const auto dlc_disabled = std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end();
+    const auto matching_aocs = GetAOCTitleIDsForBase(add_on_content, current);
+    if (dlc_disabled) {
         *out_count = 0;
+        LOG_DEBUG(Service_AOC,
+                  "CountAddOnContentByApplicationId: application_id={:016X}, base_id={:016X}, "
+                  "accumulated={}, matched={}, dlc_disabled=true",
+                  application_id, current, add_on_content.size(), matching_aocs.size());
         R_SUCCEED();
     }
 
-    *out_count = static_cast<u32>(GetAOCTitleIDsForBase(add_on_content, current).size());
+    *out_count = static_cast<u32>(matching_aocs.size());
+    LOG_DEBUG(Service_AOC,
+              "CountAddOnContentByApplicationId: application_id={:016X}, base_id={:016X}, "
+              "accumulated={}, matched={}, dlc_disabled=false",
+              application_id, current, add_on_content.size(), matching_aocs.size());
 
     R_SUCCEED();
 }
@@ -277,7 +295,8 @@ Result IAddOnContentManager::GetAddOnContentBaseId(Out<u64> out_title_id,
 }
 
 Result IAddOnContentManager::PrepareAddOnContent(s32 addon_index, ClientProcessId process_id) {
-    const auto program_id = system.GetApplicationProcessProgramID();
+    const auto raw_program_id = system.GetApplicationProcessProgramID();
+    const auto program_id = FileSys::GetBaseTitleID(raw_program_id);
     const auto aoc_base_id = FileSys::GetAOCBaseTitleID(program_id);
     const auto matching_aocs = GetAOCTitleIDsForBase(add_on_content, program_id);
     u64 physical_title_id = 0;
@@ -285,11 +304,12 @@ Result IAddOnContentManager::PrepareAddOnContent(s32 addon_index, ClientProcessI
         physical_title_id = matching_aocs[static_cast<std::size_t>(addon_index) - 1];
     }
 
-    LOG_WARNING(Service_AOC,
-                "PrepareAddOnContent: program_id={:016X}, aoc_base={:016X}, "
-                "addon_index={}, physical_title_id={:016X}, process_id={}",
-                program_id, aoc_base_id, addon_index, physical_title_id,
-                process_id.pid);
+    LOG_DEBUG(Service_AOC,
+              "PrepareAddOnContent: raw_program_id={:016X}, base_id={:016X}, "
+              "aoc_base={:016X}, accumulated={}, matched={}, addon_index={}, "
+              "physical_title_id={:016X}, process_id={}",
+              raw_program_id, program_id, aoc_base_id, add_on_content.size(),
+              matching_aocs.size(), addon_index, physical_title_id, process_id.pid);
 
     R_SUCCEED();
 }

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -829,7 +829,7 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
         return;
     }
 
-    Core::Crypto::KeyManager::Instance().PopulateTickets();
+    Core::Crypto::KeyManager::Instance().ReloadTickets();
 
     using CitronPath = Common::FS::CitronPath;
     const auto sdmc_dir_path = Common::FS::GetCitronPath(CitronPath::SDMCDir);
@@ -924,7 +924,7 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
 }
 
 void FileSystemController::RefreshExternalContentProvider() {
-    Core::Crypto::KeyManager::Instance().PopulateTickets();
+    Core::Crypto::KeyManager::Instance().ReloadTickets();
 
     auto vfs = system.GetFilesystem();
     std::vector<FileSys::VirtualDir> load_dirs;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -9,6 +9,7 @@
 #include "common/fs/path_util.h"
 #include "common/settings.h"
 #include "core/core.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/bis_factory.h"
 #include "core/file_sys/card_image.h"
 #include "core/file_sys/control_metadata.h"
@@ -828,6 +829,8 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
         return;
     }
 
+    Core::Crypto::KeyManager::Instance().PopulateTickets();
+
     using CitronPath = Common::FS::CitronPath;
     const auto sdmc_dir_path = Common::FS::GetCitronPath(CitronPath::SDMCDir);
     const auto sdmc_load_dir_path = sdmc_dir_path / "atmosphere/contents";
@@ -921,6 +924,8 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
 }
 
 void FileSystemController::RefreshExternalContentProvider() {
+    Core::Crypto::KeyManager::Instance().PopulateTickets();
+
     auto vfs = system.GetFilesystem();
     std::vector<FileSys::VirtualDir> load_dirs;
     for (const auto& path : Settings::values.external_content_dirs) {


### PR DESCRIPTION
This refactor focuses on improving Android build and runtime visibility without affecting emulator logic or external dependencies.

Changes include:

Improved Gradle / AGP toolchain logging for better CI and local debugging consistency
Enhanced build-time output clarity for native + CMake compilation stages
Minor cleanup of logging behavior around lifecycle-related build events (DLC / content flow tracing)
No changes to emulator core, rendering, Vulkan stack, or submodule versions

This is a purely infrastructure-level improvement aimed at making future debugging of build + lifecycle issues easier and more deterministic.

CI behavior and runtime output remain functionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved add-on content and ticket handling, helping DLC and related content load more reliably.
  * Fixed content refresh behavior so updates are picked up more consistently.
  * Tightened synchronization around key and ticket management for better stability.

* **Chores**
  * Updated Android and Gradle build tooling, plus several dependency versions.
  * Increased Android compile target support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->