### PR TITLE
fix(debugger): initialize addr in Ghidra CSV import

### DIFF
--- a/src/citron/debugger/function_browser.cpp
+++ b/src/citron/debugger/function_browser.cpp
@@ -251,7 +251,7 @@ void FunctionBrowserWidget::OnImportGhidraCsv() {
     std::string line;
     int count = 0;
     while (std::getline(f, line)) {
-        u64 addr;
+        u64 addr = 0;
         std::string name;
         if (ParseGhidraCsvLine(line, addr, name) && !name.empty()) {
             ghidra_import_overrides[addr] = name;


### PR DESCRIPTION
Fixes a Linux build error where GCC fails on an uninitialized `addr` in
`OnImportGhidraCsv()`. Setting `addr = 0` resolves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV import stability by ensuring address parsing starts from a defined value, reducing the risk of incorrect or unpredictable results during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->