### PR TITLE
keeps demangle, but not llvm to go with it, if the option is set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ option(CITRON_USE_EXTERNAL_VULKAN_HEADERS "Use Vulkan-Headers from externals" ON
 
 option(CITRON_USE_EXTERNAL_VULKAN_UTILITY_LIBRARIES "Use Vulkan-Utility-Libraries from externals" ON)
 
-option(CITRON_USE_LLVM_DEMANGLE "Search for and link against a system LLVM for C++ symbol demangling" ON)
+option(CITRON_USE_LLVM_DEMANGLE "Search for and link against a system LLVM for C++ symbol demangling" OFF)
 
 option(CITRON_USE_QT_MULTIMEDIA "Use QtMultimedia for Camera" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ option(CITRON_USE_EXTERNAL_VULKAN_HEADERS "Use Vulkan-Headers from externals" ON
 
 option(CITRON_USE_EXTERNAL_VULKAN_UTILITY_LIBRARIES "Use Vulkan-Utility-Libraries from externals" ON)
 
+option(CITRON_USE_LLVM_DEMANGLE "Search for and link against a system LLVM for C++ symbol demangling" ON)
+
 option(CITRON_USE_QT_MULTIMEDIA "Use QtMultimedia for Camera" OFF)
 
 option(CITRON_USE_QT_WEB_ENGINE "Use QtWebEngine for web applet implementation" OFF)
@@ -352,7 +354,7 @@ endif()
 if (NOT TARGET fmt::fmt)
     find_package(fmt 9 REQUIRED)
 endif()
-if (NOT TARGET LLVM::Demangle)
+if (CITRON_USE_LLVM_DEMANGLE AND NOT TARGET LLVM::Demangle)
     find_package(LLVM 17.0.2 MODULE COMPONENTS Demangle)
 endif()
 if (NOT TARGET lz4::lz4)


### PR DESCRIPTION
do not bundle llvm when all you want is demangle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new build option to control whether LLVM-based symbol demangling is used.
  * The build now only searches for the LLVM demangling component when the option is enabled and it isn’t already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->