### PR TITLE
fix: update shader cache directory path in GamePropertiesFragment

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -401,6 +401,32 @@ object NativeLibrary {
     external fun getPatchesForFile(path: String, programId: String): Array<Patch>?
 
     /**
+     * Checks the PatchManager for any cheats that are available
+     *
+     * @param path Path to game file. Can be a [Uri].
+     * @param programId String representation of a game's program ID
+     * @return Array of available cheats
+     */
+    external fun getCheatsForFile(path: String, programId: String): Array<Patch>?
+
+    /**
+     * Enables or disables a single cheat by build ID and readable name.
+     *
+     * @param buildId NSO build ID associated with the cheat file
+     * @param name Readable cheat name
+     * @param enabled Whether the cheat should be enabled
+     */
+    external fun setCheatEnabled(buildId: String, name: String, enabled: Boolean)
+
+    /**
+     * Reloads cheats for the currently running game, if a cheat engine is active.
+     *
+     * @param programId String representation of a game's program ID
+     * @return true if the running cheat engine accepted a reload
+     */
+    external fun reloadCheats(programId: String): Boolean
+
+    /**
      * Removes an update for a given [programId]
      * @param programId String representation of a game's program ID
      */

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -419,6 +419,14 @@ object NativeLibrary {
     external fun setCheatEnabled(buildId: String, name: String, enabled: Boolean)
 
     /**
+     * Initializes all cheats in an installed addon as disabled.
+     *
+     * @param programId String representation of a game's program ID
+     * @param addonName Name of the installed addon directory
+     */
+    external fun disableCheatsForAddon(programId: String, addonName: String)
+
+    /**
      * Reloads cheats for the currently running game, if a cheat engine is active.
      *
      * @param programId String representation of a game's program ID

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -410,13 +410,19 @@ object NativeLibrary {
     external fun getCheatsForFile(path: String, programId: String): Array<Patch>?
 
     /**
-     * Enables or disables a single cheat by build ID and readable name.
+     * Enables or disables a single cheat by build ID, source file, and readable name.
      *
      * @param buildId NSO build ID associated with the cheat file
+     * @param source Stable source identifier for the cheat file
      * @param name Readable cheat name
      * @param enabled Whether the cheat should be enabled
      */
-    external fun setCheatEnabled(buildId: String, name: String, enabled: Boolean)
+    external fun setCheatEnabled(
+        buildId: String,
+        source: String,
+        name: String,
+        enabled: Boolean
+    )
 
     /**
      * Initializes all cheats in an installed addon as disabled.

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -158,6 +158,18 @@ object NativeLibrary {
     external fun isPaused(): Boolean
 
     /**
+     * Connects to an existing multiplayer room. This can block while ENet performs its handshake,
+     * so callers must invoke it off the main thread.
+     */
+    external fun connectToRoom(nickname: String, host: String, port: Int): Boolean
+
+    /** Returns the current multiplayer room member state. */
+    external fun getRoomConnectionState(): Int
+
+    /** Disconnects from the current multiplayer room. */
+    external fun leaveRoom()
+
+    /**
      * Returns the performance stats for the current game
      */
     external fun getPerfStats(): DoubleArray

--- a/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
@@ -47,6 +47,7 @@ import org.citron.citron_emu.features.settings.model.IntSetting
 import org.citron.citron_emu.features.settings.model.Settings
 import org.citron.citron_emu.model.EmulationViewModel
 import org.citron.citron_emu.model.Game
+import org.citron.citron_emu.utils.DisplayModeUtil
 import org.citron.citron_emu.utils.InputHandler
 import org.citron.citron_emu.utils.Log
 import org.citron.citron_emu.utils.MemoryUtil
@@ -81,6 +82,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
         ThemeHelper.setTheme(this)
 
         super.onCreate(savedInstanceState)
+        DisplayModeUtil.preferHighestRefreshRate(this)
 
         InputHandler.updateControllerData()
         val players = NativeConfig.getInputSettings(true)

--- a/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
@@ -12,6 +12,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.graphics.drawable.Icon
@@ -71,6 +72,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
     private val actionPlay = "ACTION_EMULATOR_PLAY"
     private val actionMute = "ACTION_EMULATOR_MUTE"
     private val actionUnmute = "ACTION_EMULATOR_UNMUTE"
+    private val pictureInPictureFailureActions: MutableSet<String> = mutableSetOf()
 
     private val emulationViewModel: EmulationViewModel by viewModels()
 
@@ -187,12 +189,18 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
     }
 
     override fun onUserLeaveHint() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            if (BooleanSetting.PICTURE_IN_PICTURE.getBoolean() && !isInPictureInPictureMode) {
-                val pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
-                    .getPictureInPictureActionsBuilder().getPictureInPictureAspectBuilder()
-                enterPictureInPictureMode(pictureInPictureParamsBuilder.build())
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ||
+            !isPictureInPictureSupported() ||
+            !BooleanSetting.PICTURE_IN_PICTURE.getBoolean() ||
+            isInPictureInPictureMode
+        ) {
+            return
+        }
+
+        val pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
+            .getPictureInPictureActionsBuilder().getPictureInPictureAspectBuilder()
+        runPictureInPictureAction("enter picture-in-picture mode") {
+            enterPictureInPictureMode(pictureInPictureParamsBuilder.build())
         }
     }
 
@@ -396,7 +404,29 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
         return this.apply { setActions(pictureInPictureActions) }
     }
 
+    private fun isPictureInPictureSupported() =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+
+    private fun runPictureInPictureAction(actionName: String, action: () -> Unit) {
+        try {
+            action()
+        } catch (e: IllegalStateException) {
+            if (pictureInPictureFailureActions.add(actionName)) {
+                Log.warning("[PiP] Failed to $actionName: ${e.message}")
+            }
+        } catch (e: UnsupportedOperationException) {
+            if (pictureInPictureFailureActions.add(actionName)) {
+                Log.warning("[PiP] Failed to $actionName: ${e.message}")
+            }
+        }
+    }
+
     fun buildPictureInPictureParams() {
+        if (!isPictureInPictureSupported()) {
+            return
+        }
+
         val pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
             .getPictureInPictureActionsBuilder().getPictureInPictureAspectBuilder()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -406,7 +436,9 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
                 BooleanSetting.PICTURE_IN_PICTURE.getBoolean() && isEmulationActive
             )
         }
-        setPictureInPictureParams(pictureInPictureParamsBuilder.build())
+        runPictureInPictureAction("set picture-in-picture params") {
+            setPictureInPictureParams(pictureInPictureParamsBuilder.build())
+        }
     }
 
     private var pictureInPictureReceiver = object : BroadcastReceiver() {

--- a/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
@@ -425,17 +425,17 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
         try {
             action()
         } catch (e: IllegalStateException) {
-            if (pictureInPictureFailureActions.add(actionName)) {
-                Log.warning("[PiP] Failed to $actionName: ${e.message}")
-            }
+            logPictureInPictureFailure(actionName, e)
         } catch (e: UnsupportedOperationException) {
-            if (pictureInPictureFailureActions.add(actionName)) {
-                Log.warning("[PiP] Failed to $actionName: ${e.message}")
-            }
+            logPictureInPictureFailure(actionName, e)
         } catch (e: IllegalArgumentException) {
-            if (pictureInPictureFailureActions.add(actionName)) {
-                Log.warning("[PiP] Failed to $actionName: ${e.message}")
-            }
+            logPictureInPictureFailure(actionName, e)
+        }
+    }
+
+    private fun logPictureInPictureFailure(actionName: String, exception: RuntimeException) {
+        if (pictureInPictureFailureActions.add(actionName)) {
+            Log.warning("[PiP] Failed to $actionName: ${exception.message}")
         }
     }
 

--- a/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/activities/EmulationActivity.kt
@@ -236,6 +236,8 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             return super.dispatchGenericMotionEvent(event)
         }
 
+        window.decorView.requestUnbufferedDispatch(event.source)
+
         // Don't attempt to do anything if we are disconnecting a device.
         if (event.actionMasked == MotionEvent.ACTION_CANCEL) {
             return true
@@ -326,7 +328,18 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             5 -> null // Stretch to window
             else -> null // Best fit
         }
-        return this.apply { aspectRatio?.let { setAspectRatio(it) } }
+        return this.apply { aspectRatio?.let { setAspectRatio(it.clampForPictureInPicture()) } }
+    }
+
+    private fun Rational.clampForPictureInPicture(): Rational {
+        val value = toFloat()
+        return when {
+            value < MIN_PICTURE_IN_PICTURE_ASPECT_RATIO.toFloat() ->
+                MIN_PICTURE_IN_PICTURE_ASPECT_RATIO
+            value > MAX_PICTURE_IN_PICTURE_ASPECT_RATIO.toFloat() ->
+                MAX_PICTURE_IN_PICTURE_ASPECT_RATIO
+            else -> this
+        }
     }
 
     private fun PictureInPictureParams.Builder.getPictureInPictureActionsBuilder():
@@ -416,6 +429,10 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
                 Log.warning("[PiP] Failed to $actionName: ${e.message}")
             }
         } catch (e: UnsupportedOperationException) {
+            if (pictureInPictureFailureActions.add(actionName)) {
+                Log.warning("[PiP] Failed to $actionName: ${e.message}")
+            }
+        } catch (e: IllegalArgumentException) {
             if (pictureInPictureFailureActions.add(actionName)) {
                 Log.warning("[PiP] Failed to $actionName: ${e.message}")
             }
@@ -526,6 +543,8 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
 
     companion object {
         const val EXTRA_SELECTED_GAME = "SelectedGame"
+        private val MIN_PICTURE_IN_PICTURE_ASPECT_RATIO = Rational(100, 239)
+        private val MAX_PICTURE_IN_PICTURE_ASPECT_RATIO = Rational(239, 100)
 
         fun launch(activity: AppCompatActivity, game: Game) {
             val launcher = Intent(activity, EmulationActivity::class.java)

--- a/src/android/app/src/main/java/org/citron/citron_emu/adapters/AddonAdapter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/adapters/AddonAdapter.kt
@@ -4,10 +4,12 @@
 package org.citron.citron_emu.adapters
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import org.citron.citron_emu.databinding.ListItemAddonBinding
 import org.citron.citron_emu.model.Patch
 import org.citron.citron_emu.model.AddonViewModel
+import org.citron.citron_emu.model.PatchType
 import org.citron.citron_emu.viewholder.AbstractViewHolder
 
 class AddonAdapter(val addonViewModel: AddonViewModel) :
@@ -20,15 +22,19 @@ class AddonAdapter(val addonViewModel: AddonViewModel) :
     inner class AddonViewHolder(val binding: ListItemAddonBinding) :
         AbstractViewHolder<Patch>(binding) {
         override fun bind(model: Patch) {
+            val patchType = PatchType.from(model.type)
             binding.root.setOnClickListener {
                 binding.addonCheckbox.isChecked = !binding.addonCheckbox.isChecked
             }
             binding.title.text = model.name
             binding.version.text = model.version
-            binding.addonCheckbox.setOnCheckedChangeListener { _, checked ->
-                model.enabled = checked
-            }
+            binding.addonCheckbox.setOnCheckedChangeListener(null)
             binding.addonCheckbox.isChecked = model.enabled
+            binding.addonCheckbox.setOnCheckedChangeListener { _, checked ->
+                addonViewModel.onPatchEnabledChanged(model, checked)
+            }
+            binding.buttonDelete.visibility =
+                if (patchType == PatchType.Cheat) View.GONE else View.VISIBLE
             binding.buttonDelete.setOnClickListener {
                 addonViewModel.setAddonToDelete(model)
             }

--- a/src/android/app/src/main/java/org/citron/citron_emu/adapters/AddonAdapter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/adapters/AddonAdapter.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import org.citron.citron_emu.databinding.ListItemAddonBinding
 import org.citron.citron_emu.model.Patch
 import org.citron.citron_emu.model.AddonViewModel
-import org.citron.citron_emu.model.PatchType
 import org.citron.citron_emu.viewholder.AbstractViewHolder
 
 class AddonAdapter(val addonViewModel: AddonViewModel) :
@@ -22,7 +21,6 @@ class AddonAdapter(val addonViewModel: AddonViewModel) :
     inner class AddonViewHolder(val binding: ListItemAddonBinding) :
         AbstractViewHolder<Patch>(binding) {
         override fun bind(model: Patch) {
-            val patchType = PatchType.from(model.type)
             binding.root.setOnClickListener {
                 binding.addonCheckbox.isChecked = !binding.addonCheckbox.isChecked
             }
@@ -31,10 +29,9 @@ class AddonAdapter(val addonViewModel: AddonViewModel) :
             binding.addonCheckbox.setOnCheckedChangeListener(null)
             binding.addonCheckbox.isChecked = model.enabled
             binding.addonCheckbox.setOnCheckedChangeListener { _, checked ->
-                addonViewModel.onPatchEnabledChanged(model, checked)
+                model.enabled = checked
             }
-            binding.buttonDelete.visibility =
-                if (patchType == PatchType.Cheat) View.GONE else View.VISIBLE
+            binding.buttonDelete.visibility = View.VISIBLE
             binding.buttonDelete.setOnClickListener {
                 addonViewModel.setAddonToDelete(model)
             }

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/DirectConnectDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/DirectConnectDialogFragment.kt
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.citron.citron_emu.features.settings.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.citron.citron_emu.CitronApplication
+import org.citron.citron_emu.NativeLibrary
+import org.citron.citron_emu.R
+import org.citron.citron_emu.databinding.DialogDirectConnectBinding
+
+class DirectConnectDialogFragment : DialogFragment() {
+    private lateinit var binding: DialogDirectConnectBinding
+    private var connectionJob: Job? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        binding = DialogDirectConnectBinding.inflate(layoutInflater)
+        val preferences = PreferenceManager.getDefaultSharedPreferences(CitronApplication.appContext)
+        binding.directConnectHost.setText(preferences.getString(PREF_HOST, ""))
+        binding.directConnectPort.setText(preferences.getInt(PREF_PORT, DEFAULT_PORT).toString())
+        binding.directConnectNickname.setText(preferences.getString(PREF_NICKNAME, ""))
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.direct_connect)
+            .setView(binding.root)
+            .setNegativeButton(R.string.close, null)
+            .setNeutralButton(R.string.direct_connect_disconnect, null)
+            .setPositiveButton(R.string.direct_connect_connect, null)
+            .create()
+            .also { dialog ->
+                dialog.setOnShowListener {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                        connect(dialog)
+                    }
+                    dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                        disconnect(dialog)
+                    }
+                    val state = NativeLibrary.getRoomConnectionState()
+                    renderState(dialog, state)
+                    if (state == ROOM_JOINING) {
+                        startObservingConnection(dialog)
+                    }
+                }
+            }
+    }
+
+    override fun onDestroyView() {
+        connectionJob?.cancel()
+        super.onDestroyView()
+    }
+
+    private fun connect(dialog: AlertDialog) {
+        val host = binding.directConnectHost.text?.toString()?.trim().orEmpty()
+        val nickname = binding.directConnectNickname.text?.toString()?.trim().orEmpty()
+        val port = binding.directConnectPort.text?.toString()?.toIntOrNull()
+        if (host.isEmpty() || host.length > MAX_HOST_LENGTH ||
+            nickname.length !in MIN_NICKNAME_LENGTH..MAX_NICKNAME_LENGTH ||
+            !nickname.matches(NICKNAME_PATTERN) || port !in 1..MAX_PORT
+        ) {
+            showStatus(R.string.direct_connect_invalid_input)
+            return
+        }
+        val portValue = port ?: return
+
+        PreferenceManager.getDefaultSharedPreferences(CitronApplication.appContext).edit()
+            .putString(PREF_HOST, host)
+            .putInt(PREF_PORT, portValue)
+            .putString(PREF_NICKNAME, nickname)
+            .apply()
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+        showStatus(R.string.direct_connect_connecting)
+        connectionJob?.cancel()
+        connectionJob = lifecycleScope.launch {
+            val started = withContext(Dispatchers.IO) {
+                NativeLibrary.connectToRoom(nickname, host, portValue)
+            }
+            if (!started) {
+                showStatus(R.string.direct_connect_failed)
+                renderState(dialog, ROOM_IDLE)
+                return@launch
+            }
+            monitorConnection(dialog)
+        }
+    }
+
+    private fun startObservingConnection(dialog: AlertDialog) {
+        connectionJob?.cancel()
+        connectionJob = lifecycleScope.launch {
+            monitorConnection(dialog)
+        }
+    }
+
+    private suspend fun monitorConnection(dialog: AlertDialog) {
+        while (currentCoroutineContext().isActive) {
+            val state = withContext(Dispatchers.IO) {
+                NativeLibrary.getRoomConnectionState()
+            }
+            renderState(dialog, state)
+            if (state != ROOM_JOINING) {
+                if (state != ROOM_JOINED && state != ROOM_MODERATOR) {
+                    showStatus(R.string.direct_connect_failed)
+                }
+                return
+            }
+            delay(CONNECTION_STATE_POLL_MS)
+        }
+    }
+
+    private fun disconnect(dialog: AlertDialog) {
+        connectionJob?.cancel()
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) { NativeLibrary.leaveRoom() }
+            showStatus(R.string.direct_connect_disconnected)
+            renderState(dialog, ROOM_IDLE)
+        }
+    }
+
+    private fun renderState(dialog: AlertDialog, state: Int) {
+        val connecting = state == ROOM_JOINING
+        val connected = state == ROOM_JOINED || state == ROOM_MODERATOR
+        binding.directConnectHost.isEnabled = !connecting && !connected
+        binding.directConnectPort.isEnabled = !connecting && !connected
+        binding.directConnectNickname.isEnabled = !connecting && !connected
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = !connecting && !connected
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).isEnabled = connecting || connected
+
+        when {
+            connecting -> showStatus(R.string.direct_connect_connecting)
+            connected -> showStatus(R.string.direct_connect_connected)
+        }
+    }
+
+    private fun showStatus(stringId: Int) {
+        binding.directConnectStatus.setText(stringId)
+        binding.directConnectStatus.isVisible = true
+    }
+
+    companion object {
+        const val TAG = "DirectConnectDialog"
+
+        private const val PREF_HOST = "DirectConnectHost"
+        private const val PREF_PORT = "DirectConnectPort"
+        private const val PREF_NICKNAME = "DirectConnectNickname"
+        private const val DEFAULT_PORT = 24872
+        private const val MIN_NICKNAME_LENGTH = 4
+        private const val MAX_NICKNAME_LENGTH = 20
+        private const val MAX_HOST_LENGTH = 253
+        private const val MAX_PORT = 65535
+        private const val CONNECTION_STATE_POLL_MS = 250L
+        private const val ROOM_IDLE = 1
+        private const val ROOM_JOINING = 2
+        private const val ROOM_JOINED = 3
+        private const val ROOM_MODERATOR = 4
+        private val NICKNAME_PATTERN = Regex("[a-zA-Z0-9._ -]+")
+    }
+}

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/DirectConnectDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/DirectConnectDialogFragment.kt
@@ -6,6 +6,7 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AlertDialog
@@ -25,6 +26,9 @@ import org.citron.citron_emu.databinding.DialogDirectConnectBinding
 class DirectConnectDialogFragment : DialogFragment() {
     private lateinit var binding: DialogDirectConnectBinding
     private var connectionJob: Job? = null
+    private var connectionState = ROOM_IDLE
+
+    private val settingsViewModel: SettingsViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = DialogDirectConnectBinding.inflate(layoutInflater)
@@ -130,6 +134,11 @@ class DirectConnectDialogFragment : DialogFragment() {
     }
 
     private fun renderState(dialog: AlertDialog, state: Int) {
+        if (connectionState != state) {
+            connectionState = state
+            settingsViewModel.setShouldReloadSettingsList(true)
+        }
+
         val connecting = state == ROOM_JOINING
         val connected = state == ROOM_JOINED || state == ROOM_MODERATOR
         binding.directConnectHost.isEnabled = !connecting && !connected

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
@@ -128,6 +128,17 @@ class SettingsFragment : Fragment() {
                 ).show(parentFragmentManager, MessageDialogFragment.TAG)
             }
         }
