### PR TITLE
feat(vk): quicker compute identities for MSAA shaders

### DIFF
--- a/src/video_core/host_shaders/block_linear_unswizzle_2d.comp
+++ b/src/video_core/host_shaders/block_linear_unswizzle_2d.comp
@@ -3,20 +3,17 @@
 
 #version 430
 
+#extension GL_ARB_gpu_shader_int64 : enable
 #ifdef VULKAN
-
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #define HAS_EXTENDED_TYPES 1
 #define BEGIN_PUSH_CONSTANTS layout(push_constant) uniform PushConstants {
 #define END_PUSH_CONSTANTS };
 #define UNIFORM(n)
-#define BINDING_SWIZZLE_BUFFER 0
-#define BINDING_INPUT_BUFFER 1
-#define BINDING_OUTPUT_IMAGE 2
-
+#define BINDING_INPUT_BUFFER 0
+#define BINDING_OUTPUT_IMAGE 1
 #else // ^^^ Vulkan ^^^ // vvv OpenGL vvv
-
 #extension GL_NV_gpu_shader5 : enable
 #ifdef GL_NV_gpu_shader5
 #define HAS_EXTENDED_TYPES 1
@@ -26,10 +23,8 @@
 #define BEGIN_PUSH_CONSTANTS
 #define END_PUSH_CONSTANTS
 #define UNIFORM(n) layout (location = n) uniform
-#define BINDING_SWIZZLE_BUFFER 0
-#define BINDING_INPUT_BUFFER 1
+#define BINDING_INPUT_BUFFER 0
 #define BINDING_OUTPUT_IMAGE 0
-
 #endif
 
 BEGIN_PUSH_CONSTANTS
@@ -42,10 +37,6 @@ UNIFORM(5) uint x_shift;
 UNIFORM(6) uint block_height;
 UNIFORM(7) uint block_height_mask;
 END_PUSH_CONSTANTS
-
-layout(binding = BINDING_SWIZZLE_BUFFER, std430) readonly buffer SwizzleTable {
-    uint swizzle_table[];
-};
 
 #if HAS_EXTENDED_TYPES
 layout(binding = BINDING_INPUT_BUFFER, std430) buffer InputBufferU8 { uint8_t u8data[]; };
@@ -71,9 +62,16 @@ const uint GOB_SIZE_SHIFT = GOB_SIZE_X_SHIFT + GOB_SIZE_Y_SHIFT + GOB_SIZE_Z_SHI
 
 const uvec2 SWIZZLE_MASK = uvec2(GOB_SIZE_X - 1, GOB_SIZE_Y - 1);
 
