### PR TITLE
spirv: decorate bindless descriptor indices as NonUniform

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -233,25 +233,21 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
     }
 }
 
-// Decorates divergent bindless indices NonUniform, per descriptor class
-// (`supported`). non_uniform_ids dedups repeated use of the same index.
+// Decorates a copy of divergent bindless indices NonUniform, per descriptor
+// class (`supported`). Never decorates the original id - it may be used
+// elsewhere in the shader. non_uniform_ids caches id -> decorated copy.
 Id BindlessArrayIndex(EmitContext& ctx, const IR::Value& index, bool supported) {
     const Id idx{ctx.Def(index)};
-    const bool already_decorated{ctx.non_uniform_ids.contains(idx.value)};
-    if (supported) {
-        if (!already_decorated) {
-            ctx.Decorate(idx, spv::Decoration::NonUniformEXT);
-            ctx.non_uniform_ids.insert(idx.value);
-        }
+    if (!supported) {
         return idx;
     }
-    if (already_decorated) {
-        // Already decorated for a different, unsupported class here - reuse
-        // would apply it to an access chain with no matching capability.
-        // OpIAdd 0 as a cheap copy; OpCopyObject isn't confirmed in Sirit.
-        return ctx.OpIAdd(ctx.U32[1], idx, ctx.Const(0u));
+    if (const auto it{ctx.non_uniform_ids.find(idx.value)}; it != ctx.non_uniform_ids.end()) {
+        return it->second;
     }
-    return idx;
+    const Id copy{ctx.OpIAdd(ctx.U32[1], idx, ctx.Const(0u))};
+    ctx.Decorate(copy, spv::Decoration::NonUniformEXT);
+    ctx.non_uniform_ids.emplace(idx.value, copy);
+    return copy;
 }
 
 std::pair<Id, bool> Image(EmitContext& ctx, const IR::Value& index, IR::TextureInstInfo info) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -185,10 +185,18 @@ private:
     spv::ImageOperandsMask mask{};
 };
 
-Id Texture(EmitContext& ctx, IR::TextureInstInfo info, [[maybe_unused]] const IR::Value& index) {
+// Forward-declared: used by Texture()/TextureImage() below its definition.
+Id BindlessArrayIndex(EmitContext& ctx, const IR::Value& index, bool supported);
+
+Id Texture(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& index) {
     const TextureDefinition& def{ctx.textures.at(info.descriptor_index)};
     if (def.count > 1) {
-        const Id pointer{ctx.OpAccessChain(def.pointer_type, def.id, ctx.Def(index))};
+        const Id idx{index.IsImmediate()
+                         ? ctx.Const(index.U32())
+                         : BindlessArrayIndex(
+                               ctx, index,
+                               ctx.profile.support_sampled_image_array_non_uniform_indexing)};
+        const Id pointer{ctx.OpAccessChain(def.pointer_type, def.id, idx)};
         return ctx.OpLoad(def.sampled_type, pointer);
     } else {
         return ctx.OpLoad(def.sampled_type, def.id);
@@ -199,7 +207,12 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
     if (info.type == TextureType::Buffer) {
         const TextureBufferDefinition& def{ctx.texture_buffers.at(info.descriptor_index)};
         if (def.count > 1) {
-            const Id idx{index.IsImmediate() ? ctx.Const(index.U32()) : ctx.Def(index)};
+            const Id idx{
+                index.IsImmediate()
+                    ? ctx.Const(index.U32())
+                    : BindlessArrayIndex(
+                          ctx, index,
+                          ctx.profile.support_uniform_texel_buffer_array_non_uniform_indexing)};
             const Id ptr{ctx.OpAccessChain(ctx.image_buffer_type, def.id, idx)};
             return ctx.OpLoad(ctx.image_buffer_type, ptr);
         }
@@ -207,7 +220,12 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
     } else {
         const TextureDefinition& def{ctx.textures.at(info.descriptor_index)};
         if (def.count > 1) {
-            const Id idx{index.IsImmediate() ? ctx.Const(index.U32()) : ctx.Def(index)};
+            const Id idx{
+                index.IsImmediate()
+                    ? ctx.Const(index.U32())
+                    : BindlessArrayIndex(
+                          ctx, index,
+                          ctx.profile.support_sampled_image_array_non_uniform_indexing)};
             const Id ptr{ctx.OpAccessChain(def.pointer_type, def.id, idx)};
             return ctx.OpImage(def.image_type, ctx.OpLoad(def.sampled_type, ptr));
         }
@@ -215,11 +233,36 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
     }
 }
 
+// Decorates divergent bindless indices NonUniform, per descriptor class
+// (`supported`). non_uniform_ids dedups repeated use of the same index.
+Id BindlessArrayIndex(EmitContext& ctx, const IR::Value& index, bool supported) {
+    const Id idx{ctx.Def(index)};
+    const bool already_decorated{ctx.non_uniform_ids.contains(idx.value)};
+    if (supported) {
+        if (!already_decorated) {
+            ctx.Decorate(idx, spv::Decoration::NonUniformEXT);
+            ctx.non_uniform_ids.insert(idx.value);
+        }
+        return idx;
+    }
+    if (already_decorated) {
+        // Already decorated for a different, unsupported class here - reuse
+        // would apply it to an access chain with no matching capability.
+        // OpIAdd 0 as a cheap copy; OpCopyObject isn't confirmed in Sirit.
+        return ctx.OpIAdd(ctx.U32[1], idx, ctx.Const(0u));
+    }
+    return idx;
+}
+
 std::pair<Id, bool> Image(EmitContext& ctx, const IR::Value& index, IR::TextureInstInfo info) {
     if (info.type == TextureType::Buffer) {
         const ImageBufferDefinition def{ctx.image_buffers.at(info.descriptor_index)};
         if (def.count > 1) {
-            const Id idx{index.IsImmediate() ? ctx.Const(index.U32()) : ctx.Def(index)};
+            const Id idx{index.IsImmediate()
+                             ? ctx.Const(index.U32())
+                             : BindlessArrayIndex(
+                                   ctx, index,
+                                   ctx.profile.support_storage_texel_buffer_array_non_uniform_indexing)};
             const Id ptr{ctx.OpAccessChain(def.pointer_type, def.id, idx)};
             return {ctx.OpLoad(def.image_type, ptr), def.is_integer};
         }
@@ -227,7 +270,11 @@ std::pair<Id, bool> Image(EmitContext& ctx, const IR::Value& index, IR::TextureI
     } else {
         const ImageDefinition def{ctx.images.at(info.descriptor_index)};
         if (def.count > 1) {
-            const Id idx{index.IsImmediate() ? ctx.Const(index.U32()) : ctx.Def(index)};
+            const Id idx{index.IsImmediate()
+                             ? ctx.Const(index.U32())
+                             : BindlessArrayIndex(
+                                   ctx, index,
+                                   ctx.profile.support_storage_image_array_non_uniform_indexing)};
             const Id ptr{ctx.OpAccessChain(def.pointer_type, def.id, idx)};
             return {ctx.OpLoad(def.image_type, ptr), def.is_integer};
         }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1357,6 +1357,11 @@ void EmitContext::DefineTextureBuffers(const Info& info, u32& binding) {
             .pointer_type = pointer_type,
             .count = desc.count,
         });
+        if (desc.count > 1 && profile.support_uniform_texel_buffer_array_non_uniform_indexing) {
+            AddExtension("SPV_EXT_descriptor_indexing");
+            AddCapability(spv::Capability::ShaderNonUniformEXT);
+            AddCapability(spv::Capability::UniformTexelBufferArrayNonUniformIndexingEXT);
+        }
         if (profile.supported_spirv >= 0x00010400) {
             interfaces.push_back(id);
         }
@@ -1385,6 +1390,11 @@ void EmitContext::DefineImageBuffers(const Info& info, u32& binding) {
             .count = desc.count,
             .is_integer = desc.is_integer,
         });
+        if (desc.count > 1 && profile.support_storage_texel_buffer_array_non_uniform_indexing) {
+            AddExtension("SPV_EXT_descriptor_indexing");
+            AddCapability(spv::Capability::ShaderNonUniformEXT);
+            AddCapability(spv::Capability::StorageTexelBufferArrayNonUniformIndexingEXT);
+        }
         if (profile.supported_spirv >= 0x00010400) {
             interfaces.push_back(id);
         }
@@ -1411,6 +1421,11 @@ void EmitContext::DefineTextures(const Info& info, u32& binding, u32& scaling_in
             .count = desc.count,
             .is_multisample = desc.is_multisample,
         });
+        if (desc.count > 1 && profile.support_sampled_image_array_non_uniform_indexing) {
+            AddExtension("SPV_EXT_descriptor_indexing");
+            AddCapability(spv::Capability::ShaderNonUniformEXT);
+            AddCapability(spv::Capability::SampledImageArrayNonUniformIndexingEXT);
+        }
         if (profile.supported_spirv >= 0x00010400) {
             interfaces.push_back(id);
         }
@@ -1441,6 +1456,11 @@ void EmitContext::DefineImages(const Info& info, u32& binding, u32& scaling_inde
             .count = desc.count,
             .is_integer = desc.is_integer,
         });
+        if (desc.count > 1 && profile.support_storage_image_array_non_uniform_indexing) {
+            AddExtension("SPV_EXT_descriptor_indexing");
+            AddCapability(spv::Capability::ShaderNonUniformEXT);
+            AddCapability(spv::Capability::StorageImageArrayNonUniformIndexingEXT);
+        }
         if (profile.supported_spirv >= 0x00010400) {
             interfaces.push_back(id);
         }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -5,6 +5,7 @@
 
 #include <array>
 
+#include <ankerl/unordered_dense.h>
 #include <sirit/sirit.h>
 
 #include "shader_recompiler/backend/bindings.h"
@@ -213,6 +214,9 @@ public:
     const Profile& profile;
     const RuntimeInfo& runtime_info;
     Stage stage{};
+
+    // Ids already decorated NonUniform, to avoid decorating twice.
+    ankerl::unordered_dense::set<u32> non_uniform_ids;
 
     Id void_id{};
     Id U1{};

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -215,8 +215,9 @@ public:
     const RuntimeInfo& runtime_info;
     Stage stage{};
 
-    // Ids already decorated NonUniform, to avoid decorating twice.
-    ankerl::unordered_dense::set<u32> non_uniform_ids;
+    // Maps an id to its NonUniform-decorated copy, so decoration never
+    // mutates the original id.
+    ankerl::unordered_dense::map<u32, Id> non_uniform_ids;
 
     Id void_id{};
     Id U1{};

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -17,6 +17,11 @@ struct Profile {
     /// to build a split pipeline layout.
     bool has_split_descriptor_sets{};
     bool support_descriptor_aliasing{};
+    /// NonUniform decoration for bindless array indices, per descriptor class.
+    bool support_sampled_image_array_non_uniform_indexing{};
+    bool support_storage_image_array_non_uniform_indexing{};
+    bool support_uniform_texel_buffer_array_non_uniform_indexing{};
+    bool support_storage_texel_buffer_array_non_uniform_indexing{};
     bool support_int8{};
     bool support_int16{};
     bool support_int64{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -348,6 +348,14 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
         .unified_descriptor_binding = true,
         .has_split_descriptor_sets = device.IsKhrPushDescriptorSupported(),
         .support_descriptor_aliasing = device.IsDescriptorAliasingSupported(),
+        .support_sampled_image_array_non_uniform_indexing =
+            device.IsSampledImageArrayNonUniformIndexingSupported(),
+        .support_storage_image_array_non_uniform_indexing =
+            device.IsStorageImageArrayNonUniformIndexingSupported(),
+        .support_uniform_texel_buffer_array_non_uniform_indexing =
+            device.IsUniformTexelBufferArrayNonUniformIndexingSupported(),
+        .support_storage_texel_buffer_array_non_uniform_indexing =
+            device.IsStorageTexelBufferArrayNonUniformIndexingSupported(),
         .support_int8 = device.IsInt8Supported(),
         .support_int16 = device.IsShaderInt16Supported(),
         .support_int64 = device.IsShaderInt64Supported(),

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -441,6 +441,26 @@ public:
                features.descriptor_indexing.descriptorBindingStorageImageUpdateAfterBind;
     }
 
+    /// True if the device supports non-uniform indexing for sampled image arrays.
+    bool IsSampledImageArrayNonUniformIndexingSupported() const {
+        return features.descriptor_indexing.shaderSampledImageArrayNonUniformIndexing;
+    }
+
+    /// True if the device supports non-uniform indexing for storage image arrays.
+    bool IsStorageImageArrayNonUniformIndexingSupported() const {
+        return features.descriptor_indexing.shaderStorageImageArrayNonUniformIndexing;
+    }
+
+    /// True if the device supports non-uniform indexing for uniform texel buffer arrays.
+    bool IsUniformTexelBufferArrayNonUniformIndexingSupported() const {
+        return features.descriptor_indexing.shaderUniformTexelBufferArrayNonUniformIndexing;
+    }
+
+    /// True if the device supports non-uniform indexing for storage texel buffer arrays.
+    bool IsStorageTexelBufferArrayNonUniformIndexingSupported() const {
+        return features.descriptor_indexing.shaderStorageTexelBufferArrayNonUniformIndexing;
+    }
+
     /// Returns true if VK_KHR_pipeline_executable_properties is enabled.
     bool IsKhrPipelineExecutablePropertiesEnabled() const {
         return extensions.pipeline_executable_properties;


### PR DESCRIPTION
## Summary

Bindless (count > 1) descriptor arrays are indexed with a per-invocation
dynamic value, but the index was never decorated NonUniform. Per the
descriptor-indexing spec, a divergent index into a descriptor array
requires this decoration or indexing is undefined - some drivers can
serve one invocation another's descriptor without it.

Applies to all four descriptor classes that build a dynamic access chain:
sampled image and uniform texel buffer (Texture()/TextureImage()), and
storage image and storage texel buffer (Image()).

## Credit

This was built by comparing against Eden's handling of the same path-
eden-emu/eden#3900, crediting a "ported Citron-NEO fix" for the same
Tomodachi Life grass issue that motivated Citron Neo's  bindless cache 
implementation and followup PR#229. 
Eden's PR #3900 was labeled as an "AMD Pixelated Grass Fix."

## Design

**Per-class gating, not one shared flag.** Sampled image, storage image,
and both texel buffer kinds are separate Vulkan features
(`shaderSampledImageArrayNonUniformIndexing` etc.) and separate SPIR-V
capabilities. Each is checked and declared independently
(`Device::IsXArrayNonUniformIndexingSupported()` ->
`Profile::support_x_array_non_uniform_indexing`), so a device missing
support for one class doesn't silently withhold the decoration from
three others that do have it.

**Decorate the index only, not downstream results.** Confirmed against
Eden's current shipped source: they previously decorated the index, the
access-chain pointer, and the loaded value separately, then removed that
in a commit explicitly titled "hotfix-performance," (Eden PR#3975) landing on
index-only decoration as the shipping approach. Matched that here rather
than the heavier version.

**Dedup with a cross-class guard.** The same index value can be reused
across more than one bindless access, so a plain "already decorated"
check avoids duplicate `OpDecorate`. But if that same id was decorated
for one descriptor class (device supports it) and is then requested
again for a different class the device does *not* support, reusing the
decorated id would carry it into an access chain whose capability was
never declared - invalid SPIR-V. That case returns an undecorated copy

## Why this is not a direct port of Eden's fix

Eden's array-bound increase (#3897) exposed two bugs specific to their
fixed-size architecture (stride assumptions, rescaling-metadata indexing
- #3898/#3899). Citron's descriptor scratch storage is already
dynamically sized, so neither applies here.

## Files

- `vulkan_device.h` - four `IsXArrayNonUniformIndexingSupported()` queries
- `profile.h` - four matching `Profile` fields
- `vk_pipeline_cache.cpp` - wires them together
- `spirv_emit_context.h` - `non_uniform_ids` dedup set
  (`ankerl::unordered_dense::set`, already vendored via `common`)
- `spirv_emit_context.cpp` - per-class capability declaration in each
  `Define*`
- `emit_spirv_image.cpp` - `BindlessArrayIndex()` applies the decoration;
  `Texture()`, `TextureImage()`, and both branches of `Image()` use it

## Scope

No overlap with #229 (CPU-side resolution vs. SPIR-V emission). Applies
to `main` independent of #229's merge state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vulkan/SPIR-V handling for bindless descriptor-array indexing across sampled images, storage images, and texel buffers.
  - Non-uniform indexing support is now enabled conditionally per resource type and device capability, including the required SPIR-V extensions.
  - Reuses non-uniform decorated index values to avoid redundant decorations, improving compatibility across supported Vulkan hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->