+        settingsViewModel.shouldShowDirectConnectDialog.collect(
+            viewLifecycleOwner,
+            resetState = { settingsViewModel.setShouldShowDirectConnectDialog(false) }
+        ) {
+            if (it) {
+                DirectConnectDialogFragment().show(
+                    parentFragmentManager,
+                    DirectConnectDialogFragment.TAG
+                )
+            }
+        }
 
         if (args.menuTag == Settings.MenuTag.SECTION_ROOT) {
             binding.toolbarSettings.inflateMenu(R.menu.menu_settings)

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1020,7 +1020,14 @@ class SettingsFragmentPresenter(
             add(
                 RunnableSetting(
                     titleId = R.string.direct_connect,
-                    descriptionId = R.string.direct_connect_description,
+                    descriptionString = context.getString(
+                        R.string.direct_connect_status,
+                        when (NativeLibrary.getRoomConnectionState()) {
+                            2 -> context.getString(R.string.direct_connect_connecting)
+                            3, 4 -> context.getString(R.string.direct_connect_connected)
+                            else -> context.getString(R.string.direct_connect_disconnected)
+                        }
+                    ),
                     isRunnable = !NativeLibrary.isRunning(),
                     iconId = R.drawable.ic_share
                 ) {

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1017,6 +1017,16 @@ class SettingsFragmentPresenter(
         sl.apply {
             add(HeaderSetting(R.string.network_settings_header))
             add(BooleanSetting.AIRPLANE_MODE.key)
+            add(
+                RunnableSetting(
+                    titleId = R.string.direct_connect,
+                    descriptionId = R.string.direct_connect_description,
+                    isRunnable = !NativeLibrary.isRunning(),
+                    iconId = R.drawable.ic_share
+                ) {
+                    settingsViewModel.setShouldShowDirectConnectDialog(true)
+                }
+            )
         }
     }
 

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsViewModel.kt
@@ -54,6 +54,9 @@ class SettingsViewModel : ViewModel() {
     private val _shouldShowResetInputDialog = MutableStateFlow(false)
     val shouldShowResetInputDialog = _shouldShowResetInputDialog.asStateFlow()
 
+    private val _shouldShowDirectConnectDialog = MutableStateFlow(false)
+    val shouldShowDirectConnectDialog = _shouldShowDirectConnectDialog.asStateFlow()
+
     fun setShouldRecreate(value: Boolean) {
         _shouldRecreate.value = value
     }
@@ -101,6 +104,10 @@ class SettingsViewModel : ViewModel() {
 
     fun setShouldShowResetInputDialog(value: Boolean) {
         _shouldShowResetInputDialog.value = value
+    }
+
+    fun setShouldShowDirectConnectDialog(value: Boolean) {
+        _shouldShowDirectConnectDialog.value = value
     }
 
     fun getCurrentDeviceParams(defaultParams: ParamPackage): ParamPackage =

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/AddonsFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/AddonsFragment.kt
@@ -20,6 +20,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialSharedAxis
 import kotlinx.coroutines.launch
+import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.R
 import org.citron.citron_emu.adapters.AddonAdapter
 import org.citron.citron_emu.databinding.FragmentAddonsBinding
@@ -27,6 +28,7 @@ import org.citron.citron_emu.model.AddonViewModel
 import org.citron.citron_emu.model.HomeViewModel
 import org.citron.citron_emu.utils.AddonUtil
 import org.citron.citron_emu.utils.FileUtil.copyFilesTo
+import org.citron.citron_emu.utils.NativeConfig
 import org.citron.citron_emu.utils.ViewUtils.updateMargins
 import org.citron.citron_emu.utils.collect
 import java.io.File
@@ -160,7 +162,8 @@ class AddonsFragment : Fragment() {
                     R.string.installing_game_content,
                     false
                 ) { progressCallback, _ ->
-                    val parentDirectoryName = externalAddonDirectory.name
+                    val parentDirectoryName =
+                        externalAddonDirectory.name ?: return@newInstance errorMessage
                     val internalAddonDirectory =
                         File(args.game.addonDir + parentDirectoryName)
                     try {
@@ -168,6 +171,8 @@ class AddonsFragment : Fragment() {
                     } catch (_: Exception) {
                         return@newInstance errorMessage
                     }
+                    NativeLibrary.disableCheatsForAddon(args.game.programId, parentDirectoryName)
+                    NativeConfig.saveGlobalConfig()
                     addonViewModel.refreshAddons()
                     return@newInstance getString(R.string.addon_installed_successfully)
                 }.show(parentFragmentManager, ProgressDialogFragment.TAG)

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/DriverManagerFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/DriverManagerFragment.kt
@@ -120,6 +120,17 @@ class DriverManagerFragment : Fragment() {
         driverViewModel.onCloseDriverManager(args.game)
     }
 
+    override fun onResume() {
+        super.onResume()
+        refreshDriverList()
+    }
+
+    private fun refreshDriverList() {
+        driverViewModel.reloadDriverData()
+        (binding.listDrivers.adapter as? DriverAdapter)
+            ?.replaceList(driverViewModel.driverList.value)
+    }
+
     private fun setInsets() =
         ViewCompat.setOnApplyWindowInsetsListener(
             binding.root

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
@@ -36,6 +36,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout.DrawerListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.window.layout.FoldingFeature
@@ -43,6 +44,9 @@ import androidx.window.layout.WindowInfoTracker
 import androidx.window.layout.WindowLayoutInfo
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.citron.citron_emu.HomeNavigationDirections
 import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.R
@@ -58,6 +62,8 @@ import org.citron.citron_emu.features.settings.utils.SettingsFile
 import org.citron.citron_emu.model.DriverViewModel
 import org.citron.citron_emu.model.Game
 import org.citron.citron_emu.model.EmulationViewModel
+import org.citron.citron_emu.model.Patch
+import org.citron.citron_emu.model.PatchType
 import org.citron.citron_emu.overlay.model.OverlayControl
 import org.citron.citron_emu.overlay.model.OverlayLayout
 import org.citron.citron_emu.utils.*
@@ -280,6 +286,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
                 R.id.menu_overlay_controls -> {
                     showOverlayOptions()
+                    true
+                }
+
+                R.id.menu_cheats -> {
+                    showCheats()
                     true
                 }
 
@@ -769,6 +780,61 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     override fun surfaceDestroyed(holder: SurfaceHolder) {
         emulationState.clearSurface()
+    }
+
+    private fun showCheats() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val cheats = withContext(Dispatchers.IO) {
+                NativeLibrary.getCheatsForFile(game.path, game.programId)
+                    ?.filter { PatchType.from(it.type) == PatchType.Cheat }
+                    ?: emptyList()
+            }
+
+            binding.drawerLayout.close()
+
+            if (cheats.isEmpty()) {
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.emulation_cheats)
+                    .setMessage(R.string.emulation_cheats_empty)
+                    .setPositiveButton(R.string.close, null)
+                    .show()
+                return@launch
+            }
+
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.emulation_cheats)
+                .setMultiChoiceItems(
+                    cheats.map { it.name }.toTypedArray(),
+                    cheats.map { it.enabled }.toBooleanArray()
+                ) { _, which, isChecked ->
+                    setCheatEnabled(cheats[which], isChecked)
+                }
+                .setPositiveButton(R.string.close, null)
+                .show()
+        }
+    }
+
+    private fun setCheatEnabled(cheat: Patch, enabled: Boolean) {
+        val shouldResume = emulationState.isRunning && !NativeLibrary.isPaused()
+
+        if (shouldResume) {
+            emulationState.pause()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+            NativeLibrary.setCheatEnabled(cheat.titleId, cheat.name, enabled)
+            NativeConfig.saveGlobalConfig()
+            val reloaded = NativeLibrary.reloadCheats(cheat.programId)
+
+            withContext(Dispatchers.Main) {
+                if (!reloaded) {
+                    Log.warning("[EmulationFragment] Cheat reload requested without an active cheat engine.")
+                }
+                if (shouldResume && emulationState.isPaused) {
+                    emulationState.run(false)
+                }
+            }
+        }
     }
 
     private fun showOverlayOptions() {

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
@@ -45,8 +45,11 @@ import androidx.window.layout.WindowLayoutInfo
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.citron.citron_emu.HomeNavigationDirections
 import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.R
@@ -87,6 +90,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     private val emulationViewModel: EmulationViewModel by activityViewModels()
     private val driverViewModel: DriverViewModel by activityViewModels()
+    private val cheatToggleMutex = Mutex()
 
     private var isInFoldableLayout = false
 
@@ -815,23 +819,30 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     }
 
     private fun setCheatEnabled(cheat: Patch, enabled: Boolean) {
-        val shouldResume = emulationState.isRunning && !NativeLibrary.isPaused()
+        viewLifecycleOwner.lifecycleScope.launch {
+            cheatToggleMutex.withLock {
+                var shouldResume = false
+                try {
+                    shouldResume = emulationState.isRunning && !NativeLibrary.isPaused()
+                    if (shouldResume) {
+                        emulationState.pause()
+                    }
 
-        if (shouldResume) {
-            emulationState.pause()
-        }
+                    val reloaded = withContext(Dispatchers.IO) {
+                        NativeLibrary.setCheatEnabled(cheat.titleId, cheat.name, enabled)
+                        NativeConfig.saveGlobalConfig()
+                        NativeLibrary.reloadCheats(cheat.programId)
+                    }
 
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            NativeLibrary.setCheatEnabled(cheat.titleId, cheat.name, enabled)
-            NativeConfig.saveGlobalConfig()
-            val reloaded = NativeLibrary.reloadCheats(cheat.programId)
-
-            withContext(Dispatchers.Main) {
-                if (!reloaded) {
-                    Log.warning("[EmulationFragment] Cheat reload requested without an active cheat engine.")
-                }
-                if (shouldResume && emulationState.isPaused) {
-                    emulationState.run(false)
+                    if (!reloaded) {
+                        Log.warning("[EmulationFragment] Cheat reload requested without an active cheat engine.")
+                    }
+                } finally {
+                    withContext(NonCancellable) {
+                        if (shouldResume && emulationState.isPaused) {
+                            emulationState.run(false)
+                        }
+                    }
                 }
             }
         }

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/EmulationFragment.kt
@@ -829,7 +829,12 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                     }
 
                     val reloaded = withContext(Dispatchers.IO) {
-                        NativeLibrary.setCheatEnabled(cheat.titleId, cheat.name, enabled)
+                        NativeLibrary.setCheatEnabled(
+                            cheat.titleId,
+                            cheat.version,
+                            cheat.name,
+                            enabled
+                        )
                         NativeConfig.saveGlobalConfig()
                         NativeLibrary.reloadCheats(cheat.programId)
                     }

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/GamePropertiesFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/GamePropertiesFragment.kt
@@ -242,7 +242,7 @@ class GamePropertiesFragment : Fragment() {
 
                 val shaderCacheDir = File(
                     DirectoryInitialization.userDirectory +
-                        "/shader/" + args.game.settingsName.lowercase()
+                        "/cache/shader/" + args.game.settingsName.lowercase()
                 )
                 if (shaderCacheDir.exists()) {
                     add(

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
@@ -46,14 +46,10 @@ class AddonViewModel : ViewModel() {
             try {
                 val patchList = withContext(Dispatchers.IO) {
                     val patchList = (
-                        (NativeLibrary.getPatchesForFile(currentGame.path, currentGame.programId)
-                            ?: emptyArray()) +
-                            (NativeLibrary.getCheatsForFile(currentGame.path, currentGame.programId)
-                                ?: emptyArray())
+                        NativeLibrary.getPatchesForFile(currentGame.path, currentGame.programId)
+                            ?: emptyArray()
                     ).toMutableList()
-                    patchList.sortWith(
-                        compareBy<Patch> { PatchType.from(it.type).int }.thenBy { it.name }
-                    )
+                    patchList.sortBy { it.name }
                     patchList
                 }
                 _patchList.value = patchList
@@ -77,19 +73,6 @@ class AddonViewModel : ViewModel() {
         refreshAddons()
     }
 
-    fun onPatchEnabledChanged(patch: Patch, enabled: Boolean) {
-        patch.enabled = enabled
-        if (PatchType.from(patch.type) != PatchType.Cheat) {
-            return
-        }
-
-        viewModelScope.launch(Dispatchers.IO) {
-            NativeLibrary.setCheatEnabled(patch.titleId, patch.name, enabled)
-            NativeConfig.saveGlobalConfig()
-            NativeLibrary.reloadCheats(patch.programId)
-        }
-    }
-
     fun onCloseAddons() {
         val currentGame = game ?: return
         if (_patchList.value.isEmpty()) {
@@ -99,7 +82,7 @@ class AddonViewModel : ViewModel() {
         NativeConfig.setDisabledAddons(
             currentGame.programId,
             _patchList.value.mapNotNull {
-                if (it.enabled || PatchType.from(it.type) == PatchType.Cheat) {
+                if (it.enabled) {
                     null
                 } else {
                     it.name

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
@@ -37,18 +37,27 @@ class AddonViewModel : ViewModel() {
     }
 
     fun refreshAddons() {
-        if (isRefreshing.get() || game == null) {
+        val currentGame = game ?: return
+        if (isRefreshing.get()) {
             return
         }
         isRefreshing.set(true)
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                val patchList = (
-                    NativeLibrary.getPatchesForFile(game!!.path, game!!.programId)
-                        ?: emptyArray()
+            try {
+                val patchList = withContext(Dispatchers.IO) {
+                    val patchList = (
+                        (NativeLibrary.getPatchesForFile(currentGame.path, currentGame.programId)
+                            ?: emptyArray()) +
+                            (NativeLibrary.getCheatsForFile(currentGame.path, currentGame.programId)
+                                ?: emptyArray())
                     ).toMutableList()
-                patchList.sortBy { it.name }
+                    patchList.sortWith(
+                        compareBy<Patch> { PatchType.from(it.type).int }.thenBy { it.name }
+                    )
+                    patchList
+                }
                 _patchList.value = patchList
+            } finally {
                 isRefreshing.set(false)
             }
         }
@@ -63,19 +72,34 @@ class AddonViewModel : ViewModel() {
             PatchType.Update -> NativeLibrary.removeUpdate(patch.programId)
             PatchType.DLC -> NativeLibrary.removeDLC(patch.programId)
             PatchType.Mod -> NativeLibrary.removeMod(patch.programId, patch.name)
+            PatchType.Cheat -> return
         }
         refreshAddons()
     }
 
+    fun onPatchEnabledChanged(patch: Patch, enabled: Boolean) {
+        patch.enabled = enabled
+        if (PatchType.from(patch.type) != PatchType.Cheat) {
+            return
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            NativeLibrary.setCheatEnabled(patch.titleId, patch.name, enabled)
+            NativeConfig.saveGlobalConfig()
+            NativeLibrary.reloadCheats(patch.programId)
+        }
+    }
+
     fun onCloseAddons() {
+        val currentGame = game ?: return
         if (_patchList.value.isEmpty()) {
             return
         }
 
         NativeConfig.setDisabledAddons(
-            game!!.programId,
+            currentGame.programId,
             _patchList.value.mapNotNull {
-                if (it.enabled) {
+                if (it.enabled || PatchType.from(it.type) == PatchType.Cheat) {
                     null
                 } else {
                     it.name

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/AddonViewModel.kt
@@ -38,10 +38,9 @@ class AddonViewModel : ViewModel() {
 
     fun refreshAddons() {
         val currentGame = game ?: return
-        if (isRefreshing.get()) {
+        if (!isRefreshing.compareAndSet(false, true)) {
             return
         }
-        isRefreshing.set(true)
         viewModelScope.launch {
             try {
                 val patchList = withContext(Dispatchers.IO) {

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
@@ -118,25 +118,27 @@ class DriverViewModel : ViewModel() {
 
     fun onCloseDriverManager(game: Game?) {
         _isDeletingDrivers.value = true
-        try {
-            updateDriverNameForGame(game)
-            if (game == null) {
-                NativeConfig.saveGlobalConfig()
-            } else {
-                NativeConfig.savePerGameConfig()
-                NativeConfig.unloadPerGameConfig()
-                NativeConfig.reloadGlobalConfig()
-            }
-
-            driversToDelete.forEach {
-                val driver = File(it)
-                if (driver.exists()) {
-                    driver.delete()
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                updateDriverNameForGame(game)
+                if (game == null) {
+                    NativeConfig.saveGlobalConfig()
+                } else {
+                    NativeConfig.savePerGameConfig()
+                    NativeConfig.unloadPerGameConfig()
+                    NativeConfig.reloadGlobalConfig()
                 }
+
+                driversToDelete.forEach {
+                    val driver = File(it)
+                    if (driver.exists()) {
+                        driver.delete()
+                    }
+                }
+                driversToDelete.clear()
+            } finally {
+                _isDeletingDrivers.value = false
             }
-            driversToDelete.clear()
-        } finally {
-            _isDeletingDrivers.value = false
         }
     }
 

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
@@ -60,6 +60,8 @@ class DriverViewModel : ViewModel() {
     fun reloadDriverData() {
         _areDriversLoading.value = true
         driverData = GpuDriverHelper.getDrivers()
+            .filterNot { driversToDelete.contains(it.first) }
+            .toMutableList()
         updateDriverList()
         _areDriversLoading.value = false
     }
@@ -116,26 +118,25 @@ class DriverViewModel : ViewModel() {
 
     fun onCloseDriverManager(game: Game?) {
         _isDeletingDrivers.value = true
-        updateDriverNameForGame(game)
-        if (game == null) {
-            NativeConfig.saveGlobalConfig()
-        } else {
-            NativeConfig.savePerGameConfig()
-            NativeConfig.unloadPerGameConfig()
-            NativeConfig.reloadGlobalConfig()
-        }
-
-        viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                driversToDelete.forEach {
-                    val driver = File(it)
-                    if (driver.exists()) {
-                        driver.delete()
-                    }
-                }
-                driversToDelete.clear()
-                _isDeletingDrivers.value = false
+        try {
+            updateDriverNameForGame(game)
+            if (game == null) {
+                NativeConfig.saveGlobalConfig()
+            } else {
+                NativeConfig.savePerGameConfig()
+                NativeConfig.unloadPerGameConfig()
+                NativeConfig.reloadGlobalConfig()
             }
+
+            driversToDelete.forEach {
+                val driver = File(it)
+                if (driver.exists()) {
+                    driver.delete()
+                }
+            }
+            driversToDelete.clear()
+        } finally {
+            _isDeletingDrivers.value = false
         }
     }
 

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
@@ -73,8 +73,8 @@ class DriverViewModel : ViewModel() {
             Driver(
                 selectedDriver == GpuDriverMetadata(),
                 CitronApplication.appContext.getString(R.string.system_gpu_driver),
-                systemDriverData?.get(0) ?: "",
-                systemDriverData?.get(1) ?: ""
+                systemDriverData?.getOrNull(0) ?: "",
+                systemDriverData?.getOrNull(1) ?: ""
             )
         )
         driverData.forEach {

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/PatchType.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/PatchType.kt
@@ -6,7 +6,8 @@ package org.citron.citron_emu.model
 enum class PatchType(val int: Int) {
     Update(0),
     DLC(1),
-    Mod(2);
+    Mod(2),
+    Cheat(3);
 
     companion object {
         fun from(int: Int): PatchType = entries.firstOrNull { it.int == int } ?: Update

--- a/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
@@ -241,6 +241,8 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     override fun onTouch(v: View, event: MotionEvent): Boolean {
+        requestUnbufferedTouchDispatch(event)
+
         if (inEditMode) {
             return onTouchWhileEditing(event)
         }
@@ -349,6 +351,13 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
         }
 
         return true
+    }
+
+    private fun requestUnbufferedTouchDispatch(event: MotionEvent) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN,
+            MotionEvent.ACTION_POINTER_DOWN -> requestUnbufferedDispatch(event)
+        }
     }
 
     private fun playHaptics(event: MotionEvent) {

--- a/src/android/app/src/main/java/org/citron/citron_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/ui/main/MainActivity.kt
@@ -70,6 +70,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         ThemeHelper.setTheme(this)
 
         super.onCreate(savedInstanceState)
+        DisplayModeUtil.preferHighestRefreshRate(this)
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/src/android/app/src/main/java/org/citron/citron_emu/utils/DisplayModeUtil.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/utils/DisplayModeUtil.kt
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.citron.citron_emu.utils
+
+import android.app.Activity
+
+object DisplayModeUtil {
+    fun preferHighestRefreshRate(activity: Activity) {
+        val highestRefreshMode = activity.display?.supportedModes?.maxByOrNull { it.refreshRate }
+            ?: return
+        val layoutParams = activity.window.attributes
+        layoutParams.preferredDisplayModeId = highestRefreshMode.modeId
+        activity.window.attributes = layoutParams
+    }
+}

--- a/src/android/app/src/main/jni/CMakeLists.txt
+++ b/src/android/app/src/main/jni/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(citron-android SHARED
 
 set_property(TARGET citron-android PROPERTY IMPORTED_LOCATION ${FFmpeg_LIBRARY_DIR})
 
-target_link_libraries(citron-android PRIVATE audio_core common core input_common frontend_common Vulkan::Headers)
+target_link_libraries(citron-android PRIVATE audio_core common core input_common frontend_common network Vulkan::Headers)
 target_link_libraries(citron-android PRIVATE android camera2ndk EGL glad jnigraphics log)
 if (ARCHITECTURE_arm64)
     target_link_libraries(citron-android PRIVATE adrenotools)

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -57,6 +57,7 @@
 #include "core/hle/service/am/frontend/applets.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
+#include "core/memory/cheat_engine.h"
 #include "frontend_common/config.h"
 #include "hid_core/frontend/emulated_controller.h"
 #include "hid_core/hid_core.h"
@@ -875,14 +876,19 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
         env->NewObjectArray(cheats.size(), Common::Android::GetPatchClass(), nullptr);
     int i = 0;
     for (const auto& cheat : cheats) {
+        const auto jname = Common::Android::ToJString(env, cheat.name);
+        const auto jversion = Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id));
+        const auto jprogramId = Common::Android::ToJString(env, std::to_string(program_id));
+        const auto jbuildId = Common::Android::ToJString(env, cheat.build_id);
         jobject jpatch = env->NewObject(
             Common::Android::GetPatchClass(), Common::Android::GetPatchConstructor(), cheat.enabled,
-            Common::Android::ToJString(env, cheat.name),
-            Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id)),
-            static_cast<jint>(FileSys::PatchType::Cheat),
-            Common::Android::ToJString(env, std::to_string(program_id)),
-            Common::Android::ToJString(env, cheat.build_id));
+            jname, jversion, static_cast<jint>(FileSys::PatchType::Cheat), jprogramId, jbuildId);
         env->SetObjectArrayElement(jpatchArray, i, jpatch);
+        env->DeleteLocalRef(jpatch);
+        env->DeleteLocalRef(jname);
+        env->DeleteLocalRef(jversion);
+        env->DeleteLocalRef(jprogramId);
+        env->DeleteLocalRef(jbuildId);
         ++i;
     }
     return jpatchArray;

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -878,16 +878,17 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
     for (const auto& cheat : cheats) {
         const auto jname = Common::Android::ToJString(env, cheat.name);
         const auto jversion = Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id));
-        const auto jprogramId = Common::Android::ToJString(env, std::to_string(program_id));
+        const auto jpatchProgramId = Common::Android::ToJString(env, std::to_string(program_id));
         const auto jbuildId = Common::Android::ToJString(env, cheat.build_id);
         jobject jpatch = env->NewObject(
             Common::Android::GetPatchClass(), Common::Android::GetPatchConstructor(), cheat.enabled,
-            jname, jversion, static_cast<jint>(FileSys::PatchType::Cheat), jprogramId, jbuildId);
+            jname, jversion, static_cast<jint>(FileSys::PatchType::Cheat), jpatchProgramId,
+            jbuildId);
         env->SetObjectArrayElement(jpatchArray, i, jpatch);
         env->DeleteLocalRef(jpatch);
         env->DeleteLocalRef(jname);
         env->DeleteLocalRef(jversion);
-        env->DeleteLocalRef(jprogramId);
+        env->DeleteLocalRef(jpatchProgramId);
         env->DeleteLocalRef(jbuildId);
         ++i;
     }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
+#include <array>
 #include <codecvt>
 #include <cctype>
 #include <locale>
@@ -10,6 +11,7 @@
 #include <string_view>
 #include <dlfcn.h>
 #include <functional>
+#include <iterator>
 
 #ifdef ARCHITECTURE_arm64
 #include <adrenotools/driver.h>
@@ -29,6 +31,7 @@
 #include "common/detached_tasks.h"
 #include "common/dynamic_library.h"
 #include "common/fs/path_util.h"
+#include "common/hex_util.h"
 #include "common/logging.h"
 #include "common/logging.h"
 #include "common/scm_rev.h"
@@ -82,10 +85,16 @@
 #define jauto [[maybe_unused]] auto
 
 namespace {
+constexpr std::size_t CHEAT_BUILD_ID_LENGTH = sizeof(u64) * 2;
+
 std::string NormalizeCheatBuildId(std::string build_id) {
     std::transform(build_id.begin(), build_id.end(), build_id.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     return build_id;
+}
+
+std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id) {
+    return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
 }
 } // namespace
 
@@ -870,12 +879,22 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
     const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
     const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
+    const auto* cheat_engine = system.GetCheatEngine();
+    const auto active_build_id =
+        cheat_engine == nullptr ? std::string{} : GetCheatBuildId(cheat_engine->GetBuildId());
 
     const auto cheats = pm.GetCheats();
+    std::vector<FileSys::CheatPatch> active_cheats;
+    active_cheats.reserve(cheats.size());
+    std::copy_if(cheats.begin(), cheats.end(), std::back_inserter(active_cheats),
+                 [&active_build_id](const FileSys::CheatPatch& cheat) {
+                     return active_build_id.empty() || cheat.build_id == active_build_id;
+                 });
+
     jobjectArray jpatchArray =
-        env->NewObjectArray(cheats.size(), Common::Android::GetPatchClass(), nullptr);
+        env->NewObjectArray(active_cheats.size(), Common::Android::GetPatchClass(), nullptr);
     int i = 0;
-    for (const auto& cheat : cheats) {
+    for (const auto& cheat : active_cheats) {
         const auto jname = Common::Android::ToJString(env, cheat.name);
         const auto jversion = Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id));
         const auto jpatchProgramId = Common::Android::ToJString(env, std::to_string(program_id));
@@ -927,7 +946,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_reloadCheats(JNIEnv* env, job
     const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
     const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
-    cheat_engine->Reload(pm.CreateCheatList(system.GetApplicationProcessBuildID()));
+    cheat_engine->Reload(pm.CreateCheatList(cheat_engine->GetBuildId()));
     return true;
 }
 

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
-#include <array>
 #include <codecvt>
-#include <cctype>
 #include <locale>
 #include <string>
 #include <string_view>
@@ -31,7 +29,6 @@
 #include "common/detached_tasks.h"
 #include "common/dynamic_library.h"
 #include "common/fs/path_util.h"
-#include "common/hex_util.h"
 #include "common/logging.h"
 #include "common/logging.h"
 #include "common/scm_rev.h"
@@ -83,20 +80,6 @@
 
 #define jconst [[maybe_unused]] const auto
 #define jauto [[maybe_unused]] auto
-
-namespace {
-constexpr std::size_t CHEAT_BUILD_ID_LENGTH = sizeof(u64) * 2;
-
-std::string NormalizeCheatBuildId(std::string build_id) {
-    std::transform(build_id.begin(), build_id.end(), build_id.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-    return build_id;
-}
-
-std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id) {
-    return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
-}
-} // namespace
 
 static EmulationSession s_instance;
 
@@ -880,8 +863,9 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
     const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
     const auto* cheat_engine = system.GetCheatEngine();
-    const auto active_build_id =
-        cheat_engine == nullptr ? std::string{} : GetCheatBuildId(cheat_engine->GetBuildId());
+    const auto active_build_id = cheat_engine == nullptr
+                                     ? std::string{}
+                                     : FileSys::GetCheatBuildId(cheat_engine->GetBuildId());
 
     const auto cheats = pm.GetCheats();
     std::vector<FileSys::CheatPatch> active_cheats;
@@ -917,7 +901,8 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
 void Java_org_citron_citron_1emu_NativeLibrary_setCheatEnabled(JNIEnv* env, jobject jobj,
                                                            jstring jbuildId, jstring jname,
                                                            jboolean jenabled) {
-    const auto build_id = NormalizeCheatBuildId(Common::Android::GetJString(env, jbuildId));
+    const auto build_id =
+        FileSys::NormalizeCheatBuildId(Common::Android::GetJString(env, jbuildId));
     const auto name = Common::Android::GetJString(env, jname);
 
     if (build_id.empty() || name.empty()) {

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -10,6 +10,7 @@
 #include <dlfcn.h>
 #include <functional>
 #include <iterator>
+#include <limits>
 
 #ifdef ARCHITECTURE_arm64
 #include <adrenotools/driver.h>
@@ -56,6 +57,7 @@
 #include "core/hle/service/am/applet_manager.h"
 #include "core/hle/service/am/frontend/applets.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/internal_network/network_interface.h"
 #include "core/loader/loader.h"
 #include "core/memory/cheat_engine.h"
 #include "frontend_common/config.h"
@@ -63,6 +65,8 @@
 #include "hid_core/hid_core.h"
 #include "hid_core/hid_types.h"
 #include "jni/native.h"
+#include "network/network.h"
+#include "network/room_member.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_vulkan/renderer_vulkan.h"
 #include "video_core/vulkan_common/vulkan_instance.h"
@@ -136,6 +140,16 @@ static EmulationSession s_instance;
 
 EmulationSession::EmulationSession() {
     m_vfs = std::make_shared<FileSys::RealVfsFilesystem>();
+    m_network_initialized = m_system.GetRoomNetwork().Init();
+    if (!m_network_initialized) {
+        LOG_ERROR(Network, "Failed to initialize Android room networking");
+    }
+}
+
+EmulationSession::~EmulationSession() {
+    if (m_network_initialized) {
+        m_system.GetRoomNetwork().Shutdown();
+    }
 }
 
 EmulationSession& EmulationSession::GetInstance() {
@@ -212,6 +226,10 @@ bool EmulationSession::IsRunning() const {
 
 bool EmulationSession::IsPaused() const {
     return m_is_running && m_is_paused;
+}
+
+bool EmulationSession::IsNetworkInitialized() const {
+    return m_network_initialized;
 }
 
 const Core::PerfStatsResults& EmulationSession::PerfStats() {
@@ -711,6 +729,54 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_isRunning(JNIEnv* env, jclass
 
 jboolean Java_org_citron_citron_1emu_NativeLibrary_isPaused(JNIEnv* env, jclass clazz) {
     return static_cast<jboolean>(EmulationSession::GetInstance().IsPaused());
+}
+
+jboolean Java_org_citron_citron_1emu_NativeLibrary_connectToRoom(JNIEnv* env, jobject jobj,
+                                                               jstring jnickname, jstring jhost,
+                                                               jint jport) {
+    auto& session = EmulationSession::GetInstance();
+    if (!session.IsNetworkInitialized() || jport <= 0 || jport > std::numeric_limits<u16>::max()) {
+        return false;
+    }
+
+    const auto nickname = Common::Android::GetJString(env, jnickname);
+    const auto host = Common::Android::GetJString(env, jhost);
+    if (nickname.empty() || nickname.size() > 20 || host.empty() || host.size() > 253) {
+        return false;
+    }
+
+    if (!Network::GetSelectedNetworkInterface()) {
+        Network::SelectFirstNetworkInterface();
+    }
+    if (!Network::GetSelectedNetworkInterface()) {
+        return false;
+    }
+
+    const auto room_member = session.System().GetRoomNetwork().GetRoomMember().lock();
+    if (!room_member || room_member->GetState() == Network::RoomMember::State::Joining ||
+        room_member->IsConnected()) {
+        return false;
+    }
+
+    room_member->Join(nickname, host.c_str(), static_cast<u16>(jport));
+    return room_member->IsConnected();
+}
+
+jint Java_org_citron_citron_1emu_NativeLibrary_getRoomConnectionState(JNIEnv* env, jobject jobj) {
+    const auto room_member =
+        EmulationSession::GetInstance().System().GetRoomNetwork().GetRoomMember().lock();
+    if (!room_member) {
+        return static_cast<jint>(Network::RoomMember::State::Uninitialized);
+    }
+    return static_cast<jint>(room_member->GetState());
+}
+
+void Java_org_citron_citron_1emu_NativeLibrary_leaveRoom(JNIEnv* env, jobject jobj) {
+    const auto room_member =
+        EmulationSession::GetInstance().System().GetRoomNetwork().GetRoomMember().lock();
+    if (room_member && room_member->IsConnected()) {
+        room_member->Leave();
+    }
 }
 
 void Java_org_citron_citron_1emu_NativeLibrary_initializeSystem(JNIEnv* env, jclass clazz,

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -914,16 +914,17 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
     const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
     const auto* cheat_engine = system.GetCheatEngine();
-    const auto active_build_id = cheat_engine == nullptr
-                                     ? std::string{}
-                                     : FileSys::GetCheatBuildId(cheat_engine->GetBuildId());
+    if (cheat_engine == nullptr) {
+        return env->NewObjectArray(0, Common::Android::GetPatchClass(), nullptr);
+    }
+    const auto active_build_id = FileSys::GetCheatBuildId(cheat_engine->GetBuildId());
 
     const auto cheats = pm.GetCheats();
     std::vector<FileSys::CheatPatch> active_cheats;
     active_cheats.reserve(cheats.size());
     std::copy_if(cheats.begin(), cheats.end(), std::back_inserter(active_cheats),
                  [&active_build_id](const FileSys::CheatPatch& cheat) {
-                     return active_build_id.empty() || cheat.build_id == active_build_id;
+                     return cheat.build_id == active_build_id;
                  });
 
     jobjectArray jpatchArray =
@@ -931,7 +932,7 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
     int i = 0;
     for (const auto& cheat : active_cheats) {
         const auto jname = Common::Android::ToJString(env, cheat.name);
-        const auto jversion = Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id));
+        const auto jversion = Common::Android::ToJString(env, cheat.source);
         const auto jpatchProgramId = Common::Android::ToJString(env, std::to_string(program_id));
         const auto jbuildId = Common::Android::ToJString(env, cheat.build_id);
         jobject jpatch = env->NewObject(
@@ -950,24 +951,28 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* 
 }
 
 void Java_org_citron_citron_1emu_NativeLibrary_setCheatEnabled(JNIEnv* env, jobject jobj,
-                                                           jstring jbuildId, jstring jname,
-                                                           jboolean jenabled) {
+                                                           jstring jbuildId, jstring jsource,
+                                                           jstring jname, jboolean jenabled) {
     const auto build_id =
         FileSys::NormalizeCheatBuildId(Common::Android::GetJString(env, jbuildId));
+    const auto source = Common::Android::GetJString(env, jsource);
     const auto name = Common::Android::GetJString(env, jname);
 
-    if (build_id.empty() || name.empty()) {
+    if (build_id.empty() || source.empty() || name.empty()) {
         return;
     }
 
     auto& disabled_cheats = Settings::values.disabled_cheats[build_id];
+    const auto cheat_key = FileSys::GetCheatConfigKey(source, name);
     if (jenabled) {
+        disabled_cheats.erase(cheat_key);
+        // Migrate the old build-ID/name-only state when the user changes this cheat.
         disabled_cheats.erase(name);
         if (disabled_cheats.empty()) {
             Settings::values.disabled_cheats.erase(build_id);
         }
     } else {
-        disabled_cheats.insert(name);
+        disabled_cheats.insert(cheat_key);
     }
 }
 
@@ -981,7 +986,8 @@ void Java_org_citron_citron_1emu_NativeLibrary_disableCheatsForAddon(JNIEnv* env
                                    system.GetContentProvider()};
 
     for (const auto& cheat : pm.GetCheatsForMod(addon_name)) {
-        Settings::values.disabled_cheats[cheat.build_id].insert(cheat.name);
+        Settings::values.disabled_cheats[cheat.build_id].insert(
+            FileSys::GetCheatConfigKey(cheat.source, cheat.name));
     }
 }
 

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -81,6 +81,57 @@
 #define jconst [[maybe_unused]] const auto
 #define jauto [[maybe_unused]] auto
 
+namespace {
+
+std::function<bool(size_t, size_t)> CreateLongProgressCallback(JNIEnv* env, jobject jcallback) {
+    if (jcallback == nullptr) {
+        return [](size_t, size_t) { return true; };
+    }
+
+    const auto jlambda_class = env->GetObjectClass(jcallback);
+    const auto jlambda_invoke_method = env->GetMethodID(
+        jlambda_class, "invoke", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+    env->DeleteLocalRef(jlambda_class);
+
+    const auto jlong_class = env->FindClass("java/lang/Long");
+    const auto jlong_value_of =
+        env->GetStaticMethodID(jlong_class, "valueOf", "(J)Ljava/lang/Long;");
+
+    return [env, jcallback, jlambda_invoke_method, jlong_class,
+            jlong_value_of](size_t max, size_t progress) {
+        const auto jmax =
+            env->CallStaticObjectMethod(jlong_class, jlong_value_of, static_cast<jlong>(max));
+        const auto jprogress = env->CallStaticObjectMethod(
+            jlong_class, jlong_value_of, static_cast<jlong>(progress));
+
+        const auto jwas_cancelled =
+            env->CallObjectMethod(jcallback, jlambda_invoke_method, jmax, jprogress);
+
+        if (jmax != nullptr) {
+            env->DeleteLocalRef(jmax);
+        }
+        if (jprogress != nullptr) {
+            env->DeleteLocalRef(jprogress);
+        }
+
+        if (env->ExceptionCheck()) {
+            LOG_ERROR(Frontend, "Progress callback threw an exception; cancelling operation");
+            env->ExceptionClear();
+            return true;
+        }
+
+        if (jwas_cancelled == nullptr) {
+            return false;
+        }
+
+        const bool was_cancelled = Common::Android::GetJBoolean(env, jwas_cancelled);
+        env->DeleteLocalRef(jwas_cancelled);
+        return was_cancelled;
+    };
+}
+
+} // namespace
+
 static EmulationSession s_instance;
 
 EmulationSession::EmulationSession() {
@@ -527,7 +578,7 @@ void Java_org_citron_citron_1emu_NativeLibrary_setAppDirectory(JNIEnv* env, jobj
 }
 
 int Java_org_citron_citron_1emu_NativeLibrary_installFileToNand(JNIEnv* env, jobject instance,
-                                                            jstring j_file, jobject jcallback) {
+                                                              jstring j_file, jobject jcallback) {
     auto jlambdaClass = env->GetObjectClass(jcallback);
     auto jlambdaInvokeMethod = env->GetMethodID(
         jlambdaClass, "invoke", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
@@ -970,21 +1021,21 @@ void Java_org_citron_citron_1emu_NativeLibrary_removeMod(JNIEnv* env, jobject jo
 }
 
 jobjectArray Java_org_citron_citron_1emu_NativeLibrary_verifyInstalledContents(JNIEnv* env,
-                                                                           jobject jobj,
-                                                                           jobject jcallback) {
-    auto jlambdaClass = env->GetObjectClass(jcallback);
-    auto jlambdaInvokeMethod = env->GetMethodID(
-        jlambdaClass, "invoke", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-    const auto callback = [env, jcallback, jlambdaInvokeMethod](size_t max, size_t progress) {
-        auto jwasCancelled = env->CallObjectMethod(jcallback, jlambdaInvokeMethod,
-                                                   Common::Android::ToJDouble(env, max),
-                                                   Common::Android::ToJDouble(env, progress));
-        return Common::Android::GetJBoolean(env, jwasCancelled);
-    };
+                                                                            jobject jobj,
+                                                                            jobject jcallback) {
+    const auto callback = CreateLongProgressCallback(env, jcallback);
 
     auto& session = EmulationSession::GetInstance();
+    auto* content_provider = session.GetContentProvider();
+    if (content_provider == nullptr) {
+        LOG_ERROR(Frontend, "Cannot verify installed contents before content provider is initialized");
+        const auto message =
+            Common::Android::ToJString(env, "Content provider is not initialized");
+        return env->NewObjectArray(1, Common::Android::GetStringClass(), message);
+    }
+
     std::vector<std::string> result = ContentManager::VerifyInstalledContents(
-        session.System(), *session.GetContentProvider(), callback);
+        session.System(), *content_provider, callback);
     jobjectArray jresult = env->NewObjectArray(result.size(), Common::Android::GetStringClass(),
                                                Common::Android::ToJString(env, ""));
     for (size_t i = 0; i < result.size(); ++i) {
@@ -994,30 +1045,14 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_verifyInstalledContents(J
 }
 
 jint Java_org_citron_citron_1emu_NativeLibrary_verifyGameContents(JNIEnv* env, jobject jobj,
-                                                              jstring jpath, jobject jcallback) {
-    auto jlambdaClass = env->GetObjectClass(jcallback);
-    auto jlambdaInvokeMethod = env->GetMethodID(
-        jlambdaClass, "invoke", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-
-    jclass jLongClass = env->FindClass("java/lang/Long");
-    jmethodID jLongValueOf = env->GetStaticMethodID(jLongClass, "valueOf", "(J)Ljava/lang/Long;");
-
-    const auto callback = [env, jcallback, jlambdaInvokeMethod, jLongClass, jLongValueOf](size_t max, size_t progress) {
-        jobject jmax = env->CallStaticObjectMethod(jLongClass, jLongValueOf, static_cast<jlong>(max));
-        jobject jprogress = env->CallStaticObjectMethod(jLongClass, jLongValueOf, static_cast<jlong>(progress));
-
-        jobject jwasCancelled = env->CallObjectMethod(jcallback, jlambdaInvokeMethod, jmax, jprogress);
-        
-        env->DeleteLocalRef(jmax);
-        env->DeleteLocalRef(jprogress);
-
-        if (jwasCancelled == nullptr) {
-            return false;
-        }
-
-        return Common::Android::GetJBoolean(env, jwasCancelled);
-    };
+                                                               jstring jpath, jobject jcallback) {
+    const auto callback = CreateLongProgressCallback(env, jcallback);
     auto& session = EmulationSession::GetInstance();
+    if (session.System().GetFilesystem() == nullptr) {
+        LOG_ERROR(Frontend, "Cannot verify game contents before filesystem is initialized");
+        return static_cast<jint>(ContentManager::GameVerificationResult::NotImplemented);
+    }
+
     return static_cast<jint>(ContentManager::VerifyGameContents(
         session.System(), Common::Android::GetJString(env, jpath), callback));
 }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -920,6 +920,20 @@ void Java_org_citron_citron_1emu_NativeLibrary_setCheatEnabled(JNIEnv* env, jobj
     }
 }
 
+void Java_org_citron_citron_1emu_NativeLibrary_disableCheatsForAddon(JNIEnv* env, jobject jobj,
+                                                                  jstring jprogramId,
+                                                                  jstring jaddonName) {
+    auto& system = EmulationSession::GetInstance().System();
+    const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    const auto addon_name = Common::Android::GetJString(env, jaddonName);
+    const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
+
+    for (const auto& cheat : pm.GetCheatsForMod(addon_name)) {
+        Settings::values.disabled_cheats[cheat.build_id].insert(cheat.name);
+    }
+}
+
 jboolean Java_org_citron_citron_1emu_NativeLibrary_reloadCheats(JNIEnv* env, jobject jobj,
                                                             jstring jprogramId) {
     auto& system = EmulationSession::GetInstance().System();

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright 2025 Citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <codecvt>
+#include <cctype>
 #include <locale>
 #include <string>
 #include <string_view>
@@ -77,6 +79,14 @@
 
 #define jconst [[maybe_unused]] const auto
 #define jauto [[maybe_unused]] auto
+
+namespace {
+std::string NormalizeCheatBuildId(std::string build_id) {
+    std::transform(build_id.begin(), build_id.end(), build_id.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return build_id;
+}
+} // namespace
 
 static EmulationSession s_instance;
 
@@ -849,6 +859,69 @@ jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getPatchesForFile(JNIEnv*
         ++i;
     }
     return jpatchArray;
+}
+
+jobjectArray Java_org_citron_citron_1emu_NativeLibrary_getCheatsForFile(JNIEnv* env, jobject jobj,
+                                                                    jstring jpath,
+                                                                    jstring jprogramId) {
+    (void)jpath;
+    auto& system = EmulationSession::GetInstance().System();
+    const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
+
+    const auto cheats = pm.GetCheats();
+    jobjectArray jpatchArray =
+        env->NewObjectArray(cheats.size(), Common::Android::GetPatchClass(), nullptr);
+    int i = 0;
+    for (const auto& cheat : cheats) {
+        jobject jpatch = env->NewObject(
+            Common::Android::GetPatchClass(), Common::Android::GetPatchConstructor(), cheat.enabled,
+            Common::Android::ToJString(env, cheat.name),
+            Common::Android::ToJString(env, fmt::format("Cheat {}", cheat.build_id)),
+            static_cast<jint>(FileSys::PatchType::Cheat),
+            Common::Android::ToJString(env, std::to_string(program_id)),
+            Common::Android::ToJString(env, cheat.build_id));
+        env->SetObjectArrayElement(jpatchArray, i, jpatch);
+        ++i;
+    }
+    return jpatchArray;
+}
+
+void Java_org_citron_citron_1emu_NativeLibrary_setCheatEnabled(JNIEnv* env, jobject jobj,
+                                                           jstring jbuildId, jstring jname,
+                                                           jboolean jenabled) {
+    const auto build_id = NormalizeCheatBuildId(Common::Android::GetJString(env, jbuildId));
+    const auto name = Common::Android::GetJString(env, jname);
+
+    if (build_id.empty() || name.empty()) {
+        return;
+    }
+
+    auto& disabled_cheats = Settings::values.disabled_cheats[build_id];
+    if (jenabled) {
+        disabled_cheats.erase(name);
+        if (disabled_cheats.empty()) {
+            Settings::values.disabled_cheats.erase(build_id);
+        }
+    } else {
+        disabled_cheats.insert(name);
+    }
+}
+
+jboolean Java_org_citron_citron_1emu_NativeLibrary_reloadCheats(JNIEnv* env, jobject jobj,
+                                                            jstring jprogramId) {
+    auto& system = EmulationSession::GetInstance().System();
+    auto* cheat_engine = system.GetCheatEngine();
+    if (cheat_engine == nullptr) {
+        return false;
+    }
+
+    const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
+    cheat_engine->Reload(pm.CreateCheatList(system.GetApplicationProcessBuildID()));
+    return true;
 }
 
 void Java_org_citron_citron_1emu_NativeLibrary_removeUpdate(JNIEnv* env, jobject jobj,

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -18,7 +18,7 @@
 class EmulationSession final {
 public:
     explicit EmulationSession();
-    ~EmulationSession() = default;
+    ~EmulationSession();
 
     static EmulationSession& GetInstance();
     const Core::System& System() const;
@@ -38,6 +38,7 @@ public:
 
     bool IsRunning() const;
     bool IsPaused() const;
+    bool IsNetworkInitialized() const;
     void PauseEmulation();
     void UnPauseEmulation();
     void HaltEmulation();
@@ -82,6 +83,7 @@ private:
     Core::SystemResultStatus m_load_result{Core::SystemResultStatus::ErrorNotInitialized};
     std::atomic<bool> m_is_running = false;
     std::atomic<bool> m_is_paused = false;
+    bool m_network_initialized{};
     Common::Android::SoftwareKeyboard::AndroidKeyboard* m_software_keyboard{};
     std::unique_ptr<FileSys::ManualContentProvider> m_manual_provider;
     int m_applet_id{1};

--- a/src/android/app/src/main/res/layout/dialog_direct_connect.xml
+++ b/src/android/app/src/main/res/layout/dialog_direct_connect.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="8dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/direct_connect_host">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/direct_connect_host"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textUri"
+            android:maxLength="253"
+            android:singleLine="true" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/direct_connect_port">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/direct_connect_port"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="5"
+            android:singleLine="true" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/direct_connect_nickname">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/direct_connect_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPersonName"
+            android:maxLength="20"
+            android:singleLine="true" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/direct_connect_status"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:visibility="gone"
+        app:lineHeight="20dp" />
+
+</LinearLayout>

--- a/src/android/app/src/main/res/menu/menu_in_game.xml
+++ b/src/android/app/src/main/res/menu/menu_in_game.xml
@@ -27,6 +27,11 @@
         android:title="@string/emulation_input_overlay" />
 
     <item
+        android:id="@+id/menu_cheats"
+        android:icon="@drawable/ic_code"
+        android:title="@string/emulation_cheats" />
+
+    <item
         android:id="@+id/menu_lock_drawer"
         android:icon="@drawable/ic_unlock"
         android:title="@string/emulation_input_overlay" />

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -69,8 +69,8 @@
     </string-array>
 
     <integer-array name="rendererApiValues">
+        <item>0</item>
         <item>1</item>
-        <item>2</item>
     </integer-array>
 
     <string-array name="rendererAccuracyNames">

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -447,6 +447,7 @@
     <string name="airplane_mode_description">Disable all network functionality, similar to Nintendo Switch airplane mode</string>
     <string name="direct_connect">Direct Connect</string>
     <string name="direct_connect_description">Join an existing multiplayer room by address</string>
+    <string name="direct_connect_status">Status: %1$s</string>
     <string name="direct_connect_connect">Connect</string>
     <string name="direct_connect_host">Server address</string>
     <string name="direct_connect_port">Port</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -564,6 +564,8 @@
     <string name="emulation_pause">Pause emulation</string>
     <string name="emulation_unpause">Unpause emulation</string>
     <string name="emulation_input_overlay">Overlay options</string>
+    <string name="emulation_cheats">Cheats</string>
+    <string name="emulation_cheats_empty">No cheats are available for this game.</string>
     <string name="touchscreen">Touchscreen</string>
     <string name="lock_drawer">Lock drawer</string>
     <string name="unlock_drawer">Unlock drawer</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -445,6 +445,18 @@
     <string name="network_settings_header">Network Settings</string>
     <string name="airplane_mode">Airplane Mode</string>
     <string name="airplane_mode_description">Disable all network functionality, similar to Nintendo Switch airplane mode</string>
+    <string name="direct_connect">Direct Connect</string>
+    <string name="direct_connect_description">Join an existing multiplayer room by address</string>
+    <string name="direct_connect_connect">Connect</string>
+    <string name="direct_connect_host">Server address</string>
+    <string name="direct_connect_port">Port</string>
+    <string name="direct_connect_nickname">Nickname</string>
+    <string name="direct_connect_connecting">Connecting…</string>
+    <string name="direct_connect_connected">Connected</string>
+    <string name="direct_connect_disconnected">Disconnected</string>
+    <string name="direct_connect_failed">Unable to connect to the room</string>
+    <string name="direct_connect_invalid_input">Enter a server address, port, and 4-20 character nickname.</string>
+    <string name="direct_connect_disconnect">Disconnect</string>
 
     <!-- Zep Zone Headers -->
     <string name="memory_layout_header">Memory Layout</string>

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -28,8 +28,10 @@
 #endif // ^^^ Linux ^^^
 
 #include <atomic>
+#include <limits>
 #include <mutex>
 #include <random>
+#include <stdexcept>
 
 #include "common/alignment.h"
 #include "common/assert.h"
@@ -41,6 +43,32 @@ namespace Common {
 
 constexpr size_t PageAlignment = 0x1000;
 constexpr size_t HugePageSize = 0x200000;
+
+[[noreturn]] void CrashHostMemoryInvariant(const char* operation, const char* reason,
+                                           size_t virtual_offset, size_t host_offset,
+                                           size_t length, size_t virtual_size,
+                                           size_t backing_size, MemoryPermission perms,
+                                           u8* virtual_base, size_t virtual_base_offset) {
+    const bool virtual_overflow =
+        length > std::numeric_limits<size_t>::max() - virtual_offset;
+    const bool host_overflow = length > std::numeric_limits<size_t>::max() - host_offset;
+    const size_t virtual_end =
+        virtual_overflow ? std::numeric_limits<size_t>::max() : virtual_offset + length;
+    const size_t host_end =
+        host_overflow ? std::numeric_limits<size_t>::max() : host_offset + length;
+
+    LOG_CRITICAL(HW_Memory,
+                 "HostMemory::{} invariant failed: reason={} virtual_offset={:#x} "
+                 "host_offset={:#x} length={:#x} virtual_end={:#x} host_end={:#x} "
+                 "virtual_overflow={} host_overflow={} virtual_size={:#x} backing_size={:#x} "
+                 "perms={:#x} virtual_base={} virtual_base_offset={:#x}",
+                 operation, reason, virtual_offset, host_offset, length, virtual_end, host_end,
+                 virtual_overflow, host_overflow, virtual_size, backing_size, static_cast<u32>(perms),
+                 static_cast<void*>(virtual_base), virtual_base_offset);
+    Common::Log::Stop();
+    Crash();
+    throw std::runtime_error("HostMemory invariant failed");
+}
 
 #ifdef _WIN32
 
@@ -693,11 +721,33 @@ HostMemory& HostMemory::operator=(HostMemory&&) noexcept = default;
 
 void HostMemory::Map(size_t virtual_offset, size_t host_offset, size_t length,
                      MemoryPermission perms, bool separate_heap) {
-    ASSERT(virtual_offset % PageAlignment == 0);
-    ASSERT(host_offset % PageAlignment == 0);
-    ASSERT(length % PageAlignment == 0);
-    ASSERT(virtual_offset + length <= virtual_size);
-    ASSERT(host_offset + length <= backing_size);
+    if (virtual_offset % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Map", "virtual_offset is not page aligned", virtual_offset,
+                                 host_offset, length, virtual_size, backing_size, perms, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (host_offset % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Map", "host_offset is not page aligned", virtual_offset,
+                                 host_offset, length, virtual_size, backing_size, perms, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Map", "length is not page aligned", virtual_offset, host_offset,
+                                 length, virtual_size, backing_size, perms, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length > std::numeric_limits<size_t>::max() - virtual_offset ||
+        virtual_offset + length > virtual_size) [[unlikely]] {
+        CrashHostMemoryInvariant("Map", "virtual range exceeds virtual_size", virtual_offset,
+                                 host_offset, length, virtual_size, backing_size, perms, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length > std::numeric_limits<size_t>::max() - host_offset ||
+        host_offset + length > backing_size) [[unlikely]] {
+        CrashHostMemoryInvariant("Map", "host range exceeds backing_size", virtual_offset,
+                                 host_offset, length, virtual_size, backing_size, perms, virtual_base,
+                                 virtual_base_offset);
+    }
     if (length == 0 || !virtual_base || !impl) {
         return;
     }
@@ -705,9 +755,21 @@ void HostMemory::Map(size_t virtual_offset, size_t host_offset, size_t length,
 }
 
 void HostMemory::Unmap(size_t virtual_offset, size_t length, bool separate_heap) {
-    ASSERT(virtual_offset % PageAlignment == 0);
-    ASSERT(length % PageAlignment == 0);
-    ASSERT(virtual_offset + length <= virtual_size);
+    if (virtual_offset % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Unmap", "virtual_offset is not page aligned", virtual_offset, 0,
+                                 length, virtual_size, backing_size, {}, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Unmap", "length is not page aligned", virtual_offset, 0, length,
+                                 virtual_size, backing_size, {}, virtual_base, virtual_base_offset);
+    }
+    if (length > std::numeric_limits<size_t>::max() - virtual_offset ||
+        virtual_offset + length > virtual_size) [[unlikely]] {
+        CrashHostMemoryInvariant("Unmap", "virtual range exceeds virtual_size", virtual_offset, 0,
+                                 length, virtual_size, backing_size, {}, virtual_base,
+                                 virtual_base_offset);
+    }
     if (length == 0 || !virtual_base || !impl) {
         return;
     }
@@ -715,9 +777,22 @@ void HostMemory::Unmap(size_t virtual_offset, size_t length, bool separate_heap)
 }
 
 void HostMemory::Protect(size_t virtual_offset, size_t length, MemoryPermission perm) {
-    ASSERT(virtual_offset % PageAlignment == 0);
-    ASSERT(length % PageAlignment == 0);
-    ASSERT(virtual_offset + length <= virtual_size);
+    if (virtual_offset % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Protect", "virtual_offset is not page aligned", virtual_offset,
+                                 0, length, virtual_size, backing_size, perm, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length % PageAlignment != 0) [[unlikely]] {
+        CrashHostMemoryInvariant("Protect", "length is not page aligned", virtual_offset, 0,
+                                 length, virtual_size, backing_size, perm, virtual_base,
+                                 virtual_base_offset);
+    }
+    if (length > std::numeric_limits<size_t>::max() - virtual_offset ||
+        virtual_offset + length > virtual_size) [[unlikely]] {
+        CrashHostMemoryInvariant("Protect", "virtual range exceeds virtual_size", virtual_offset,
+                                 0, length, virtual_size, backing_size, perm, virtual_base,
+                                 virtual_base_offset);
+    }
     if (length == 0 || !virtual_base || !impl) {
         return;
     }

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -27,6 +27,7 @@
 
 #endif // ^^^ Linux ^^^
 
+#include <atomic>
 #include <mutex>
 #include <random>
 
@@ -483,6 +484,10 @@ public:
     }
 
     void Map(size_t virtual_offset, size_t host_offset, size_t length, MemoryPermission perms) {
+        const u64 map_id = map_count.fetch_add(1, std::memory_order_relaxed) + 1;
+        const size_t requested_virtual_offset = virtual_offset;
+        const size_t requested_length = length;
+
         // Intersect the range with our address space.
         AdjustMap(&virtual_offset, &length);
 
@@ -505,10 +510,30 @@ public:
 
         void* ret = mmap(virtual_base + virtual_offset, length, flags, MAP_SHARED | MAP_FIXED, fd,
                          host_offset);
-        ASSERT_MSG(ret != MAP_FAILED, "mmap failed: {}", strerror(errno));
+        if (ret == MAP_FAILED) [[unlikely]] {
+            const int saved_errno = errno;
+            LOG_CRITICAL(HW_Memory,
+                         "HostMemory::Map mmap failed: error={} ({}) map_id={} unmap_count={} "
+                         "requested_virtual_offset={:#x} adjusted_virtual_offset={:#x} "
+                         "host_offset={:#x} requested_length={:#x} adjusted_length={:#x} "
+                         "perms={:#x} prot_flags={:#x} fd={} virtual_base={} target={} "
+                         "backing_size={:#x} virtual_size={:#x}",
+                         saved_errno, strerror(saved_errno), map_id,
+                         unmap_count.load(std::memory_order_relaxed), requested_virtual_offset,
+                         virtual_offset, host_offset, requested_length, length,
+                         static_cast<u32>(perms), flags, fd, static_cast<void*>(virtual_base),
+                         static_cast<void*>(virtual_base + virtual_offset), backing_size,
+                         virtual_size);
+            Common::Log::Stop();
+            Crash();
+        }
     }
 
     void Unmap(size_t virtual_offset, size_t length) {
+        const u64 unmap_id = unmap_count.fetch_add(1, std::memory_order_relaxed) + 1;
+        const size_t requested_virtual_offset = virtual_offset;
+        const size_t requested_length = length;
+
         // The method name is wrong. We're still talking about the virtual range.
         // We don't want to unmap, we want to reserve this memory.
 
@@ -521,7 +546,21 @@ public:
 
         void* ret = mmap(merged_pointer, merged_size, PROT_NONE,
                          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
-        ASSERT_MSG(ret != MAP_FAILED, "mmap failed: {}", strerror(errno));
+        if (ret == MAP_FAILED) [[unlikely]] {
+            const int saved_errno = errno;
+            LOG_CRITICAL(HW_Memory,
+                         "HostMemory::Unmap reserve mmap failed: error={} ({}) map_count={} "
+                         "unmap_id={} requested_virtual_offset={:#x} adjusted_virtual_offset={:#x} "
+                         "requested_length={:#x} adjusted_length={:#x} merged_pointer={} "
+                         "merged_size={:#x} virtual_base={} backing_size={:#x} virtual_size={:#x}",
+                         saved_errno, strerror(saved_errno),
+                         map_count.load(std::memory_order_relaxed), unmap_id,
+                         requested_virtual_offset, virtual_offset, requested_length, length,
+                         merged_pointer, merged_size, static_cast<void*>(virtual_base), backing_size,
+                         virtual_size);
+            Common::Log::Stop();
+            Crash();
+        }
     }
 
     void Protect(size_t virtual_offset, size_t length, bool read, bool write, bool execute) {
@@ -597,6 +636,8 @@ private:
 
     int fd{-1}; // memfd file descriptor, -1 is the error value of memfd_create
     FreeRegionManager free_manager{};
+    std::atomic<u64> map_count{0};
+    std::atomic<u64> unmap_count{0};
 };
 
 #else // ^^^ Linux ^^^ vvv Generic vvv

--- a/src/common/host_memory.h
+++ b/src/common/host_memory.h
@@ -65,6 +65,10 @@ public:
         return virtual_base;
     }
 
+    [[nodiscard]] size_t VirtualSize() const noexcept {
+        return virtual_size;
+    }
+
     bool IsInVirtualRange(void* address) const noexcept {
         return address >= virtual_base && address < virtual_base + virtual_size;
     }

--- a/src/core/arm/nce/patcher.cpp
+++ b/src/core/arm/nce/patcher.cpp
@@ -292,10 +292,10 @@ size_t Patcher::GetSectionSize() const noexcept {
 
 bool Patcher::CanRelocateBranches() const noexcept {
     if (modules.empty() || mode == PatchMode::None) {
-        LOG_CRITICAL(Core_ARM,
-                     "NCE branch relocation preflight called without patched modules: mode={}, "
-                     "modules={}, total_program_size={:#x}",
-                     mode, modules.size(), total_program_size);
+        LOG_WARNING(Core_ARM,
+                    "NCE branch relocation preflight called without patched modules: mode={}, "
+                    "modules={}, total_program_size={:#x}",
+                    mode, modules.size(), total_program_size);
         return false;
     }
 
@@ -304,27 +304,27 @@ bool Patcher::CanRelocateBranches() const noexcept {
     const auto LogInvalidBranch = [&](const char* kind, size_t module_index,
                                       size_t remaining_program_size,
                                       const Relocation& rel, ptrdiff_t branch_offset) {
-        LOG_CRITICAL(Core_ARM,
-                     "NCE branch relocation preflight failed: kind={}, mode={}, "
-                     "relocate_module={}, modules={}, branch_offset={:#x}, valid_range=[{:#x}, "
-                     "{:#x}], patch_offset={:#x}, module_offset={:#x}, patch_size={:#x}, "
-                     "image_size={:#x}, total_program_size={:#x}",
-                     kind, mode, module_index, modules.size(), branch_offset,
-                     MinRelativeBranchOffset, MaxRelativeBranchOffset, rel.patch_offset,
-                     rel.module_offset, patch_size, modules[module_index].image_size,
-                     remaining_program_size);
+        LOG_WARNING(Core_ARM,
+                    "NCE branch relocation preflight failed: kind={}, mode={}, "
+                    "relocate_module={}, modules={}, branch_offset={:#x}, valid_range=[{:#x}, "
+                    "{:#x}], patch_offset={:#x}, module_offset={:#x}, patch_size={:#x}, "
+                    "image_size={:#x}, total_program_size={:#x}",
+                    kind, mode, module_index, modules.size(), branch_offset,
+                    MinRelativeBranchOffset, MaxRelativeBranchOffset, rel.patch_offset,
+                    rel.module_offset, patch_size, modules[module_index].image_size,
+                    remaining_program_size);
     };
 
     size_t remaining_program_size = total_program_size;
     for (size_t module_index = 0; module_index < modules.size(); module_index++) {
         const auto& patch = modules[module_index];
         if (patch.image_size > remaining_program_size) {
-            LOG_CRITICAL(Core_ARM,
-                         "NCE branch relocation preflight size state mismatch: mode={}, "
-                         "relocate_module={}, modules={}, image_size={:#x}, "
-                         "remaining_program_size={:#x}, total_program_size={:#x}",
-                         mode, module_index, modules.size(), patch.image_size,
-                         remaining_program_size, total_program_size);
+            LOG_WARNING(Core_ARM,
+                        "NCE branch relocation preflight size state mismatch: mode={}, "
+                        "relocate_module={}, modules={}, image_size={:#x}, "
+                        "remaining_program_size={:#x}, total_program_size={:#x}",
+                        mode, module_index, modules.size(), patch.image_size,
+                        remaining_program_size, total_program_size);
             return false;
         }
 
@@ -354,10 +354,10 @@ bool Patcher::CanRelocateBranches() const noexcept {
     }
 
     if (remaining_program_size != 0) {
-        LOG_CRITICAL(Core_ARM,
-                     "NCE branch relocation preflight size state mismatch after scan: mode={}, "
-                     "modules={}, remaining_program_size={:#x}, total_program_size={:#x}",
-                     mode, modules.size(), remaining_program_size, total_program_size);
+        LOG_WARNING(Core_ARM,
+                    "NCE branch relocation preflight size state mismatch after scan: mode={}, "
+                    "modules={}, remaining_program_size={:#x}, total_program_size={:#x}",
+                    mode, modules.size(), remaining_program_size, total_program_size);
         return false;
     }
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -216,6 +216,33 @@ std::vector<VirtualDir> GetEnabledModsList(
     return mods;
 }
 
+std::vector<VirtualDir> GetCheatModsList(
+    u64 title_id, const Service::FileSystem::FileSystemController& fs_controller) {
+    std::vector<VirtualDir> mods;
+    const auto load_dir = fs_controller.GetModificationLoadRoot(title_id);
+    if (!load_dir) {
+        return mods;
+    }
+
+    for (const auto& top_dir : load_dir->GetSubdirectories()) {
+        if (!top_dir) {
+            continue;
+        }
+
+        if (FindSubdirectoryCaseless(top_dir, "cheats") != nullptr) {
+            mods.push_back(top_dir);
+            continue;
+        }
+
+        for (const auto& sub_dir : top_dir->GetSubdirectories()) {
+            if (sub_dir && FindSubdirectoryCaseless(sub_dir, "cheats") != nullptr) {
+                mods.push_back(sub_dir);
+            }
+        }
+    }
+    return mods;
+}
+
 bool IsDirValidAndNonEmpty(const VirtualDir& dir) {
     return dir != nullptr && (!dir->GetFiles().empty() || !dir->GetSubdirectories().empty());
 }
@@ -434,7 +461,7 @@ bool PatchManager::HasNSOPatch(const BuildID& build_id_, std::string_view name) 
 std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
     const BuildID& build_id_) const {
 
-    std::vector<VirtualDir> patch_dirs = GetEnabledModsList(title_id, fs_controller);
+    std::vector<VirtualDir> patch_dirs = GetCheatModsList(title_id, fs_controller);
     const auto build_id = GetCheatBuildId(build_id_);
 
     std::sort(patch_dirs.begin(), patch_dirs.end(),
@@ -923,7 +950,7 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
 }
 
 std::vector<CheatPatch> PatchManager::GetCheats() const {
-    std::vector<VirtualDir> patch_dirs = GetEnabledModsList(title_id, fs_controller);
+    std::vector<VirtualDir> patch_dirs = GetCheatModsList(title_id, fs_controller);
     std::sort(patch_dirs.begin(), patch_dirs.end(),
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstring>
 #include <map>
@@ -54,6 +55,7 @@ const ContentProviderUnion* GetUnionProvider(const ContentProvider& p) {
 }
 
 constexpr u32 SINGLE_BYTE_MODULUS = 0x100;
+constexpr std::size_t CHEAT_BUILD_ID_LENGTH = sizeof(u64) * 2;
 
 enum class TitleVersionFormat : u8 {
     ThreeElements, ///< vX.Y.Z
@@ -100,7 +102,7 @@ VirtualDir FindSubdirectoryCaseless(const VirtualDir dir, std::string_view name)
 std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
     u64 title_id, const PatchManager::BuildID& build_id_, const VirtualDir& base_path, bool upper) {
     const auto build_id_raw = Common::HexToString(build_id_, upper);
-    const auto build_id = build_id_raw.substr(0, sizeof(u64) * 2);
+    const auto build_id = build_id_raw.substr(0, CHEAT_BUILD_ID_LENGTH);
     const auto file = base_path->GetFile(fmt::format("{}.txt", build_id));
     if (file == nullptr) {
         LOG_INFO(Common_Filesystem, "No cheats file found for title_id={:016X}, build_id={}",
@@ -115,6 +117,38 @@ std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
     }
     const Core::Memory::TextCheatParser parser;
     return parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
+}
+
+std::string GetCheatBuildId(const PatchManager::BuildID& build_id) {
+    return Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH);
+}
+
+std::string NormalizeCheatBuildId(std::string build_id) {
+    std::transform(build_id.begin(), build_id.end(), build_id.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return build_id;
+}
+
+std::string GetCheatName(const Core::Memory::CheatEntry& cheat) {
+    const auto& name = cheat.definition.readable_name;
+    const auto end = std::find(name.cbegin(), name.cend(), '\0');
+    const auto length = static_cast<std::size_t>(std::distance(name.cbegin(), end));
+    return std::string(name.data(), length);
+}
+
+void ApplyDisabledCheats(std::vector<Core::Memory::CheatEntry>& cheats,
+                         const std::string& build_id) {
+    const auto disabled_it = Settings::values.disabled_cheats.find(build_id);
+    if (disabled_it == Settings::values.disabled_cheats.end()) {
+        return;
+    }
+
+    const auto& disabled = disabled_it->second;
+    for (auto& cheat : cheats) {
+        if (disabled.contains(GetCheatName(cheat))) {
+            cheat.enabled = false;
+        }
+    }
 }
 
 void AppendCommaIfNotEmpty(std::string& to, std::string_view with) {
@@ -392,6 +426,7 @@ std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
     const BuildID& build_id_) const {
 
     std::vector<VirtualDir> patch_dirs = GetEnabledModsList(title_id, fs_controller);
+    const auto build_id = GetCheatBuildId(build_id_);
 
     std::sort(patch_dirs.begin(), patch_dirs.end(),
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
@@ -401,11 +436,15 @@ std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
         auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
         if (cheats_dir != nullptr) {
             if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, true)) {
-                std::copy(res->begin(), res->end(), std::back_inserter(out));
+                auto cheats = *res;
+                ApplyDisabledCheats(cheats, build_id);
+                std::copy(cheats.begin(), cheats.end(), std::back_inserter(out));
                 continue;
             }
             if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, false)) {
-                std::copy(res->begin(), res->end(), std::back_inserter(out));
+                auto cheats = *res;
+                ApplyDisabledCheats(cheats, build_id);
+                std::copy(cheats.begin(), cheats.end(), std::back_inserter(out));
             }
         }
     }
@@ -867,6 +906,70 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
                     global_tool.title_id = title_id;
                     out.push_back(std::move(global_tool));
                 }
+            }
+        }
+    }
+
+    return out;
+}
+
+std::vector<CheatPatch> PatchManager::GetCheats() const {
+    std::vector<VirtualDir> patch_dirs = GetEnabledModsList(title_id, fs_controller);
+    std::sort(patch_dirs.begin(), patch_dirs.end(),
+              [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
+
+    std::vector<CheatPatch> out;
+    const Core::Memory::TextCheatParser parser;
+    for (const auto& subdir : patch_dirs) {
+        const auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
+        if (cheats_dir == nullptr) {
+            continue;
+        }
+
+        auto files = cheats_dir->GetFiles();
+        std::sort(files.begin(), files.end(), [](const VirtualFile& l, const VirtualFile& r) {
+            return l->GetName() < r->GetName();
+        });
+
+        for (const auto& file : files) {
+            if (file->GetExtension() != "txt") {
+                continue;
+            }
+
+            auto build_id = file->GetName();
+            const auto extension_pos = build_id.find_last_of('.');
+            if (extension_pos != std::string::npos) {
+                build_id = build_id.substr(0, extension_pos);
+            }
+            if (build_id.size() < CHEAT_BUILD_ID_LENGTH) {
+                continue;
+            }
+            build_id = NormalizeCheatBuildId(build_id.substr(0, CHEAT_BUILD_ID_LENGTH));
+
+            std::vector<u8> data(file->GetSize());
+            if (file->Read(data.data(), data.size()) != data.size()) {
+                LOG_INFO(Common_Filesystem,
+                         "Failed to read cheats file for title_id={:016X}, build_id={}", title_id,
+                         build_id);
+                continue;
+            }
+
+            auto cheats =
+                parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
+            ApplyDisabledCheats(cheats, build_id);
+            for (const auto& cheat : cheats) {
+                if (cheat.definition.num_opcodes == 0) {
+                    continue;
+                }
+
+                const auto cheat_name = GetCheatName(cheat);
+                if (cheat_name.empty()) {
+                    continue;
+                }
+
+                out.push_back({.enabled = cheat.enabled,
+                               .name = cheat_name,
+                               .build_id = build_id});
             }
         }
     }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -119,16 +119,6 @@ std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
     return parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
 }
 
-std::string NormalizeCheatBuildId(std::string build_id) {
-    std::transform(build_id.begin(), build_id.end(), build_id.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-    return build_id;
-}
-
-std::string GetCheatBuildId(const PatchManager::BuildID& build_id) {
-    return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
-}
-
 std::string GetCheatName(const Core::Memory::CheatEntry& cheat) {
     const auto& name = cheat.definition.readable_name;
     const auto end = std::find(name.cbegin(), name.cend(), '\0');
@@ -247,6 +237,16 @@ bool IsDirValidAndNonEmpty(const VirtualDir& dir) {
     return dir != nullptr && (!dir->GetFiles().empty() || !dir->GetSubdirectories().empty());
 }
 } // Anonymous namespace
+
+std::string NormalizeCheatBuildId(std::string build_id) {
+    std::transform(build_id.begin(), build_id.end(), build_id.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return build_id;
+}
+
+std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id) {
+    return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
+}
 
 
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -236,6 +236,58 @@ std::vector<VirtualDir> GetCheatModsList(
 bool IsDirValidAndNonEmpty(const VirtualDir& dir) {
     return dir != nullptr && (!dir->GetFiles().empty() || !dir->GetSubdirectories().empty());
 }
+
+void AppendCheatsFromMod(std::vector<CheatPatch>& out, const VirtualDir& mod_dir) {
+    const auto cheats_dir = FindSubdirectoryCaseless(mod_dir, "cheats");
+    if (cheats_dir == nullptr) {
+        return;
+    }
+
+    const Core::Memory::TextCheatParser parser;
+    auto files = cheats_dir->GetFiles();
+    std::sort(files.begin(), files.end(), [](const VirtualFile& l, const VirtualFile& r) {
+        return l->GetName() < r->GetName();
+    });
+
+    for (const auto& file : files) {
+        if (file->GetExtension() != "txt") {
+            continue;
+        }
+
+        auto build_id = file->GetName();
+        const auto extension_pos = build_id.find_last_of('.');
+        if (extension_pos != std::string::npos) {
+            build_id = build_id.substr(0, extension_pos);
+        }
+        if (build_id.size() < CHEAT_BUILD_ID_LENGTH) {
+            continue;
+        }
+        build_id = NormalizeCheatBuildId(build_id.substr(0, CHEAT_BUILD_ID_LENGTH));
+
+        std::vector<u8> data(file->GetSize());
+        if (file->Read(data.data(), data.size()) != data.size()) {
+            LOG_INFO(Common_Filesystem, "Failed to read cheats file, build_id={}", build_id);
+            continue;
+        }
+
+        auto cheats =
+            parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
+        ApplyDisabledCheats(cheats, build_id);
+        for (const auto& cheat : cheats) {
+            if (cheat.definition.num_opcodes == 0) {
+                continue;
+            }
+
+            const auto cheat_name = GetCheatName(cheat);
+            if (cheat_name.empty()) {
+                continue;
+            }
+
+            out.push_back(
+                {.enabled = cheat.enabled, .name = cheat_name, .build_id = build_id});
+        }
+    }
+}
 } // Anonymous namespace
 
 std::string NormalizeCheatBuildId(std::string build_id) {
@@ -955,61 +1007,24 @@ std::vector<CheatPatch> PatchManager::GetCheats() const {
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
 
     std::vector<CheatPatch> out;
-    const Core::Memory::TextCheatParser parser;
     for (const auto& subdir : patch_dirs) {
-        const auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
-        if (cheats_dir == nullptr) {
-            continue;
-        }
-
-        auto files = cheats_dir->GetFiles();
-        std::sort(files.begin(), files.end(), [](const VirtualFile& l, const VirtualFile& r) {
-            return l->GetName() < r->GetName();
-        });
-
-        for (const auto& file : files) {
-            if (file->GetExtension() != "txt") {
-                continue;
-            }
-
-            auto build_id = file->GetName();
-            const auto extension_pos = build_id.find_last_of('.');
-            if (extension_pos != std::string::npos) {
-                build_id = build_id.substr(0, extension_pos);
-            }
-            if (build_id.size() < CHEAT_BUILD_ID_LENGTH) {
-                continue;
-            }
-            build_id = NormalizeCheatBuildId(build_id.substr(0, CHEAT_BUILD_ID_LENGTH));
-
-            std::vector<u8> data(file->GetSize());
-            if (file->Read(data.data(), data.size()) != data.size()) {
-                LOG_INFO(Common_Filesystem,
-                         "Failed to read cheats file for title_id={:016X}, build_id={}", title_id,
-                         build_id);
-                continue;
-            }
-
-            auto cheats =
-                parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
-            ApplyDisabledCheats(cheats, build_id);
-            for (const auto& cheat : cheats) {
-                if (cheat.definition.num_opcodes == 0) {
-                    continue;
-                }
-
-                const auto cheat_name = GetCheatName(cheat);
-                if (cheat_name.empty()) {
-                    continue;
-                }
-
-                out.push_back({.enabled = cheat.enabled,
-                               .name = cheat_name,
-                               .build_id = build_id});
-            }
-        }
+        AppendCheatsFromMod(out, subdir);
     }
 
+    return out;
+}
+
+std::vector<CheatPatch> PatchManager::GetCheatsForMod(std::string_view mod_name) const {
+    std::vector<CheatPatch> out;
+    const auto load_dir = fs_controller.GetModificationLoadRoot(title_id);
+    if (!load_dir) {
+        return out;
+    }
+
+    const auto mod_dir = load_dir->GetSubdirectory(mod_name);
+    if (mod_dir != nullptr) {
+        AppendCheatsFromMod(out, mod_dir);
+    }
     return out;
 }
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -119,14 +119,14 @@ std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
     return parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
 }
 
-std::string GetCheatBuildId(const PatchManager::BuildID& build_id) {
-    return Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH);
-}
-
 std::string NormalizeCheatBuildId(std::string build_id) {
     std::transform(build_id.begin(), build_id.end(), build_id.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     return build_id;
+}
+
+std::string GetCheatBuildId(const PatchManager::BuildID& build_id) {
+    return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
 }
 
 std::string GetCheatName(const Core::Memory::CheatEntry& cheat) {
@@ -138,9 +138,18 @@ std::string GetCheatName(const Core::Memory::CheatEntry& cheat) {
 
 void ApplyDisabledCheats(std::vector<Core::Memory::CheatEntry>& cheats,
                          const std::string& build_id) {
-    const auto disabled_it = Settings::values.disabled_cheats.find(build_id);
+    const auto normalized_build_id = NormalizeCheatBuildId(build_id);
+    auto disabled_it = Settings::values.disabled_cheats.find(normalized_build_id);
     if (disabled_it == Settings::values.disabled_cheats.end()) {
-        return;
+        disabled_it = std::find_if(Settings::values.disabled_cheats.begin(),
+                                   Settings::values.disabled_cheats.end(),
+                                   [&normalized_build_id](const auto& entry) {
+                                       return NormalizeCheatBuildId(entry.first) ==
+                                              normalized_build_id;
+                                   });
+        if (disabled_it == Settings::values.disabled_cheats.end()) {
+            return;
+        }
     }
 
     const auto& disabled = disabled_it->second;

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -57,6 +57,11 @@ const ContentProviderUnion* GetUnionProvider(const ContentProvider& p) {
 constexpr u32 SINGLE_BYTE_MODULUS = 0x100;
 constexpr std::size_t CHEAT_BUILD_ID_LENGTH = sizeof(u64) * 2;
 
+struct CheatMod {
+    VirtualDir directory;
+    std::string identifier;
+};
+
 enum class TitleVersionFormat : u8 {
     ThreeElements, ///< vX.Y.Z
     FourElements,  ///< vX.Y.Z.W
@@ -126,8 +131,22 @@ std::string GetCheatName(const Core::Memory::CheatEntry& cheat) {
     return std::string(name.data(), length);
 }
 
+bool IsCheatModDisabled(u64 title_id, std::string_view mod_identifier) {
+    const auto& disabled_addons = Settings::values.disabled_addons[title_id];
+    if (std::find(disabled_addons.begin(), disabled_addons.end(), mod_identifier) !=
+        disabled_addons.end()) {
+        return true;
+    }
+
+    const auto separator = mod_identifier.find_last_of('/');
+    return separator != std::string_view::npos &&
+           std::find(disabled_addons.begin(), disabled_addons.end(),
+                     mod_identifier.substr(separator + 1)) != disabled_addons.end();
+}
+
 void ApplyDisabledCheats(std::vector<Core::Memory::CheatEntry>& cheats,
-                         const std::string& build_id) {
+                         const std::string& build_id, std::string_view source,
+                         bool mod_disabled) {
     const auto normalized_build_id = NormalizeCheatBuildId(build_id);
     auto disabled_it = Settings::values.disabled_cheats.find(normalized_build_id);
     if (disabled_it == Settings::values.disabled_cheats.end()) {
@@ -137,14 +156,15 @@ void ApplyDisabledCheats(std::vector<Core::Memory::CheatEntry>& cheats,
                                        return NormalizeCheatBuildId(entry.first) ==
                                               normalized_build_id;
                                    });
-        if (disabled_it == Settings::values.disabled_cheats.end()) {
-            return;
-        }
     }
 
-    const auto& disabled = disabled_it->second;
     for (auto& cheat : cheats) {
-        if (disabled.contains(GetCheatName(cheat))) {
+        const auto cheat_name = GetCheatName(cheat);
+        if (mod_disabled ||
+            (disabled_it != Settings::values.disabled_cheats.end() &&
+             (disabled_it->second.contains(GetCheatConfigKey(source, cheat_name)) ||
+              // Keep configs written before source-specific cheat keys working.
+              disabled_it->second.contains(cheat_name)))) {
             cheat.enabled = false;
         }
     }
@@ -206,9 +226,9 @@ std::vector<VirtualDir> GetEnabledModsList(
     return mods;
 }
 
-std::vector<VirtualDir> GetCheatModsList(
+std::vector<CheatMod> GetCheatModsList(
     u64 title_id, const Service::FileSystem::FileSystemController& fs_controller) {
-    std::vector<VirtualDir> mods;
+    std::vector<CheatMod> mods;
     const auto load_dir = fs_controller.GetModificationLoadRoot(title_id);
     if (!load_dir) {
         return mods;
@@ -220,13 +240,14 @@ std::vector<VirtualDir> GetCheatModsList(
         }
 
         if (FindSubdirectoryCaseless(top_dir, "cheats") != nullptr) {
-            mods.push_back(top_dir);
+            mods.push_back({.directory = top_dir, .identifier = top_dir->GetName()});
             continue;
         }
 
         for (const auto& sub_dir : top_dir->GetSubdirectories()) {
             if (sub_dir && FindSubdirectoryCaseless(sub_dir, "cheats") != nullptr) {
-                mods.push_back(sub_dir);
+                mods.push_back({.directory = sub_dir,
+                                .identifier = top_dir->GetName() + "/" + sub_dir->GetName()});
             }
         }
     }
@@ -237,8 +258,8 @@ bool IsDirValidAndNonEmpty(const VirtualDir& dir) {
     return dir != nullptr && (!dir->GetFiles().empty() || !dir->GetSubdirectories().empty());
 }
 
-void AppendCheatsFromMod(std::vector<CheatPatch>& out, const VirtualDir& mod_dir) {
-    const auto cheats_dir = FindSubdirectoryCaseless(mod_dir, "cheats");
+void AppendCheatsFromMod(std::vector<CheatPatch>& out, u64 title_id, const CheatMod& mod) {
+    const auto cheats_dir = FindSubdirectoryCaseless(mod.directory, "cheats");
     if (cheats_dir == nullptr) {
         return;
     }
@@ -259,10 +280,12 @@ void AppendCheatsFromMod(std::vector<CheatPatch>& out, const VirtualDir& mod_dir
         if (extension_pos != std::string::npos) {
             build_id = build_id.substr(0, extension_pos);
         }
-        if (build_id.size() < CHEAT_BUILD_ID_LENGTH) {
+        if (build_id.size() != CHEAT_BUILD_ID_LENGTH ||
+            !std::all_of(build_id.cbegin(), build_id.cend(),
+                         [](unsigned char c) { return std::isxdigit(c) != 0; })) {
             continue;
         }
-        build_id = NormalizeCheatBuildId(build_id.substr(0, CHEAT_BUILD_ID_LENGTH));
+        build_id = NormalizeCheatBuildId(build_id);
 
         std::vector<u8> data(file->GetSize());
         if (file->Read(data.data(), data.size()) != data.size()) {
@@ -272,7 +295,9 @@ void AppendCheatsFromMod(std::vector<CheatPatch>& out, const VirtualDir& mod_dir
 
         auto cheats =
             parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
-        ApplyDisabledCheats(cheats, build_id);
+        const auto source = mod.identifier + "/" + file->GetName();
+        ApplyDisabledCheats(cheats, build_id, source,
+                            IsCheatModDisabled(title_id, mod.identifier));
         for (const auto& cheat : cheats) {
             if (cheat.definition.num_opcodes == 0) {
                 continue;
@@ -283,8 +308,10 @@ void AppendCheatsFromMod(std::vector<CheatPatch>& out, const VirtualDir& mod_dir
                 continue;
             }
 
-            out.push_back(
-                {.enabled = cheat.enabled, .name = cheat_name, .build_id = build_id});
+            out.push_back({.enabled = cheat.enabled,
+                           .name = cheat_name,
+                           .build_id = build_id,
+                           .source = source});
         }
     }
 }
@@ -298,6 +325,10 @@ std::string NormalizeCheatBuildId(std::string build_id) {
 
 std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id) {
     return NormalizeCheatBuildId(Common::HexToString(build_id).substr(0, CHEAT_BUILD_ID_LENGTH));
+}
+
+std::string GetCheatConfigKey(std::string_view source, std::string_view name) {
+    return fmt::format("{}:{}{}", source.size(), source, name);
 }
 
 
@@ -513,25 +544,35 @@ bool PatchManager::HasNSOPatch(const BuildID& build_id_, std::string_view name) 
 std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
     const BuildID& build_id_) const {
 
-    std::vector<VirtualDir> patch_dirs = GetCheatModsList(title_id, fs_controller);
+    std::vector<CheatMod> patch_dirs = GetCheatModsList(title_id, fs_controller);
     const auto build_id = GetCheatBuildId(build_id_);
 
     std::sort(patch_dirs.begin(), patch_dirs.end(),
-              [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
+              [](const CheatMod& l, const CheatMod& r) { return l.identifier < r.identifier; });
 
     std::vector<Core::Memory::CheatEntry> out;
-    for (const auto& subdir : patch_dirs) {
-        auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
+    for (const auto& mod : patch_dirs) {
+        auto cheats_dir = FindSubdirectoryCaseless(mod.directory, "cheats");
         if (cheats_dir != nullptr) {
             if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, true)) {
                 auto cheats = *res;
-                ApplyDisabledCheats(cheats, build_id);
+                ApplyDisabledCheats(
+                    cheats, build_id,
+                    mod.identifier + "/" + Common::HexToString(build_id_, true).substr(
+                                               0, CHEAT_BUILD_ID_LENGTH) +
+                        ".txt",
+                    IsCheatModDisabled(title_id, mod.identifier));
                 std::copy(cheats.begin(), cheats.end(), std::back_inserter(out));
                 continue;
             }
             if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, false)) {
                 auto cheats = *res;
-                ApplyDisabledCheats(cheats, build_id);
+                ApplyDisabledCheats(
+                    cheats, build_id,
+                    mod.identifier + "/" + Common::HexToString(build_id_, false).substr(
+                                               0, CHEAT_BUILD_ID_LENGTH) +
+                        ".txt",
+                    IsCheatModDisabled(title_id, mod.identifier));
                 std::copy(cheats.begin(), cheats.end(), std::back_inserter(out));
             }
         }
@@ -1002,13 +1043,13 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
 }
 
 std::vector<CheatPatch> PatchManager::GetCheats() const {
-    std::vector<VirtualDir> patch_dirs = GetCheatModsList(title_id, fs_controller);
+    std::vector<CheatMod> patch_dirs = GetCheatModsList(title_id, fs_controller);
     std::sort(patch_dirs.begin(), patch_dirs.end(),
-              [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
+              [](const CheatMod& l, const CheatMod& r) { return l.identifier < r.identifier; });
 
     std::vector<CheatPatch> out;
-    for (const auto& subdir : patch_dirs) {
-        AppendCheatsFromMod(out, subdir);
+    for (const auto& mod : patch_dirs) {
+        AppendCheatsFromMod(out, title_id, mod);
     }
 
     return out;
@@ -1023,7 +1064,8 @@ std::vector<CheatPatch> PatchManager::GetCheatsForMod(std::string_view mod_name)
 
     const auto mod_dir = load_dir->GetSubdirectory(mod_name);
     if (mod_dir != nullptr) {
-        AppendCheatsFromMod(out, mod_dir);
+        AppendCheatsFromMod(out, title_id,
+                            {.directory = mod_dir, .identifier = std::string{mod_name}});
     }
     return out;
 }

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <optional>
@@ -43,6 +44,9 @@ struct CheatPatch {
     std::string name;
     std::string build_id;
 };
+
+[[nodiscard]] std::string NormalizeCheatBuildId(std::string build_id);
+[[nodiscard]] std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id);
 
 // A centralized class to manage patches to games.
 class PatchManager {

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include "common/common_types.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/vfs/vfs_types.h"
@@ -90,8 +91,11 @@ public:
     // Returns a vector of patches
     [[nodiscard]] std::vector<Patch> GetPatches(VirtualFile update_raw = nullptr) const;
 
-    // Returns a vector of cheats found in enabled mod directories.
+    // Returns a vector of cheats found in mod directories.
     [[nodiscard]] std::vector<CheatPatch> GetCheats() const;
+
+    // Returns a vector of cheats found in one installed mod directory.
+    [[nodiscard]] std::vector<CheatPatch> GetCheatsForMod(std::string_view mod_name) const;
 
     // If the game update exists, returns the u32 version field in its Meta-type NCA. If that fails,
     // it will fallback to the Meta-type NCA of the base game. If that fails, the result will be

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -44,10 +44,12 @@ struct CheatPatch {
     bool enabled;
     std::string name;
     std::string build_id;
+    std::string source;
 };
 
 [[nodiscard]] std::string NormalizeCheatBuildId(std::string build_id);
 [[nodiscard]] std::string GetCheatBuildId(const std::array<u8, 0x20>& build_id);
+[[nodiscard]] std::string GetCheatConfigKey(std::string_view source, std::string_view name);
 
 // A centralized class to manage patches to games.
 class PatchManager {

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -27,7 +27,7 @@ class ContentProvider;
 class NCA;
 class NACP;
 
-enum class PatchType { Update, DLC, Mod };
+enum class PatchType { Update, DLC, Mod, Cheat };
 
 struct Patch {
     bool enabled;
@@ -36,6 +36,12 @@ struct Patch {
     PatchType type;
     u64 program_id;
     u64 title_id;
+};
+
+struct CheatPatch {
+    bool enabled;
+    std::string name;
+    std::string build_id;
 };
 
 // A centralized class to manage patches to games.
@@ -79,6 +85,9 @@ public:
 
     // Returns a vector of patches
     [[nodiscard]] std::vector<Patch> GetPatches(VirtualFile update_raw = nullptr) const;
+
+    // Returns a vector of cheats found in enabled mod directories.
+    [[nodiscard]] std::vector<CheatPatch> GetCheats() const;
 
     // If the game update exists, returns the u32 version field in its Meta-type NCA. If that fails,
     // it will fallback to the Meta-type NCA of the base game. If that fails, the result will be

--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright 2025 citron Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "core/core.h"
@@ -476,7 +478,16 @@ void KPageTableBase::Finalize() {
 
     auto BlockCallback = [&](KProcessAddress addr, u64 size) {
         if (m_impl->fastmem_arena) {
-            m_system.DeviceMemory().buffer.Unmap(GetInteger(addr), size, false);
+            // Some platforms reserve a smaller fastmem arena than the full 39-bit process
+            // address space. The block manager still contains a trailing free block for
+            // that unreserved range when the process is finalized. It was never mapped,
+            // so do not pass it to HostMemory::Unmap.
+            const size_t virtual_offset = GetInteger(addr);
+            const size_t virtual_size = m_system.DeviceMemory().buffer.VirtualSize();
+            if (virtual_offset < virtual_size) {
+                const size_t mapped_size = std::min<size_t>(size, virtual_size - virtual_offset);
+                m_system.DeviceMemory().buffer.Unmap(virtual_offset, mapped_size, false);
+            }
         }
 
         // Get physical pages.

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -271,12 +271,14 @@ void CheatEngine::SetMainMemoryParameters(VAddr main_region_begin, u64 main_regi
 }
 
 void CheatEngine::Reload(std::vector<CheatEntry> reload_cheats) {
+    std::scoped_lock lock{cheats_mutex};
     cheats = std::move(reload_cheats);
     is_pending_reload.exchange(true);
 }
 
 void CheatEngine::FrameCallback(std::chrono::nanoseconds ns_late) {
     if (is_pending_reload.exchange(false)) {
+        std::scoped_lock lock{cheats_mutex};
         vm.LoadProgram(cheats);
     }
 

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -270,6 +270,10 @@ void CheatEngine::SetMainMemoryParameters(VAddr main_region_begin, u64 main_regi
     };
 }
 
+const std::array<u8, 0x20>& CheatEngine::GetBuildId() const {
+    return metadata.main_nso_build_id;
+}
+
 void CheatEngine::Reload(std::vector<CheatEntry> reload_cheats) {
     std::scoped_lock lock{cheats_mutex};
     cheats = std::move(reload_cheats);

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -70,6 +70,8 @@ public:
     void Initialize();
     void SetMainMemoryParameters(VAddr main_region_begin, u64 main_region_size);
 
+    [[nodiscard]] const std::array<u8, 0x20>& GetBuildId() const;
+
     void Reload(std::vector<CheatEntry> reload_cheats);
 
 private:

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <vector>
 #include "common/common_types.h"
 #include "core/memory/dmnt_cheat_types.h"
@@ -78,6 +79,7 @@ private:
     CheatProcessMetadata metadata;
 
     std::vector<CheatEntry> cheats;
+    std::mutex cheats_mutex;
     std::atomic_bool is_pending_reload{false};
 
     std::shared_ptr<Core::Timing::EventType> event;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -43,7 +43,9 @@ using VideoCore::Surface::PixelFormatFromDepthFormat;
 using VideoCore::Surface::PixelFormatFromRenderTargetFormat;
 
 constexpr size_t NUM_STAGES = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
-constexpr size_t MAX_IMAGE_ELEMENTS = 1024;
+// Descriptor scratch storage is dynamically sized. Keep this as a diagnostic threshold for
+// unusually large bindless pipelines, rather than rejecting them as the old fixed arrays did.
+constexpr size_t LARGE_IMAGE_DESCRIPTOR_COUNT = 1024;
 
 // Stale SamplerIds are possible if the sampler pool is rebuilt with a different
 // sampler at the same handle while the cbuf bytes don't change. Add a pool
@@ -1094,7 +1096,12 @@ void GraphicsPipeline::Validate() {
         num_images += Shader::NumDescriptors(info.texture_descriptors);
         num_images += Shader::NumDescriptors(info.image_descriptors);
     }
-    ASSERT(num_images <= MAX_IMAGE_ELEMENTS);
+    if (num_images > LARGE_IMAGE_DESCRIPTOR_COUNT) {
+        LOG_WARNING(Render_Vulkan,
+                    "Graphics pipeline has {} image descriptors; using dynamically sized "
+                    "descriptor scratch storage",
+                    num_images);
+    }
 }
 
 } // namespace Vulkan


### PR DESCRIPTION
## Changes

- Updated `GamePropertiesFragment.kt`
  - Fixed shader cache deletion path.

- Updated `EmulationActivity.kt`
  - Added PiP feature gating.
  - Added defensive handling around PiP-related calls.

No renderer/core changes included; this PR only contains Android-side fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-game **Cheats** menu to list available cheats for the current game and enable/disable them.
* **Bug Fixes**
  * Improved **Picture-in-Picture** stability and parameter handling, including safer setup and aspect-ratio clamping.
  * Fixed **clear shader cache** to use the correct cache location.
  * Improved touch/input responsiveness for more consistent interactions.
* **Other**
  * Prefer the device’s **highest refresh rate** on startup.
  * Refresh the driver list when returning to the driver manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->