### PR TITLE
fix: make CrashHostMemoryInvariant static to fix build

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -44,7 +44,7 @@ namespace Common {
 constexpr size_t PageAlignment = 0x1000;
 constexpr size_t HugePageSize = 0x200000;
 
-[[noreturn]] void CrashHostMemoryInvariant(const char* operation, const char* reason,
+[[noreturn]] static void CrashHostMemoryInvariant(const char* operation, const char* reason,
                                            size_t virtual_offset, size_t host_offset,
                                            size_t length, size_t virtual_size,
                                            size_t backing_size, MemoryPermission perms,


### PR DESCRIPTION
## Summary

`CrashHostMemoryInvariant` was added in `host_memory.cpp` without a prior declaration. Because the project builds with `-Werror=missing-declarations`, this causes the build to fail.

This change marks the function as `static` since it is only used inside `host_memory.cpp`.

## Error
 no previous declaration for 'void Common::CrashHostMemoryInvariant(...)' [-Werror=missing-declarations]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unrecoverable host memory errors to ensure program execution stops consistently when a critical memory invariant is violated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->