### PR TITLE
Android: Add safe volume boost up to 200%

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
@@ -8,19 +8,48 @@ import org.citron.citron_emu.utils.NativeConfig
 enum class ByteSetting(override val key: String) : AbstractByteSetting {
     AUDIO_VOLUME("volume");
 
-    override fun getByte(needsGlobal: Boolean): Byte = NativeConfig.getByte(key, needsGlobal)
+    override fun getByte(needsGlobal: Boolean): Byte {
+        val boost = NativeConfig.getByte(VOLUME_BOOST_KEY, needsGlobal)
+        return if ((boost.toInt() and 0xFF) > DEFAULT_VOLUME) {
+            boost
+        } else {
+            NativeConfig.getByte(key, needsGlobal)
+        }
+    }
 
     override fun setByte(value: Byte) {
         if (NativeConfig.isPerGameConfigLoaded()) {
             global = false
         }
-        NativeConfig.setByte(key, value)
+
+        if ((value.toInt() and 0xFF) > DEFAULT_VOLUME) {
+            NativeConfig.setByte(key, DEFAULT_VOLUME.toByte())
+            NativeConfig.setByte(VOLUME_BOOST_KEY, value)
+        } else {
+            NativeConfig.setByte(key, value)
+            NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
+        }
     }
+
+    override var global: Boolean
+        get() = NativeConfig.usingGlobal(key)
+        set(value) {
+            NativeConfig.setGlobal(key, value)
+            NativeConfig.setGlobal(VOLUME_BOOST_KEY, value)
+        }
 
     override val defaultValue: Byte by lazy { NativeConfig.getDefaultToString(key).toByte() }
 
     override fun getValueAsString(needsGlobal: Boolean): String =
         (getByte(needsGlobal).toInt() and 0xFF).toString()
 
-    override fun reset() = NativeConfig.setByte(key, defaultValue)
+    override fun reset() {
+        NativeConfig.setByte(key, defaultValue)
+        NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
+    }
+
+    companion object {
+        private const val DEFAULT_VOLUME = 100
+        private const val VOLUME_BOOST_KEY = "volume_boost"
+    }
 }

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
@@ -19,7 +19,8 @@ enum class ByteSetting(override val key: String) : AbstractByteSetting {
 
     override val defaultValue: Byte by lazy { NativeConfig.getDefaultToString(key).toByte() }
 
-    override fun getValueAsString(needsGlobal: Boolean): String = getByte(needsGlobal).toString()
+    override fun getValueAsString(needsGlobal: Boolean): String =
+        (getByte(needsGlobal).toInt() and 0xFF).toString()
 
     override fun reset() = NativeConfig.setByte(key, defaultValue)
 }

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/ByteSetting.kt
@@ -9,12 +9,13 @@ enum class ByteSetting(override val key: String) : AbstractByteSetting {
     AUDIO_VOLUME("volume");
 
     override fun getByte(needsGlobal: Boolean): Byte {
-        val boost = NativeConfig.getByte(VOLUME_BOOST_KEY, needsGlobal)
-        return if ((boost.toInt() and 0xFF) > DEFAULT_VOLUME) {
-            boost
-        } else {
-            NativeConfig.getByte(key, needsGlobal)
+        if (this == AUDIO_VOLUME) {
+            val boost = NativeConfig.getByte(VOLUME_BOOST_KEY, needsGlobal)
+            if ((boost.toInt() and 0xFF) > DEFAULT_VOLUME) {
+                return boost
+            }
         }
+        return NativeConfig.getByte(key, needsGlobal)
     }
 
     override fun setByte(value: Byte) {
@@ -22,12 +23,16 @@ enum class ByteSetting(override val key: String) : AbstractByteSetting {
             global = false
         }
 
-        if ((value.toInt() and 0xFF) > DEFAULT_VOLUME) {
-            NativeConfig.setByte(key, DEFAULT_VOLUME.toByte())
-            NativeConfig.setByte(VOLUME_BOOST_KEY, value)
+        if (this == AUDIO_VOLUME) {
+            if ((value.toInt() and 0xFF) > DEFAULT_VOLUME) {
+                NativeConfig.setByte(key, DEFAULT_VOLUME.toByte())
+                NativeConfig.setByte(VOLUME_BOOST_KEY, value)
+            } else {
+                NativeConfig.setByte(key, value)
+                NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
+            }
         } else {
             NativeConfig.setByte(key, value)
-            NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
         }
     }
 
@@ -35,7 +40,9 @@ enum class ByteSetting(override val key: String) : AbstractByteSetting {
         get() = NativeConfig.usingGlobal(key)
         set(value) {
             NativeConfig.setGlobal(key, value)
-            NativeConfig.setGlobal(VOLUME_BOOST_KEY, value)
+            if (this == AUDIO_VOLUME) {
+                NativeConfig.setGlobal(VOLUME_BOOST_KEY, value)
+            }
         }
 
     override val defaultValue: Byte by lazy { NativeConfig.getDefaultToString(key).toByte() }
@@ -45,7 +52,9 @@ enum class ByteSetting(override val key: String) : AbstractByteSetting {
 
     override fun reset() {
         NativeConfig.setByte(key, defaultValue)
-        NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
+        if (this == AUDIO_VOLUME) {
+            NativeConfig.setByte(VOLUME_BOOST_KEY, DEFAULT_VOLUME.toByte())
+        }
     }
 
     companion object {

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SettingsItem.kt
@@ -339,6 +339,7 @@ abstract class SettingsItem(
                     ByteSetting.AUDIO_VOLUME,
                     titleId = R.string.audio_volume,
                     descriptionId = R.string.audio_volume_description,
+                    max = 200,
                     units = "%"
                 )
             )

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SliderSetting.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SliderSetting.kt
@@ -26,7 +26,7 @@ class SliderSetting(
 
     fun getSelectedValue(needsGlobal: Boolean = false) =
         when (setting) {
-            is AbstractByteSetting -> setting.getByte(needsGlobal).toInt()
+            is AbstractByteSetting -> setting.getByte(needsGlobal).toInt() and 0xFF
             is AbstractShortSetting -> setting.getShort(needsGlobal).toInt()
             is AbstractIntSetting -> setting.getInt(needsGlobal)
             is AbstractFloatSetting -> (setting.getFloat(needsGlobal) * scale).roundToInt()

--- a/src/android/app/src/main/jni/android_config.cpp
+++ b/src/android/app/src/main/jni/android_config.cpp
@@ -5,12 +5,16 @@
 #include <input_common/main.h>
 #include "android_config.h"
 #include "android_settings.h"
+#include "common/settings.h"
 #include "common/settings_setting.h"
 
 AndroidConfig::AndroidConfig(const std::string& config_name, ConfigType config_type)
     : Config(config_type) {
     Initialize(config_name);
     if (config_type != ConfigType::InputProfile) {
+        if (MigrateLegacyVolumeBoost()) {
+            SaveValues();
+        }
         ReadAndroidValues();
         SaveAndroidValues();
     }
@@ -18,6 +22,9 @@ AndroidConfig::AndroidConfig(const std::string& config_name, ConfigType config_t
 
 void AndroidConfig::ReloadAllValues() {
     Reload();
+    if (MigrateLegacyVolumeBoost()) {
+        SaveValues();
+    }
     ReadAndroidValues();
     SaveAndroidValues();
 }
@@ -25,6 +32,22 @@ void AndroidConfig::ReloadAllValues() {
 void AndroidConfig::SaveAllValues() {
     SaveValues();
     SaveAndroidValues();
+}
+
+bool AndroidConfig::MigrateLegacyVolumeBoost() {
+    auto& volume = Settings::values.volume;
+    const auto legacy_volume = volume.GetValue();
+    if (legacy_volume <= 100) {
+        return false;
+    }
+
+    auto& volume_boost = Settings::values.volume_boost;
+    volume_boost.SetGlobal(volume.UsingGlobal());
+    if (volume_boost.GetValue() == volume_boost.GetDefault()) {
+        volume_boost.SetValue(legacy_volume);
+    }
+    volume.SetValue(100);
+    return true;
 }
 
 void AndroidConfig::ReadAndroidValues() {

--- a/src/android/app/src/main/jni/android_config.h
+++ b/src/android/app/src/main/jni/android_config.h
@@ -17,6 +17,7 @@ public:
     void SaveAndroidControlPlayerValues(std::size_t player_index);
 
 protected:
+    bool MigrateLegacyVolumeBoost();
     void ReadAndroidPlayerValues(std::size_t player_index);
     void ReadAndroidControlValues();
     void ReadAndroidValues();

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -211,7 +211,11 @@ float Volume() {
     if (values.audio_muted) {
         return 0.0f;
     }
-    return values.volume.GetValue() / static_cast<f32>(values.volume.GetDefault());
+    const auto volume =
+        values.volume.GetValue() / static_cast<f32>(values.volume.GetDefault());
+    const auto boost =
+        values.volume_boost.GetValue() / static_cast<f32>(values.volume_boost.GetDefault());
+    return volume * boost;
 }
 
 const char* TranslateCategory(Category category) {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -191,6 +191,16 @@ struct Values {
                                        Specialization::Scalar | Specialization::Percentage,
                                        true,
                                        true};
+    SwitchableSetting<u8, true> volume_boost{
+        linkage,
+        100,
+        100,
+        200,
+        "volume_boost",
+        Category::Audio,
+        Specialization::Scalar | Specialization::Percentage,
+        true,
+        true};
     Setting<bool, false> audio_muted{
         linkage, false, "audio_muted", Category::Audio, Specialization::Default, true, true};
     Setting<bool, false> dump_audio_commands{


### PR DESCRIPTION
## Summary

Adds an Android volume boost option up to 200%.

On my Motorola Edge 70, in-game audio remained unusually low even with the phone’s media volume was nearly set to maximum. This change provides additional amplification through the existing volume slider.

- Extends the volume slider range from 100% to 200%.
- Correctly handles values above 127 across the JNI byte interface.
- Stores boost separately while keeping the legacy volume at or below 100%.
- Falls back safely to 100% when reverting to an older build.
- Supports global and per-game settings.

## Testing

- [x] `./gradlew :app:compileMainlineDebugKotlin`
- [x] `./gradlew :app:externalNativeBuildMainlineDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio volume boost control, allowing audio volume up to 200%.
  * Updated the audio volume slider range to reflect the expanded boost setting.
  * Audio volume now applies both the base level and the separate boost level.

* **Bug Fixes**
  * Migrates legacy volume-boost values to the new boost setting (when boost is still at default).
  * Corrected volume slider/value handling and formatting for values above 100% (unsigned behavior).
  * Reset and global changes now keep the base and boost values synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->