### PR TITLE
fix(game_list): use CitronPath for game list metadata storage

### DIFF
--- a/src/citron/game_list.cpp
+++ b/src/citron/game_list.cpp
@@ -53,7 +53,6 @@
 #include <QSequentialAnimationGroup>
 #include <QSpacerItem>
 #include <QStackedWidget>
-#include <QStandardPaths>
 #include <QStyle>
 #include <QStyleOption>
 #include <QThreadPool>
@@ -4483,8 +4482,9 @@ void GameList::SaveGameListIndex() {
         root_array.append(folder_obj);
     }
 
-    const QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) +
-                         QStringLiteral("/game_list_metadata.json");
+    const auto cache_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::CacheDir) / "game_list";
+    const QString path =
+        QString::fromStdString(Common::FS::PathToUTF8String(cache_dir / "game_list_metadata.json"));
     QDir().mkpath(QFileInfo(path).absolutePath());
     QFile file(path);
     if (file.open(QIODevice::WriteOnly)) {
@@ -4493,8 +4493,9 @@ void GameList::SaveGameListIndex() {
 }
 
 void GameList::LoadGameListIndex() {
-    const QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) +
-                         QStringLiteral("/game_list_metadata.json");
+    const auto cache_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::CacheDir) / "game_list";
+    const QString path =
+        QString::fromStdString(Common::FS::PathToUTF8String(cache_dir / "game_list_metadata.json"));
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly))
         return;


### PR DESCRIPTION
Replace QStandardPaths::AppDataLocation with Common::FS::GetCitronPath(CitronPath::CacheDir) when resolving the path for game_list_metadata.json.

Previously, SaveGameListIndex and LoadGameListIndex each independently constructed a path using Qt's standard paths, which could diverge from the path used by the rest of the application's filesystem layer — especially on platforms where the two APIs resolve to different locations. This meant the metadata file could be written to one location and read from another, or simply land outside the expected Citron cache directory.

Changes:

Remove QStandardPaths usage from game_list.cpp (and drop the now-unused QStandardPaths include)
Both save and load now resolve cache_dir via Common::FS::GetCitronPath(CitronPath::CacheDir) / "game_list" and convert it to a QString via PathToUTF8String
Path construction is consistent and goes through the single canonical filesystem abstraction used elsewhere in the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated where game list metadata is stored so it now uses the app’s cache area, helping ensure the list is saved and loaded more consistently across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->