### PR TITLE
Apply two low-risk upstream fixes from Eden Nightly v1783019526.a9c4c8aefd:fix: include <cstring> in dynamic_library.cpp and handle null image v…

### DIFF
--- a/src/common/dynamic_library.cpp
+++ b/src/common/dynamic_library.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <string>
+#include <cstring>
 #include <utility>
 
 #include <fmt/format.h>

--- a/src/video_core/renderer_vulkan/pipeline_helper.h
+++ b/src/video_core/renderer_vulkan/pipeline_helper.h
@@ -282,7 +282,14 @@ inline void PushImageDescriptors(TextureCache& texture_cache,
             const VideoCommon::ImageViewId image_view_id{(views++)->id};
             const VideoCommon::SamplerId sampler_id{*(samplers++)};
             ImageView& image_view{texture_cache.GetImageView(image_view_id)};
-            const VkImageView vk_image_view{image_view.Handle(desc.type)};
+            VkImageView vk_image_view{image_view.Handle(desc.type)};
+            if (vk_image_view == VK_NULL_HANDLE) {
+                const VkImageView null_image_view{
+                    texture_cache.GetImageView(VideoCommon::NULL_IMAGE_VIEW_ID).Handle(desc.type)};
+                if (null_image_view != VK_NULL_HANDLE) {
+                    vk_image_view = null_image_view;
+                }
+            }
             const Sampler& sampler{texture_cache.GetSampler(sampler_id)};
             const bool use_fallback_sampler{sampler.HasAddedAnisotropy() &&
                                             !image_view.SupportsAnisotropy()};


### PR DESCRIPTION
- Avoid writing VK_NULL_HANDLE into image descriptors when nullDescriptor is unavailable.
  Use the existing null image view fallback instead, improving compatibility with older/mobile Vulkan drivers.
- Include <cstring> in dynamic_library.cpp to fix builds on non-Windows/AUR-like environments.

The swizzle-table shader cleanup from the same nightly was intentionally not included because the relevant accelerated unswizzle paths are not wired up in this tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vulkan rendering robustness when an image view is unavailable, reducing the chance of missing or broken visuals in affected cases.
  * Updated low-level support code to better handle standard string/memory functions, helping maintain compatibility across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->