+uint SwizzleTable(uint pos) {
+    uint n = pos >> 4;
+    uint c0 = (n << 3) & 0x10;
+    uint c1 = (uint(uint64_t(0x7575646431312020ull) >> uint64_t((n & 0xf) << 2)) + ((n & 0x10) >> 1)) & 0xf;
+    return ((c0 | c1) << 4) | (pos & 0xf);
+}
+
 uint SwizzleOffset(uvec2 pos) {
     pos = pos & SWIZZLE_MASK;
-    return swizzle_table[pos.y * 64 + pos.x];
+    return SwizzleTable(pos.y * 64 + pos.x);
 }
 
 uvec4 ReadTexel(uint offset) {

--- a/src/video_core/host_shaders/block_linear_unswizzle_2d.comp
+++ b/src/video_core/host_shaders/block_linear_unswizzle_2d.comp
@@ -65,7 +65,7 @@ const uvec2 SWIZZLE_MASK = uvec2(GOB_SIZE_X - 1, GOB_SIZE_Y - 1);
 uint SwizzleTable(uint pos) {
     uint n = pos >> 4;
     uint c0 = (n << 3) & 0x10;
-    uint c1 = (uint(uint64_t(0x7575646431312020ull) >> uint64_t((n & 0xf) << 2)) + ((n & 0x10) >> 1)) & 0xf;
+    uint c1 = (uint(uint64_t(0x7575646431312020ul) >> uint64_t((n & 0xf) << 2)) + ((n & 0x10) >> 1)) & 0xf;
     return ((c0 | c1) << 4) | (pos & 0xf);
 }
 

--- a/src/video_core/host_shaders/block_linear_unswizzle_3d.comp
+++ b/src/video_core/host_shaders/block_linear_unswizzle_3d.comp
@@ -3,20 +3,17 @@
 
 #version 430
 
+#extension GL_ARB_gpu_shader_int64 : enable
 #ifdef VULKAN
-
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #define HAS_EXTENDED_TYPES 1
 #define BEGIN_PUSH_CONSTANTS layout(push_constant) uniform PushConstants {
 #define END_PUSH_CONSTANTS };
 #define UNIFORM(n)
-#define BINDING_SWIZZLE_BUFFER 0
-#define BINDING_INPUT_BUFFER 1
-#define BINDING_OUTPUT_IMAGE 2
-
+#define BINDING_INPUT_BUFFER 0
+#define BINDING_OUTPUT_IMAGE 1
 #else // ^^^ Vulkan ^^^ // vvv OpenGL vvv
-
 #extension GL_NV_gpu_shader5 : enable
 #ifdef GL_NV_gpu_shader5
 #define HAS_EXTENDED_TYPES 1
@@ -26,10 +23,8 @@
 #define BEGIN_PUSH_CONSTANTS
 #define END_PUSH_CONSTANTS
 #define UNIFORM(n) layout (location = n) uniform
-#define BINDING_SWIZZLE_BUFFER 0
-#define BINDING_INPUT_BUFFER 1
+#define BINDING_INPUT_BUFFER 0
 #define BINDING_OUTPUT_IMAGE 0
-
 #endif
 
 BEGIN_PUSH_CONSTANTS
@@ -44,10 +39,6 @@ UNIFORM(7) uint block_height_mask;
 UNIFORM(8) uint block_depth;
 UNIFORM(9) uint block_depth_mask;
 END_PUSH_CONSTANTS
-
-layout(binding = BINDING_SWIZZLE_BUFFER, std430) readonly buffer SwizzleTable {
-    uint swizzle_table[];
-};
 
 #if HAS_EXTENDED_TYPES
 layout(binding = BINDING_INPUT_BUFFER, std430) buffer InputBufferU8 { uint8_t u8data[]; };
@@ -75,7 +66,7 @@ const uvec2 SWIZZLE_MASK = uvec2(GOB_SIZE_X - 1, GOB_SIZE_Y - 1);
 
 uint SwizzleOffset(uvec2 pos) {
     pos = pos & SWIZZLE_MASK;
-    return swizzle_table[pos.y * 64 + pos.x];
+    return SwizzleTable(pos.y * 64 + pos.x);
 }
 
 uvec4 ReadTexel(uint offset) {

--- a/src/video_core/host_shaders/block_linear_unswizzle_3d.comp
+++ b/src/video_core/host_shaders/block_linear_unswizzle_3d.comp
@@ -64,6 +64,13 @@ const uint GOB_SIZE_SHIFT = GOB_SIZE_X_SHIFT + GOB_SIZE_Y_SHIFT + GOB_SIZE_Z_SHI
 
 const uvec2 SWIZZLE_MASK = uvec2(GOB_SIZE_X - 1, GOB_SIZE_Y - 1);
 
+uint SwizzleTable(uint pos) {
+    uint n = pos >> 4;
+    uint c0 = (n << 3) & 0x10;
+    uint c1 = (uint(uint64_t(0x7575646431312020ull) >> uint64_t((n & 0xf) << 2)) + ((n & 0x10) >> 1)) & 0xf;
+    return ((c0 | c1) << 4) | (pos & 0xf);
+}
+
 uint SwizzleOffset(uvec2 pos) {
     pos = pos & SWIZZLE_MASK;
     return SwizzleTable(pos.y * 64 + pos.x);

--- a/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
+++ b/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
@@ -20,7 +20,7 @@ void main() {
     const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
         const vec4 pixel = imageLoad(msaa_in, coords, curr_sample);
-        const ivec3 dest_coords = ivec3(scale.xy, 1) * coords + (ivec3(cur_sample, cur_sample / 2, 0) & 1);
+        const ivec3 dest_coords = ivec3(scale.xy, 1) * coords + (ivec3(curr_sample, curr_sample / 2, 0) & 1);
         if (!any(greaterThanEqual(dest_coords, imageSize(output_img)))) {
             imageStore(output_img, dest_coords, pixel);
         }

--- a/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
+++ b/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
@@ -20,14 +20,9 @@ void main() {
     const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
         const vec4 pixel = imageLoad(msaa_in, coords, curr_sample);
-
-        const int single_sample_x = scale.x * coords.x + (curr_sample & 1);
-        const int single_sample_y = scale.y * coords.y + ((curr_sample / 2) & 1);
-        const ivec3 dest_coords = ivec3(single_sample_x, single_sample_y, coords.z);
-
-        if (any(greaterThanEqual(dest_coords, imageSize(output_img)))) {
-            continue;
+        const ivec3 dest_coords = ivec3(scale.xy, 1) * coords + (ivec3(cur_sample, cur_sample / 2, 0) & 1);
+        if (!any(greaterThanEqual(dest_coords, imageSize(output_img)))) {
+            imageStore(output_img, dest_coords, pixel);
         }
-        imageStore(output_img, dest_coords, pixel);
     }
 }

--- a/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
+++ b/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
@@ -19,14 +19,10 @@ void main() {
     const ivec3 out_size = imageSize(img_in);
     const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
-        const int single_sample_x = scale.x * coords.x + (curr_sample & 1);
-        const int single_sample_y = scale.y * coords.y + ((curr_sample / 2) & 1);
-        const ivec3 single_coords = ivec3(single_sample_x, single_sample_y, coords.z);
-
-        if (any(greaterThanEqual(single_coords, imageSize(img_in)))) {
-            continue;
+        const ivec3 single_coords = ivec3(scale.xy, 1) * coords + (ivec3(cur_sample, cur_sample / 2, 0) & 1);
+        if (!any(greaterThanEqual(single_coords, imageSize(img_in)))) {
+            const vec4 pixel = imageLoad(img_in, single_coords);
+            imageStore(output_msaa, coords, curr_sample, pixel);
         }
-        const vec4 pixel = imageLoad(img_in, single_coords);
-        imageStore(output_msaa, coords, curr_sample, pixel);
     }
 }

--- a/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
+++ b/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
@@ -19,7 +19,7 @@ void main() {
     const ivec3 out_size = imageSize(img_in);
     const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
-        const ivec3 single_coords = ivec3(scale.xy, 1) * coords + (ivec3(cur_sample, cur_sample / 2, 0) & 1);
+        const ivec3 single_coords = ivec3(scale.xy, 1) * coords + (ivec3(curr_sample, curr_sample / 2, 0) & 1);
         if (!any(greaterThanEqual(single_coords, imageSize(img_in)))) {
             const vec4 pixel = imageLoad(img_in, single_coords);
             imageStore(output_msaa, coords, curr_sample, pixel);


### PR DESCRIPTION
same result
different SPIRV code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image conversion behavior between MSAA and non-MSAA formats, with updated coordinate handling and bounds checks for more reliable results.
  * Updated texture unswizzling logic for 2D and 3D video paths to use a new procedural mapping approach, improving compatibility across graphics backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->