### PR TITLE
Add Tracy profiler support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,14 @@ option(CITRON_ENABLE_TRACY "Enable Tracy profiler instrumentation (default off, 
 option(CITRON_ENABLE_TRACY_MEMORY "Enable verbose Tracy profiling for guest memory read/write operations (high overhead)" OFF)
 option(CITRON_ENABLE_TRACY_ALLOC "Enable Tracy's heap allocator tracking (Memory panel) via global operator new/delete overrides" OFF)
 
+if ((CITRON_ENABLE_TRACY_MEMORY OR CITRON_ENABLE_TRACY_ALLOC) AND NOT CITRON_ENABLE_TRACY)
+    message(FATAL_ERROR
+        "CITRON_ENABLE_TRACY_MEMORY and CITRON_ENABLE_TRACY_ALLOC both require "
+        "CITRON_ENABLE_TRACY=ON -- they add profiling data on top of the base Tracy "
+        "instrumentation and do nothing without it. Pass -DCITRON_ENABLE_TRACY=ON "
+        "(or --tracy on the build scripts) alongside them.")
+endif()
+
 if (CITRON_ENABLE_TRACY AND NOT CITRON_USE_CPM AND NOT TARGET Tracy::TracyClient)
     message(FATAL_ERROR "CITRON_ENABLE_TRACY requires CITRON_USE_CPM=ON (Tracy is fetched via CPM in CMakeModules/dependencies.cmake) or an externally provided Tracy::TracyClient target.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,8 @@ option(CITRON_ENABLE_PGO_GENERATE "Build with PGO instrumentation to generate pr
 option(CITRON_ENABLE_PGO_USE "Build using PGO profile data for optimization (Stage 2)" OFF)
 
 option(CITRON_ENABLE_TRACY "Enable Tracy profiler instrumentation (default off, zero overhead when disabled)" OFF)
-option(CITRON_ENABLE_TRACY_MEMORY "Enable verbose Tracy profiling for memory read/write operations (high overhead)" OFF)
+option(CITRON_ENABLE_TRACY_MEMORY "Enable verbose Tracy profiling for guest memory read/write operations (high overhead)" OFF)
+option(CITRON_ENABLE_TRACY_ALLOC "Enable Tracy's heap allocator tracking (Memory panel) via global operator new/delete overrides" OFF)
 
 if (CITRON_ENABLE_TRACY AND NOT CITRON_USE_CPM AND NOT TARGET Tracy::TracyClient)
     message(FATAL_ERROR "CITRON_ENABLE_TRACY requires CITRON_USE_CPM=ON (Tracy is fetched via CPM in CMakeModules/dependencies.cmake) or an externally provided Tracy::TracyClient target.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,13 @@ option(CITRON_ENABLE_LTO "Enable link-time optimization" OFF)
 
 option(CITRON_ENABLE_PGO_GENERATE "Build with PGO instrumentation to generate profile data (Stage 1)" OFF)
 option(CITRON_ENABLE_PGO_USE "Build using PGO profile data for optimization (Stage 2)" OFF)
+
+option(CITRON_ENABLE_TRACY "Enable Tracy profiler instrumentation (default off, zero overhead when disabled)" OFF)
+option(CITRON_ENABLE_TRACY_MEMORY "Enable verbose Tracy profiling for memory read/write operations (high overhead)" OFF)
+
+if (CITRON_ENABLE_TRACY AND NOT CITRON_USE_CPM)
+    message(FATAL_ERROR "CITRON_ENABLE_TRACY requires CITRON_USE_CPM=ON (Tracy is fetched via CPM in CMakeModules/dependencies.cmake)")
+endif()
 set(CITRON_PGO_PROFILE_DIR "${CMAKE_BINARY_DIR}/pgo-profiles" CACHE PATH "Directory to store PGO profile data")
 
 option(CITRON_DOWNLOAD_TIME_ZONE_DATA "Always download time zone binaries" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ option(CITRON_ENABLE_PGO_USE "Build using PGO profile data for optimization (Sta
 option(CITRON_ENABLE_TRACY "Enable Tracy profiler instrumentation (default off, zero overhead when disabled)" OFF)
 option(CITRON_ENABLE_TRACY_MEMORY "Enable verbose Tracy profiling for memory read/write operations (high overhead)" OFF)
 
-if (CITRON_ENABLE_TRACY AND NOT CITRON_USE_CPM)
-    message(FATAL_ERROR "CITRON_ENABLE_TRACY requires CITRON_USE_CPM=ON (Tracy is fetched via CPM in CMakeModules/dependencies.cmake)")
+if (CITRON_ENABLE_TRACY AND NOT CITRON_USE_CPM AND NOT TARGET Tracy::TracyClient)
+    message(FATAL_ERROR "CITRON_ENABLE_TRACY requires CITRON_USE_CPM=ON (Tracy is fetched via CPM in CMakeModules/dependencies.cmake) or an externally provided Tracy::TracyClient target.")
 endif()
 set(CITRON_PGO_PROFILE_DIR "${CMAKE_BINARY_DIR}/pgo-profiles" CACHE PATH "Directory to store PGO profile data")
 

--- a/CMakeModules/dependencies.cmake
+++ b/CMakeModules/dependencies.cmake
@@ -585,6 +585,17 @@ if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
         "TRACY_NO_FRAME_IMAGE ON"
         "TRACY_FIBERS ON"
         "TRACY_ONLY_IPV4 ON"
+        # With /WHOLEARCHIVE forcing TracyClient's translation unit to link in on
+        # MSVC/clang-cl, its global static constructor (which spawns the profiler's
+        # background thread) now runs eagerly during CRT static init, before main()
+        # -- this has been observed to hang process startup on Windows with no log,
+        # no window, and no crash dump. TRACY_DELAYED_INIT moves that work out of the
+        # static constructor and into a lazy first-call path triggered by the first
+        # real zone/instrumentation macro, which by then runs safely after CRT/Qt
+        # startup has completed. Whole-archive linking still keeps the translation
+        # unit's *functions* reachable regardless, so the port still opens once the
+        # first zone fires.
+        "TRACY_DELAYED_INIT ON"
         # NOTE: TRACY_CALLSTACK is NOT passed here because Tracy's set_option() macro
         # only supports boolean ON/OFF via CMake option(), which would produce
         # -DTRACY_CALLSTACK with no value.  Tracy uses TRACY_CALLSTACK as an integer

--- a/CMakeModules/dependencies.cmake
+++ b/CMakeModules/dependencies.cmake
@@ -566,6 +566,67 @@ set(CITRON_XCB_KEYSYMS_VER "0.4.1" CACHE STRING "XCB keysyms version")
 set(CITRON_XCB_RENDERUTIL_VER "0.3.10" CACHE STRING "XCB renderutil version")
 set(CITRON_XCB_WM_VER "0.4.2" CACHE STRING "XCB wm version")
 
+# ── Tracy (optional profiler) ─────────────────────────────────────────────────
+# Fetched only when CITRON_ENABLE_TRACY=ON.  TRACY_ENABLE must be set before
+# CPMAddPackage so the client library and application agree on configuration.
+if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
+    set(TRACY_ENABLE ON CACHE BOOL "Enable Tracy client" FORCE)
+    set(TRACY_ON_DEMAND ON CACHE BOOL "Collect Tracy data only while a profiler is connected" FORCE)
+    set(TRACY_NO_EXIT ON CACHE BOOL "Do not call exit() from the Tracy client" FORCE)
+    if (CITRON_ENABLE_LTO)
+        set(TRACY_NO_LTO ON CACHE BOOL "Disable LTO on TracyClient when the main project uses LTO" FORCE)
+    endif()
+    set(_tracy_cpm_options
+        "TRACY_ENABLE ON"
+        "TRACY_ON_DEMAND ON"
+        "TRACY_NO_EXIT ON"
+        "TRACY_NO_BROADCAST ON"
+        "TRACY_NO_VSYNC_CAPTURE ON"
+        "TRACY_NO_FRAME_IMAGE ON"
+        "TRACY_FIBERS ON"
+        # NOTE: TRACY_CALLSTACK is NOT passed here because Tracy's set_option() macro
+        # only supports boolean ON/OFF via CMake option(), which would produce
+        # -DTRACY_CALLSTACK with no value.  Tracy uses TRACY_CALLSTACK as an integer
+        # (callstack depth) in all zone macros.  We set it to 15 via
+        # target_compile_definitions below after CPMAddPackage completes.
+    )
+    if (CITRON_ENABLE_LTO)
+        list(APPEND _tracy_cpm_options "TRACY_NO_LTO ON")
+    endif()
+    CPMAddPackage(
+        NAME TracyClient
+        GITHUB_REPOSITORY wolfpld/tracy
+        GIT_TAG v0.13.1
+        OPTIONS
+            ${_tracy_cpm_options}
+    )
+    unset(_tracy_cpm_options)
+    if (TARGET TracyClient)
+        # Ensure LTO is completely disabled on the TracyClient library to avoid toolchain mismatches during PGO builds
+        set_target_properties(TracyClient PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+            target_compile_options(TracyClient PRIVATE
+                "-fno-lto"
+                "-fno-profile-generate"
+                "-fno-profile-use"
+                "-fno-profile-instr-generate"
+                "-fno-profile-instr-use"
+                "-fno-cs-profile-generate"
+            )
+        endif()
+        # Set callstack depth to 15 frames.  Must be done as a direct
+        # target_compile_definitions call with a numeric value because Tracy's
+        # CMakeLists.txt set_option() macro uses option() (boolean only) and
+        # would produce -DTRACY_CALLSTACK with no value if passed via OPTIONS above.
+        target_compile_definitions(TracyClient PUBLIC TRACY_CALLSTACK=15)
+        if (NOT TARGET Tracy::TracyClient)
+            add_library(Tracy::TracyClient ALIAS TracyClient)
+        endif()
+    endif()
+    message(STATUS "[Tracy] Profiling enabled (TRACY_ON_DEMAND=ON, callstacks=15, fibers)")
+endif()
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Qt
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/CMakeModules/dependencies.cmake
+++ b/CMakeModules/dependencies.cmake
@@ -596,11 +596,11 @@ if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
         # unit's *functions* reachable regardless, so the port still opens once the
         # first zone fires.
         "TRACY_DELAYED_INIT ON"
-        # NOTE: TRACY_CALLSTACK is NOT passed here because Tracy's set_option() macro
-        # only supports boolean ON/OFF via CMake option(), which would produce
-        # -DTRACY_CALLSTACK with no value.  Tracy uses TRACY_CALLSTACK as an integer
-        # (callstack depth) in all zone macros.  We set it to 15 via
-        # target_compile_definitions below after CPMAddPackage completes.
+        # NOTE: TRACY_CALLSTACK is deliberately NOT set anywhere for this project,
+        # globally or otherwise. See the comment further below (right after this
+        # OPTIONS list, near the TracyClient PGO/LTO opt-out block) for why: it
+        # would silently upgrade every plain ZoneScoped/CITRON_PROFILE_SCOPE zone
+        # in the whole codebase into a per-call stack walk.
     )
     if (CITRON_ENABLE_LTO)
         list(APPEND _tracy_cpm_options "TRACY_NO_LTO ON")
@@ -630,11 +630,19 @@ if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
                 "-fno-cs-profile-generate"
             )
         endif()
-        # Set callstack depth to 15 frames.  Must be done as a direct
-        # target_compile_definitions call with a numeric value because Tracy's
-        # CMakeLists.txt set_option() macro uses option() (boolean only) and
-        # would produce -DTRACY_CALLSTACK with no value if passed via OPTIONS above.
-        target_compile_definitions(TracyClient PUBLIC TRACY_CALLSTACK=15)
+        # NOTE: We deliberately do NOT define a project-wide TRACY_CALLSTACK depth
+        # here. Tracy's ZoneScoped/ZoneScopedN macros (what CITRON_PROFILE_SCOPE
+        # expands to) pass TRACY_CALLSTACK straight through as the callstack-capture
+        # depth on every single call -- if TRACY_CALLSTACK is defined project-wide,
+        # every zone everywhere captures a full stack walk on every invocation
+        # instead of a cheap timestamp, regardless of whether that zone's call site
+        # ever asked for one. For hot zones (Kernel::Svc::Call, KScheduler::
+        # ScheduleImpl, GPU per-command dispatch) this is enormous, unnecessary
+        # overhead. Tracy's header already falls back to TRACY_CALLSTACK=0 (no
+        # capture) when it's undefined, which is what we want as the default.
+        # If callstack capture is genuinely needed for a specific zone, use
+        # ZoneScopedNS(name, depth) / CITRON_PROFILE_SCOPE_CS(name, depth) at that
+        # call site instead of turning it on globally.
         if (NOT TARGET Tracy::TracyClient)
             add_library(Tracy::TracyClient ALIAS TracyClient)
         endif()

--- a/CMakeModules/dependencies.cmake
+++ b/CMakeModules/dependencies.cmake
@@ -584,6 +584,7 @@ if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
         "TRACY_NO_VSYNC_CAPTURE ON"
         "TRACY_NO_FRAME_IMAGE ON"
         "TRACY_FIBERS ON"
+        "TRACY_ONLY_IPV4 ON"
         # NOTE: TRACY_CALLSTACK is NOT passed here because Tracy's set_option() macro
         # only supports boolean ON/OFF via CMake option(), which would produce
         # -DTRACY_CALLSTACK with no value.  Tracy uses TRACY_CALLSTACK as an integer
@@ -604,11 +605,15 @@ if (CITRON_ENABLE_TRACY AND NOT TARGET Tracy::TracyClient)
     if (TARGET TracyClient)
         # Ensure LTO is completely disabled on the TracyClient library to avoid toolchain mismatches during PGO builds
         set_target_properties(TracyClient PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
-        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             target_compile_options(TracyClient PRIVATE
                 "-fno-lto"
                 "-fno-profile-generate"
                 "-fno-profile-use"
+            )
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+            target_compile_options(TracyClient PRIVATE
                 "-fno-profile-instr-generate"
                 "-fno-profile-instr-use"
                 "-fno-cs-profile-generate"

--- a/build-citron-linux.sh
+++ b/build-citron-linux.sh
@@ -71,6 +71,7 @@
 #                           v3 = x86-64-v3 (AVX2, BMI, FMA — Haswell+)
 #   --unity               Enable unity (jumbo) builds (~30-90% faster compile)
 #   --tracy               Enable Tracy profiler instrumentation (default off)
+#   --tracy-alloc         Enable Tracy heap allocator tracking (default off, requires --tracy)
 #   --relwithdebinfo      Include debug symbols alongside optimizations
 #   --clang-version N     Clang version to use (default: 21)
 #   --help, -h            Show this message
@@ -148,6 +149,7 @@ LTO_MODE="${LTO_MODE:-full}"
 PGO_MODE="${PGO_MODE:-ir}"
 UNITY_BUILD="${UNITY_BUILD:-OFF}"
 TRACY_BUILD="${TRACY_BUILD:-OFF}"
+TRACY_ALLOC_BUILD="${TRACY_ALLOC_BUILD:-OFF}"
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 NO_PACKAGE="${NO_PACKAGE:-false}"
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-${HOME}/.cache/cpm}"
@@ -1064,6 +1066,7 @@ build_common_cmake_args() {
 
     [[ "${UNITY_BUILD}" == "ON" ]] && _CMAKE_ARGS+=("-DENABLE_UNITY_BUILD=ON")
     _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY=${TRACY_BUILD}")
+    _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY_ALLOC=${TRACY_ALLOC_BUILD}")
     # Ensure the function always returns 0: a trailing [[ ]] that evaluates false
     # would otherwise return exit code 1, triggering set -e in the caller.
     :
@@ -1850,6 +1853,8 @@ while [[ $# -gt 0 ]]; do
         --no-unity)       UNITY_BUILD="OFF"; shift ;;
         --tracy)          TRACY_BUILD="ON"; shift ;;
         --no-tracy)       TRACY_BUILD="OFF"; shift ;;
+        --tracy-alloc)    TRACY_ALLOC_BUILD="ON"; shift ;;
+        --no-tracy-alloc) TRACY_ALLOC_BUILD="OFF"; shift ;;
         --relwithdebinfo) BUILD_TYPE="RelWithDebInfo"; shift ;;
         --clang-version)
             CLANG_VERSION="$2"; _set_clang_tools; shift 2 ;;

--- a/build-citron-linux.sh
+++ b/build-citron-linux.sh
@@ -1870,6 +1870,10 @@ done
 [[ -n "${STAGE}" ]] \
     || error "No stage specified.\nUsage: $0 <stage> [options]\nStages: setup generate csgenerate merge summary use bolt clean"
 
+if [[ "${TRACY_ALLOC_BUILD}" == "ON" && "${TRACY_BUILD}" != "ON" ]]; then
+    error "--tracy-alloc requires --tracy (it adds heap tracking on top of the base Tracy instrumentation and does nothing without it)."
+fi
+
 resolve_arch_flags
 
 case "${STAGE}" in

--- a/build-citron-linux.sh
+++ b/build-citron-linux.sh
@@ -70,6 +70,7 @@
 #                         Optimization target (default: auto)
 #                           v3 = x86-64-v3 (AVX2, BMI, FMA — Haswell+)
 #   --unity               Enable unity (jumbo) builds (~30-90% faster compile)
+#   --tracy               Enable Tracy profiler instrumentation (default off)
 #   --relwithdebinfo      Include debug symbols alongside optimizations
 #   --clang-version N     Clang version to use (default: 21)
 #   --help, -h            Show this message
@@ -146,6 +147,7 @@ JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 LTO_MODE="${LTO_MODE:-full}"
 PGO_MODE="${PGO_MODE:-ir}"
 UNITY_BUILD="${UNITY_BUILD:-OFF}"
+TRACY_BUILD="${TRACY_BUILD:-OFF}"
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 NO_PACKAGE="${NO_PACKAGE:-false}"
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-${HOME}/.cache/cpm}"
@@ -1061,6 +1063,7 @@ build_common_cmake_args() {
     fi
 
     [[ "${UNITY_BUILD}" == "ON" ]] && _CMAKE_ARGS+=("-DENABLE_UNITY_BUILD=ON")
+    _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY=${TRACY_BUILD}")
     # Ensure the function always returns 0: a trailing [[ ]] that evaluates false
     # would otherwise return exit code 1, triggering set -e in the caller.
     :
@@ -1845,6 +1848,8 @@ while [[ $# -gt 0 ]]; do
             esac ;;
         --unity)          UNITY_BUILD="ON";  shift ;;
         --no-unity)       UNITY_BUILD="OFF"; shift ;;
+        --tracy)          TRACY_BUILD="ON"; shift ;;
+        --no-tracy)       TRACY_BUILD="OFF"; shift ;;
         --relwithdebinfo) BUILD_TYPE="RelWithDebInfo"; shift ;;
         --clang-version)
             CLANG_VERSION="$2"; _set_clang_tools; shift 2 ;;

--- a/build-clangtron-windows.sh
+++ b/build-clangtron-windows.sh
@@ -162,6 +162,7 @@
 #     --release                Release build (default)
 #     --relwithdebinfo         RelWithDebInfo (adds -g, keeps O3/LTO/PGO)
 #     --unity                  Unity builds (~30-90% faster compile, no runtime effect)
+#     --tracy                  Enable Tracy profiler instrumentation (default off)
 #     --clang-version N        Host Clang version (default: 21)
 #     --llvm-mingw-version VER llvm-mingw release tag (default: 20260224)
 #
@@ -219,6 +220,7 @@ JOBS="${JOBS:-$(nproc)}"
 LTO_MODE="${LTO_MODE:-full}"
 PGO_MODE="${PGO_MODE:-ir}"          # ir|fe|none
 UNITY_BUILD="${UNITY_BUILD:-OFF}"   # ENABLE_UNITY_BUILD
+TRACY_BUILD="${TRACY_BUILD:-OFF}"   # CITRON_ENABLE_TRACY
 BUILD_TYPE="${BUILD_TYPE:-Release}" # Release|RelWithDebInfo
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-${HOME}/.cache/cpm}"
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE/#\~/$HOME}"
@@ -1985,6 +1987,7 @@ build_common_cmake_args() {
         "-DCMAKE_C_FLAGS=${MARCH_NATIVE}"
         "-DCMAKE_CXX_FLAGS=${MARCH_NATIVE}"
     )
+    _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY=${TRACY_BUILD}")
     # Always return 0 — a trailing [[ ]] that evaluates false would trigger set -e in caller.
     :
 }
@@ -4787,6 +4790,10 @@ while [[ $# -gt 0 ]]; do
             UNITY_BUILD="ON"; shift ;;
         --no-unity)
             UNITY_BUILD="OFF"; shift ;;
+        --tracy)
+            TRACY_BUILD="ON"; shift ;;
+        --no-tracy)
+            TRACY_BUILD="OFF"; shift ;;
         --clang-version)
             CLANG_VERSION="$2"
             CLANG="clang-${CLANG_VERSION}"

--- a/build-clangtron-windows.sh
+++ b/build-clangtron-windows.sh
@@ -163,6 +163,7 @@
 #     --relwithdebinfo         RelWithDebInfo (adds -g, keeps O3/LTO/PGO)
 #     --unity                  Unity builds (~30-90% faster compile, no runtime effect)
 #     --tracy                  Enable Tracy profiler instrumentation (default off)
+#     --tracy-alloc             Enable Tracy heap allocator tracking (default off, requires --tracy)
 #     --clang-version N        Host Clang version (default: 21)
 #     --llvm-mingw-version VER llvm-mingw release tag (default: 20260224)
 #
@@ -221,6 +222,7 @@ LTO_MODE="${LTO_MODE:-full}"
 PGO_MODE="${PGO_MODE:-ir}"          # ir|fe|none
 UNITY_BUILD="${UNITY_BUILD:-OFF}"   # ENABLE_UNITY_BUILD
 TRACY_BUILD="${TRACY_BUILD:-OFF}"   # CITRON_ENABLE_TRACY
+TRACY_ALLOC_BUILD="${TRACY_ALLOC_BUILD:-OFF}"   # CITRON_ENABLE_TRACY_ALLOC
 BUILD_TYPE="${BUILD_TYPE:-Release}" # Release|RelWithDebInfo
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-${HOME}/.cache/cpm}"
 CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE/#\~/$HOME}"
@@ -1988,6 +1990,7 @@ build_common_cmake_args() {
         "-DCMAKE_CXX_FLAGS=${MARCH_NATIVE}"
     )
     _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY=${TRACY_BUILD}")
+    _CMAKE_ARGS+=("-DCITRON_ENABLE_TRACY_ALLOC=${TRACY_ALLOC_BUILD}")
     # Always return 0 — a trailing [[ ]] that evaluates false would trigger set -e in caller.
     :
 }
@@ -4713,6 +4716,7 @@ ${sccache_cmake_args}
 ${qt_cmake_line}
   -DCITRON_ENABLE_LTO=${_clangcl_lto_cmake} ^
   -DCITRON_ENABLE_TRACY=${TRACY_BUILD} ^
+  -DCITRON_ENABLE_TRACY_ALLOC=${TRACY_ALLOC_BUILD} ^
   -DCITRON_ENABLE_PGO_GENERATE=${_clangcl_pgo_generate} -DCITRON_ENABLE_PGO_USE=${_clangcl_pgo_use} ^
   -DCMAKE_C_FLAGS_${config^^}="${config_compile_flags} ${flags_batch}" -DCMAKE_CXX_FLAGS_${config^^}="${config_compile_flags} ${flags_batch}" ^
   -DCMAKE_EXE_LINKER_FLAGS_${config^^}="${config_link_flags}" ^
@@ -4824,6 +4828,10 @@ while [[ $# -gt 0 ]]; do
             TRACY_BUILD="ON"; shift ;;
         --no-tracy)
             TRACY_BUILD="OFF"; shift ;;
+        --tracy-alloc)
+            TRACY_ALLOC_BUILD="ON"; shift ;;
+        --no-tracy-alloc)
+            TRACY_ALLOC_BUILD="OFF"; shift ;;
         --clang-version)
             CLANG_VERSION="$2"
             CLANG="clang-${CLANG_VERSION}"

--- a/build-clangtron-windows.sh
+++ b/build-clangtron-windows.sh
@@ -4857,6 +4857,10 @@ done
 
 [[ -n "$STAGE" ]] || error "No stage specified. Run with --help for usage."
 
+if [[ "${TRACY_ALLOC_BUILD}" == "ON" && "${TRACY_BUILD}" != "ON" ]]; then
+    error "--tracy-alloc requires --tracy (it adds heap tracking on top of the base Tracy instrumentation and does nothing without it)."
+fi
+
 if [[ "${COMPILER_MODE}" == "clang-cl" ]]; then
     if [[ "${STAGE}" == "setup" ]]; then
         stage_setup

--- a/build-clangtron-windows.sh
+++ b/build-clangtron-windows.sh
@@ -4653,6 +4653,35 @@ stage_clangcl() {
     local pgo_link_flags_batch="${pgo_link_flags//%/%%}"
     local pgo_flags_dash_batch="${pgo_flags_dash//%/%%}"
 
+    # NOTE: CITRON_ENABLE_LTO and CITRON_ENABLE_PGO_GENERATE/USE are deliberately left
+    # OFF below, even though this build may genuinely be doing LTO/PGO via the raw
+    # /clang:-flto=... and /clang:-fprofile-instr-... flags already baked into
+    # CMAKE_C/CXX_FLAGS_${config} above. Do NOT "fix" these to reflect real state --
+    # turning them ON activates CMake-native, MSVC-flavored codepaths that fire
+    # whenever MSVC==TRUE (true for clang-cl) and stack incompatible flags on top of
+    # the script's own Clang-native ones:
+    #   - citron_configure_lto() (called from common/core/video_core/shader_recompiler/
+    #     network/audio_core/hid_core/input_common/frontend_common/web_service) sets
+    #     CMake's INTERPROCEDURAL_OPTIMIZATION property, which for an MSVC-ABI compiler
+    #     means CMake injects /GL at compile time and expects /LTCG at link time --
+    #     MSVC's own whole-program-optimization mechanism, not Clang's bitcode LTO.
+    #   - the top-level `if (MSVC) ... add_link_options(/LTCG)` block (CMakeLists.txt)
+    #     fires on the same OR condition.
+    #   - citron_configure_pgo()'s MSVC branch adds /FASTGENPROFILE, /PGD:, and
+    #     /USEPROFILE:PGD= link options -- MSVC's .pgd-based PGO, a completely
+    #     different, incompatible system from Clang's .profraw/.profdata instr-PGO
+    #     the script already sets up via -fprofile-instr-generate/-fprofile-instr-use.
+    #   - PGO.cmake's `if (MSVC) ... add_compile_options(/GL)` block fires too, and is
+    #     not gated by CITRON_PGO_FLAGS_MANAGED_BY_SCRIPT (that guard only wraps the
+    #     GNU/Clang branch, not the MSVC one).
+    # TracyClient's own LTO/PGO opt-out in dependencies.cmake does not depend on these
+    # vars being accurate -- it unconditionally forces INTERPROCEDURAL_OPTIMIZATION
+    # FALSE and appends -fno-lto/-fno-profile-* as target-level compile options on
+    # TracyClient regardless, so Tracy stays correctly isolated either way.
+    local _clangcl_lto_cmake="OFF"
+    local _clangcl_pgo_generate="OFF"
+    local _clangcl_pgo_use="OFF"
+
     cat > "${build_dir}/build-clang-cl.cmd" <<CLANGCL_CMD_EOF
 @echo off
 setlocal
@@ -4682,8 +4711,9 @@ ${sccache_cmake_args}
   -DCLANGCL_OPENSSL_EXTRA_CFLAGS="${pgo_flags_dash_batch}" ^
   -DCLANGCL_FFMPEG_EXTRA_CFLAGS="${pgo_flags_dash_batch}" ^
 ${qt_cmake_line}
-  -DCITRON_ENABLE_LTO=OFF ^
-  -DCITRON_ENABLE_PGO_GENERATE=OFF -DCITRON_ENABLE_PGO_USE=OFF ^
+  -DCITRON_ENABLE_LTO=${_clangcl_lto_cmake} ^
+  -DCITRON_ENABLE_TRACY=${TRACY_BUILD} ^
+  -DCITRON_ENABLE_PGO_GENERATE=${_clangcl_pgo_generate} -DCITRON_ENABLE_PGO_USE=${_clangcl_pgo_use} ^
   -DCMAKE_C_FLAGS_${config^^}="${config_compile_flags} ${flags_batch}" -DCMAKE_CXX_FLAGS_${config^^}="${config_compile_flags} ${flags_batch}" ^
   -DCMAKE_EXE_LINKER_FLAGS_${config^^}="${config_link_flags}" ^
   -DCITRON_CLANGCL_PGO_COMPILE_FLAGS="${pgo_flags_batch}" -DCITRON_CLANGCL_PGO_LINK_FLAGS="${pgo_link_flags_batch}" ^

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -12,6 +12,7 @@
 #include "audio_core/sink/sink_stream.h"
 #include "common/common_types.h"
 #include "common/fixed_point.h"
+#include "common/profiling.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "core/core.h"
@@ -201,6 +202,7 @@ void SinkStream::ProcessAudioIn(std::span<const s16> input_buffer, std::size_t n
 }
 
 void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::size_t num_frames) {
+    CITRON_PROFILE_SCOPE("SinkStream::ProcessAudioOutAndRender");
     const std::size_t num_channels = GetDeviceChannels();
     const std::size_t frame_size = num_channels;
     const std::size_t frame_size_bytes = frame_size * sizeof(s16);

--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -494,17 +494,33 @@ if (NOT MSVC AND NOT APPLE)
     # Force-include critical static archives and resolve cycles
     if (ENABLE_WEB_SERVICE)
         target_compile_definitions(citron PRIVATE -DENABLE_WEB_SERVICE)
-        target_link_libraries(citron PRIVATE
-            "-Wl,--start-group"
-            "-Wl,--whole-archive" common core input_common frontend_common network video_core web_service "-Wl,--no-whole-archive"
-            "-Wl,--end-group"
-        )
+        if (CITRON_ENABLE_TRACY AND TARGET TracyClient)
+            target_link_libraries(citron PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network video_core web_service TracyClient "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        else()
+            target_link_libraries(citron PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network video_core web_service "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        endif()
     else()
-        target_link_libraries(citron PRIVATE
-            "-Wl,--start-group"
-            "-Wl,--whole-archive" common core input_common frontend_common network video_core "-Wl,--no-whole-archive"
-            "-Wl,--end-group"
-        )
+        if (CITRON_ENABLE_TRACY AND TARGET TracyClient)
+            target_link_libraries(citron PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network video_core TracyClient "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        else()
+            target_link_libraries(citron PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network video_core "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        endif()
     endif()
 else()
     target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core)

--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -523,7 +523,20 @@ if (NOT MSVC AND NOT APPLE)
         endif()
     endif()
 else()
-    target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core)
+    # MSVC-style linkers (real MSVC and clang-cl, both report MSVC=TRUE) and
+    # Apple's ld64 don't understand -Wl,--whole-archive. Without an explicit
+    # equivalent, TracyClient's static initializer (which spawns the profiler
+    # worker thread) gets stripped because nothing in citron.exe directly
+    # references a TracyClient symbol.
+    if (MSVC AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
+        target_link_options(citron PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE_NAME:TracyClient>")
+        target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core TracyClient)
+    elseif (APPLE AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
+        target_link_options(citron PRIVATE "-Wl,-force_load,$<TARGET_FILE:TracyClient>")
+        target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core TracyClient)
+    else()
+        target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core)
+    endif()
 endif()
 
 target_link_libraries(citron PRIVATE Boost::headers glad nlohmann_json::nlohmann_json Qt6::Widgets Qt6::Network Qt6::Svg)

--- a/src/citron/CMakeLists.txt
+++ b/src/citron/CMakeLists.txt
@@ -529,7 +529,7 @@ else()
     # worker thread) gets stripped because nothing in citron.exe directly
     # references a TracyClient symbol.
     if (MSVC AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
-        target_link_options(citron PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE_NAME:TracyClient>")
+        target_link_options(citron PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE:TracyClient>")
         target_link_libraries(citron PRIVATE common core input_common frontend_common network video_core TracyClient)
     elseif (APPLE AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
         target_link_options(citron PRIVATE "-Wl,-force_load,$<TARGET_FILE:TracyClient>")

--- a/src/citron_cmd/CMakeLists.txt
+++ b/src/citron_cmd/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
     # worker thread) gets stripped because nothing in citron-cmd.exe directly
     # references a TracyClient symbol.
     if (MSVC AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
-        target_link_options(citron-cmd PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE_NAME:TracyClient>")
+        target_link_options(citron-cmd PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE:TracyClient>")
         target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common TracyClient)
     elseif (APPLE AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
         target_link_options(citron-cmd PRIVATE "-Wl,-force_load,$<TARGET_FILE:TracyClient>")

--- a/src/citron_cmd/CMakeLists.txt
+++ b/src/citron_cmd/CMakeLists.txt
@@ -64,7 +64,20 @@ if (NOT MSVC AND NOT APPLE)
         endif()
     endif()
 else()
-    target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common)
+    # MSVC-style linkers (real MSVC and clang-cl, both report MSVC=TRUE) and
+    # Apple's ld64 don't understand -Wl,--whole-archive. Without an explicit
+    # equivalent, TracyClient's static initializer (which spawns the profiler
+    # worker thread) gets stripped because nothing in citron-cmd.exe directly
+    # references a TracyClient symbol.
+    if (MSVC AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
+        target_link_options(citron-cmd PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE_NAME:TracyClient>")
+        target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common TracyClient)
+    elseif (APPLE AND CITRON_ENABLE_TRACY AND TARGET TracyClient)
+        target_link_options(citron-cmd PRIVATE "-Wl,-force_load,$<TARGET_FILE:TracyClient>")
+        target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common TracyClient)
+    else()
+        target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common)
+    endif()
 endif()
 
 target_link_libraries(citron-cmd PRIVATE glad)

--- a/src/citron_cmd/CMakeLists.txt
+++ b/src/citron_cmd/CMakeLists.txt
@@ -35,17 +35,33 @@ if (NOT MSVC AND NOT APPLE)
     # Force-include critical static archives and resolve cycles
     if (ENABLE_WEB_SERVICE)
         target_compile_definitions(citron-cmd PRIVATE -DENABLE_WEB_SERVICE)
-        target_link_libraries(citron-cmd PRIVATE
-            "-Wl,--start-group"
-            "-Wl,--whole-archive" common core input_common frontend_common network web_service "-Wl,--no-whole-archive"
-            "-Wl,--end-group"
-        )
+        if (CITRON_ENABLE_TRACY AND TARGET TracyClient)
+            target_link_libraries(citron-cmd PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network web_service TracyClient "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        else()
+            target_link_libraries(citron-cmd PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network web_service "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        endif()
     else()
-        target_link_libraries(citron-cmd PRIVATE
-            "-Wl,--start-group"
-            "-Wl,--whole-archive" common core input_common frontend_common network "-Wl,--no-whole-archive"
-            "-Wl,--end-group"
-        )
+        if (CITRON_ENABLE_TRACY AND TARGET TracyClient)
+            target_link_libraries(citron-cmd PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network TracyClient "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        else()
+            target_link_libraries(citron-cmd PRIVATE
+                "-Wl,--start-group"
+                "-Wl,--whole-archive" common core input_common frontend_common network "-Wl,--no-whole-archive"
+                "-Wl,--end-group"
+            )
+        endif()
     endif()
 else()
     target_link_libraries(citron-cmd PRIVATE common core input_common frontend_common)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -259,6 +259,13 @@ if (CITRON_ENABLE_TRACY)
     if (CITRON_ENABLE_TRACY_MEMORY)
         target_compile_definitions(common PUBLIC CITRON_ENABLE_TRACY_MEMORY=1)
     endif()
+    if (CITRON_ENABLE_TRACY_ALLOC)
+        # Global operator new/delete overrides -- only compiled in when this is
+        # explicitly on, so every other configuration keeps the default,
+        # un-instrumented allocator with no added indirection.
+        target_sources(common PRIVATE tracy_alloc.cpp)
+        target_compile_definitions(common PUBLIC CITRON_ENABLE_TRACY_ALLOC=1)
+    endif()
     target_link_libraries(common PUBLIC Tracy::TracyClient)
 endif()
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -251,6 +251,17 @@ if (CITRON_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(common PRIVATE precompiled_headers.h)
 endif()
 
+if (CITRON_ENABLE_TRACY)
+    if (NOT TARGET Tracy::TracyClient)
+        message(FATAL_ERROR "CITRON_ENABLE_TRACY=ON but Tracy::TracyClient was not fetched. Enable CITRON_USE_CPM or provide Tracy separately.")
+    endif()
+    target_compile_definitions(common PUBLIC CITRON_ENABLE_TRACY=1)
+    if (CITRON_ENABLE_TRACY_MEMORY)
+        target_compile_definitions(common PUBLIC CITRON_ENABLE_TRACY_MEMORY=1)
+    endif()
+    target_link_libraries(common PUBLIC Tracy::TracyClient)
+endif()
+
 citron_configure_lto(common)
 
 create_target_directory_groups(common)

--- a/src/common/fiber.cpp
+++ b/src/common/fiber.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <mutex>
+#include <string>
 
 #include "common/assert.h"
 #include "common/fiber.h"
+#include "common/profiling.h"
 #include "common/virtual_buffer.h"
 
 #include <boost/context/detail/fcontext.hpp>
@@ -25,6 +27,7 @@ struct Fiber::FiberImpl {
     std::shared_ptr<Fiber> previous_fiber;
     bool is_thread_fiber{};
     bool released{};
+    std::string name;
 
     u8* stack_limit{};
     u8* rewind_stack_limit{};
@@ -94,6 +97,9 @@ void Fiber::Exit() {
     if (!impl->is_thread_fiber) {
         return;
     }
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+    TracyFiberLeave;
+#endif
     impl->guard.unlock();
     impl->released = true;
 }
@@ -111,6 +117,9 @@ void Fiber::YieldTo(std::weak_ptr<Fiber> weak_from, Fiber& to) {
     to.impl->guard.lock();
     to.impl->previous_fiber = weak_from.lock();
 
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+    TracyFiberEnter(to.GetName().c_str());
+#endif
     auto transfer = boost::context::detail::jump_fcontext(to.impl->context, &to);
 
     // "from" might no longer be valid if the thread was killed
@@ -130,6 +139,17 @@ std::shared_ptr<Fiber> Fiber::ThreadToFiber() {
     fiber->impl->guard.lock();
     fiber->impl->is_thread_fiber = true;
     return fiber;
+}
+
+void Fiber::SetName(std::string name) {
+    impl->name = std::move(name);
+}
+
+const std::string& Fiber::GetName() const {
+    if (impl->name.empty()) {
+        impl->name = "Fiber_" + std::to_string(reinterpret_cast<uintptr_t>(this));
+    }
+    return impl->name;
 }
 
 } // namespace Common

--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace boost::context::detail {
 struct transfer_t;
@@ -49,6 +50,9 @@ public:
 
     /// Only call from main thread's fiber
     void Exit();
+
+    void SetName(std::string name);
+    const std::string& GetName() const;
 
 private:
     Fiber();

--- a/src/common/profiling.h
+++ b/src/common/profiling.h
@@ -15,15 +15,32 @@
  #    ifndef TRACY_FIBERS
  #        define TRACY_FIBERS
  #    endif
- #    ifndef TRACY_CALLSTACK
- #        define TRACY_CALLSTACK 15
- #    endif
+ // NOTE: We deliberately do NOT define TRACY_CALLSTACK here. Tracy's
+ // ZoneScoped/ZoneScopedN macros (what CITRON_PROFILE_SCOPE expands to) pass
+ // TRACY_CALLSTACK straight through as the callstack-capture depth on every
+ // single call. If it's defined project-wide, every zone everywhere -- including
+ // very hot ones like Kernel::Svc::Call and KScheduler::ScheduleImpl -- captures
+ // a full native stack walk on every invocation instead of a cheap timestamp.
+ // Tracy's own header falls back to TRACY_CALLSTACK 0 (no capture) when this is
+ // left undefined, which is what we want by default. Use
+ // CITRON_PROFILE_SCOPE_CS(name, depth) below at a specific call site if that
+ // one zone genuinely needs callstack capture.
 
  #    include <tracy/Tracy.hpp>
 
  #    define CITRON_PROFILE_SCOPE(name) ZoneScopedN(name)
+ #    define CITRON_PROFILE_SCOPE_CS(name, depth) ZoneScopedNS(name, depth)
  #    define CITRON_PROFILE_FRAME_MARK() FrameMark
  #    define CITRON_PROFILE_FRAME_MARK_N(name) FrameMarkNamed(name)
+ #    define CITRON_PROFILE_PLOT(name, value) TracyPlot(name, value)
+
+ // Wraps a mutex type so Tracy tracks acquire/wait/hold time on its own timeline
+ // lane. Declare in place of the plain type, e.g.:
+ //   CITRON_PROFILE_LOCKABLE(std::mutex, list_lock);
+ // The resulting variable is still a valid std::mutex-compatible lockable (works
+ // with std::scoped_lock/std::unique_lock as normal) when Tracy is enabled, and
+ // is the untouched plain type with zero overhead when it's not.
+ #    define CITRON_PROFILE_LOCKABLE(type, varname) TracyLockable(type, varname)
 
  #    if defined(CITRON_ENABLE_TRACY_MEMORY) && CITRON_ENABLE_TRACY_MEMORY
  #        define CITRON_PROFILE_MEM_SCOPE(name) CITRON_PROFILE_SCOPE(name)
@@ -34,8 +51,11 @@
  #else
 
  #    define CITRON_PROFILE_SCOPE(name)
+ #    define CITRON_PROFILE_SCOPE_CS(name, depth)
  #    define CITRON_PROFILE_FRAME_MARK()
  #    define CITRON_PROFILE_FRAME_MARK_N(name)
  #    define CITRON_PROFILE_MEM_SCOPE(name)
+ #    define CITRON_PROFILE_PLOT(name, value)
+ #    define CITRON_PROFILE_LOCKABLE(type, varname) type varname
 
  #endif

--- a/src/common/profiling.h
+++ b/src/common/profiling.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Optional Tracy instrumentation. When CITRON_ENABLE_TRACY is off (the default),
+// every macro below expands to nothing — no Tracy headers, no client code, no
+// runtime overhead.
+
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+
+ #    ifndef TRACY_ENABLE
+ #        define TRACY_ENABLE
+ #    endif
+ #    ifndef TRACY_FIBERS
+ #        define TRACY_FIBERS
+ #    endif
+ #    ifndef TRACY_CALLSTACK
+ #        define TRACY_CALLSTACK 15
+ #    endif
+
+ #    include <tracy/Tracy.hpp>
+
+ #    define CITRON_PROFILE_SCOPE(name) ZoneScopedN(name)
+ #    define CITRON_PROFILE_FRAME_MARK() FrameMark
+ #    define CITRON_PROFILE_FRAME_MARK_N(name) FrameMarkNamed(name)
+
+ #    if defined(CITRON_ENABLE_TRACY_MEMORY) && CITRON_ENABLE_TRACY_MEMORY
+ #        define CITRON_PROFILE_MEM_SCOPE(name) CITRON_PROFILE_SCOPE(name)
+ #    else
+ #        define CITRON_PROFILE_MEM_SCOPE(name)
+ #    endif
+
+ #else
+
+ #    define CITRON_PROFILE_SCOPE(name)
+ #    define CITRON_PROFILE_FRAME_MARK()
+ #    define CITRON_PROFILE_FRAME_MARK_N(name)
+ #    define CITRON_PROFILE_MEM_SCOPE(name)
+
+ #endif

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -6,6 +6,7 @@
 
 #include "common/error.h"
 #include "common/logging.h"
+#include "common/profiling.h"
 #include "common/thread.h"
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -85,6 +86,9 @@ void SetCurrentThreadPriority(ThreadPriority new_priority) {
 // Sets the debugger-visible name of the current thread.
 void SetCurrentThreadName(const char* name) {
     SetThreadDescription(GetCurrentThread(), UTF8ToUTF16W(name).data());
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+    tracy::SetThreadName(name);
+#endif
 }
 
 bool SetCurrentThreadAffinityMask(u64 affinity_mask) {
@@ -117,12 +121,18 @@ void SetCurrentThreadName(const char* name) {
 #else
     pthread_setname_np(pthread_self(), name);
 #endif
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+    tracy::SetThreadName(name);
+#endif
 }
 #endif
 
 #if defined(_WIN32)
 void SetCurrentThreadName(const char* name) {
     // Do Nothing on MingW
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
+    tracy::SetThreadName(name);
+#endif
 }
 #endif
 

--- a/src/common/tracy_alloc.cpp
+++ b/src/common/tracy_alloc.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 citron Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Global operator new/delete overrides that feed Tracy's built-in heap
+// allocator tracking (the "Memory" panel in the Tracy client), via
+// TracyAlloc/TracyFree.
+//
+// This file is only added to the `common` target when both CITRON_ENABLE_TRACY
+// and CITRON_ENABLE_TRACY_ALLOC are ON (see src/common/CMakeLists.txt) so that
+// the default global operator new/delete are left completely untouched --
+// with zero indirection -- for every other build configuration.
+//
+// Unlike CITRON_ENABLE_TRACY_MEMORY (which instruments guest emulated memory
+// bus reads/writes with profiling zones), this tracks the *host* C++ heap:
+// every allocation citron itself makes. It gives a live, continuously updated
+// view of process memory usage in Tracy, broken down by allocation site.
+
+#include <cstdlib>
+#include <new>
+
+#include <tracy/Tracy.hpp>
+
+namespace {
+// operator new is required to return a non-null pointer or throw; malloc can
+// return nullptr on failure, so retry via the new-handler chain before giving
+// up, matching what the default global operator new does.
+void* AllocOrThrow(std::size_t size) {
+    while (true) {
+        void* ptr = std::malloc(size == 0 ? 1 : size);
+        if (ptr) {
+            TracyAlloc(ptr, size);
+            return ptr;
+        }
+        std::new_handler handler = std::get_new_handler();
+        if (!handler) {
+            throw std::bad_alloc();
+        }
+        handler();
+    }
+}
+
+void* AllocOrThrowAligned(std::size_t size, std::align_val_t align) {
+    const std::size_t alignment = static_cast<std::size_t>(align);
+    while (true) {
+#if defined(_WIN32)
+        void* ptr = _aligned_malloc(size == 0 ? 1 : size, alignment);
+#else
+        void* ptr = nullptr;
+        // posix_memalign requires alignment to be a multiple of sizeof(void*).
+        const std::size_t effective_align = alignment < sizeof(void*) ? sizeof(void*) : alignment;
+        if (posix_memalign(&ptr, effective_align, size == 0 ? 1 : size) != 0) {
+            ptr = nullptr;
+        }
+#endif
+        if (ptr) {
+            TracyAlloc(ptr, size);
+            return ptr;
+        }
+        std::new_handler handler = std::get_new_handler();
+        if (!handler) {
+            throw std::bad_alloc();
+        }
+        handler();
+    }
+}
+
+void FreeAligned(void* ptr) noexcept {
+    if (!ptr) {
+        return;
+    }
+    TracyFree(ptr);
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+}
+} // namespace
+
+void* operator new(std::size_t size) {
+    return AllocOrThrow(size);
+}
+
+void* operator new[](std::size_t size) {
+    return AllocOrThrow(size);
+}
+
+void* operator new(std::size_t size, std::align_val_t align) {
+    return AllocOrThrowAligned(size, align);
+}
+
+void* operator new[](std::size_t size, std::align_val_t align) {
+    return AllocOrThrowAligned(size, align);
+}
+
+void operator delete(void* ptr) noexcept {
+    if (!ptr) {
+        return;
+    }
+    TracyFree(ptr);
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr) noexcept {
+    operator delete(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept {
+    operator delete(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t) noexcept {
+    operator delete(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t) noexcept {
+    FreeAligned(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t) noexcept {
+    FreeAligned(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t) noexcept {
+    FreeAligned(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t) noexcept {
+    FreeAligned(ptr);
+}

--- a/src/common/tracy_alloc.cpp
+++ b/src/common/tracy_alloc.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <new>
 
+#include "common/profiling.h"
 #include <tracy/Tracy.hpp>
 
 namespace {

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <dynarmic/interface/code_page.h>
+#include "common/profiling.h"
 #include "common/settings.h"
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/arm/dynarmic/arm_dynarmic_32.h"
@@ -345,11 +346,13 @@ bool ArmDynarmic32::IsInThumbMode() const {
 }
 
 HaltReason ArmDynarmic32::RunThread(Kernel::KThread* thread) {
+    CITRON_PROFILE_SCOPE("Dynarmic32::Run");
     m_jit->ClearExclusiveState();
     return TranslateHaltReason(m_jit->Run());
 }
 
 HaltReason ArmDynarmic32::StepThread(Kernel::KThread* thread) {
+    CITRON_PROFILE_SCOPE("Dynarmic32::Step");
     m_jit->ClearExclusiveState();
     return TranslateHaltReason(m_jit->Step());
 }
@@ -446,10 +449,12 @@ void ArmDynarmic32::SignalInterrupt(Kernel::KThread* thread) {
 }
 
 void ArmDynarmic32::ClearInstructionCache() {
+    CITRON_PROFILE_SCOPE("Dynarmic32::ClearCache");
     m_jit->ClearCache();
 }
 
 void ArmDynarmic32::InvalidateCacheRange(u64 addr, std::size_t size) {
+    CITRON_PROFILE_SCOPE("Dynarmic32::InvalidateCacheRange");
     m_jit->InvalidateCacheRange(static_cast<u32>(addr), size);
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <dynarmic/interface/code_page.h>
+#include "common/profiling.h"
 #include "common/settings.h"
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/arm/dynarmic/arm_dynarmic_64.h"
@@ -390,11 +391,13 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* pa
 }
 
 HaltReason ArmDynarmic64::RunThread(Kernel::KThread* thread) {
+    CITRON_PROFILE_SCOPE("Dynarmic64::Run");
     m_jit->ClearExclusiveState();
     return TranslateHaltReason(m_jit->Run());
 }
 
 HaltReason ArmDynarmic64::StepThread(Kernel::KThread* thread) {
+    CITRON_PROFILE_SCOPE("Dynarmic64::Step");
     m_jit->ClearExclusiveState();
     return TranslateHaltReason(m_jit->Step());
 }
@@ -490,10 +493,12 @@ void ArmDynarmic64::SignalInterrupt(Kernel::KThread* thread) {
 }
 
 void ArmDynarmic64::ClearInstructionCache() {
+    CITRON_PROFILE_SCOPE("Dynarmic64::ClearCache");
     m_jit->ClearCache();
 }
 
 void ArmDynarmic64::InvalidateCacheRange(u64 addr, std::size_t size) {
+    CITRON_PROFILE_SCOPE("Dynarmic64::InvalidateCacheRange");
     m_jit->InvalidateCacheRange(addr, size);
 }
 

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/fiber.h"
+#include "common/profiling.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "common/thread.h"
@@ -82,6 +83,7 @@ void CpuManager::MultiCoreRunGuestThread() {
     while (true) {
         auto* physical_core = &kernel.CurrentPhysicalCore();
         while (!physical_core->IsInterrupted()) {
+            CITRON_PROFILE_SCOPE("CpuManager::CoreTick");
             physical_core->RunThread(thread);
             physical_core = &kernel.CurrentPhysicalCore();
         }
@@ -120,6 +122,7 @@ void CpuManager::SingleCoreRunGuestThread() {
     while (true) {
         auto* physical_core = &kernel.CurrentPhysicalCore();
         if (!physical_core->IsInterrupted()) {
+            CITRON_PROFILE_SCOPE("CpuManager::CoreTick");
             physical_core->RunThread(thread);
             physical_core = &kernel.CurrentPhysicalCore();
         }
@@ -211,6 +214,7 @@ void CpuManager::RunThread(std::stop_token token, std::size_t core) {
 
     auto& data = core_data[core];
     data.host_context = Common::Fiber::ThreadToFiber();
+    data.host_context->SetName("HostCore_" + std::to_string(core));
 
     // Cleanup
     SCOPE_EXIT {

--- a/src/core/file_sys/vfs/vfs_real.cpp
+++ b/src/core/file_sys/vfs/vfs_real.cpp
@@ -204,9 +204,9 @@ bool RealVfsFilesystem::DeleteDirectory(std::string_view path_) {
     return FS::RemoveDirRecursively(path);
 }
 
-std::unique_lock<std::mutex> RealVfsFilesystem::RefreshReference(const std::string& path,
-                                                                 OpenMode perms,
-                                                                 FileReference& reference) {
+RealVfsFilesystem::ListLockGuard RealVfsFilesystem::RefreshReference(const std::string& path,
+                                                                      OpenMode perms,
+                                                                      FileReference& reference) {
     std::unique_lock lk{list_lock};
 
     // Temporarily remove from list.

--- a/src/core/file_sys/vfs/vfs_real.h
+++ b/src/core/file_sys/vfs/vfs_real.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string_view>
 #include "common/intrusive_list.h"
+#include "common/profiling.h"
 #include "core/file_sys/fs_filesystem.h"
 #include "core/file_sys/vfs/vfs.h"
 
@@ -68,13 +69,18 @@ private:
     std::map<std::string, std::weak_ptr<VfsFile>, std::less<>> cache;
     ReferenceListType open_references;
     ReferenceListType closed_references;
-    std::mutex list_lock;
+    CITRON_PROFILE_LOCKABLE(std::mutex, list_lock);
+    // list_lock's actual type depends on CITRON_PROFILE_LOCKABLE (plain std::mutex
+    // vs. tracy::Lockable<std::mutex> when Tracy is enabled) -- alias the matching
+    // unique_lock instead of spelling out std::unique_lock<std::mutex> so this can't
+    // silently mismatch if that macro's expansion ever changes.
+    using ListLockGuard = std::unique_lock<decltype(list_lock)>;
     size_t num_open_files{};
 
 private:
     friend class RealVfsFile;
-    std::unique_lock<std::mutex> RefreshReference(const std::string& path, OpenMode perms,
-                                                  FileReference& reference);
+    ListLockGuard RefreshReference(const std::string& path, OpenMode perms,
+                                    FileReference& reference);
     void DropReference(std::unique_ptr<FileReference>&& reference);
 
 private:

--- a/src/core/hle/kernel/global_scheduler_context.h
+++ b/src/core/hle/kernel/global_scheduler_context.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "common/profiling.h"
 #include "core/hardware_properties.h"
 #include "core/hle/kernel/k_priority_queue.h"
 #include "core/hle/kernel/k_scheduler_lock.h"
@@ -83,7 +84,7 @@ private:
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<KThread*> m_thread_list;
-    std::mutex m_global_list_guard;
+    CITRON_PROFILE_LOCKABLE(std::mutex, m_global_list_guard);
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -7,6 +7,7 @@
 #include "common/bit_util.h"
 #include "common/fiber.h"
 #include "common/logging.h"
+#include "common/profiling.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/core_timing.h"
@@ -385,6 +386,7 @@ void KScheduler::SwitchThread(KThread* next_thread) {
 }
 
 void KScheduler::ScheduleImpl() {
+    CITRON_PROFILE_SCOPE("KScheduler::ScheduleImpl");
     // First, clear the needs scheduling bool.
     m_state.needs_scheduling.store(false, std::memory_order_relaxed);
     std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -148,6 +148,7 @@ void KScheduler::Initialize(KThread* main_thread, KThread* idle_thread, s32 core
     // Set core ID/idle thread/interrupt task manager.
     m_core_id = core_id;
     m_idle_thread = idle_thread;
+    m_switch_fiber->SetName("SwitchFiber_Core_" + std::to_string(core_id));
     // m_state.idle_thread_stack = m_idle_thread->GetStackTop();
     // m_state.interrupt_task_manager = std::addressof(kernel.GetInterruptTaskManager());
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -262,6 +262,7 @@ Result KThread::InitializeThread(KThread* thread, KThreadFunction func, uintptr_
 
     // Initialize emulation parameters.
     thread->m_host_context = std::make_shared<Common::Fiber>(std::move(init_func));
+    thread->m_host_context->SetName("GuestThread_" + std::to_string(thread->GetId()));
 
     R_SUCCEED();
 }

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2020 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/profiling.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "citron/util/title_ids.h"
@@ -89,6 +90,7 @@ void PhysicalCore::RunThread(Kernel::KThread* thread) {
                     thread->SetStepState(StepState::StepPerformed);
                 }
             } else {
+                CITRON_PROFILE_SCOPE("PhysicalCore::RunThread");
                 hr = interface->RunThread(thread);
             }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -6,6 +6,7 @@
 
 #include <type_traits>
 
+#include "common/profiling.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/hle/kernel/k_process.h"
@@ -4439,6 +4440,7 @@ static void Call64(Core::System& system, u32 imm, std::span<uint64_t, 8> args) {
 // clang-format on
 
 void Call(Core::System& system, u32 imm) {
+    CITRON_PROFILE_SCOPE("Kernel::Svc::Call");
     auto& kernel = system.Kernel();
     auto& process = GetCurrentProcess(kernel);
 

--- a/src/core/hle/service/nvdrv/core/nvmap.h
+++ b/src/core/hle/service/nvdrv/core/nvmap.h
@@ -14,6 +14,7 @@
 
 #include "common/bit_field.h"
 #include "common/common_types.h"
+#include "common/profiling.h"
 #include "core/hle/service/nvdrv/core/container.h"
 #include "core/hle/service/nvdrv/nvdata.h"
 
@@ -156,11 +157,11 @@ public:
 
 private:
     std::list<std::shared_ptr<Handle>> unmap_queue{};
-    std::mutex unmap_queue_lock{}; //!< Protects access to `unmap_queue`
+    CITRON_PROFILE_LOCKABLE(std::mutex, unmap_queue_lock); //!< Protects access to `unmap_queue`
 
     std::unordered_map<Handle::Id, std::shared_ptr<Handle>>
         handles{};           //!< Main owning map of handles
-    std::mutex handles_lock; //!< Protects access to `handles`
+    CITRON_PROFILE_LOCKABLE(std::mutex, handles_lock); //!< Protects access to `handles`
 
     static constexpr u32 HandleIdIncrement{
         4}; //!< Each new handle ID is an increment of 4 from the previous

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -4,6 +4,7 @@
 #include <fmt/format.h>
 #include "common/assert.h"
 #include "common/logging.h"
+#include "common/profiling.h"
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/hle/ipc.h"
@@ -110,6 +111,7 @@ void ServiceFrameworkBase::InvokeRequestTipc(HLERequestContext& ctx) {
 
 Result ServiceFrameworkBase::HandleSyncRequest(Kernel::KServerSession& session,
                                                HLERequestContext& ctx) {
+    CITRON_PROFILE_SCOPE("ServiceFrameworkBase::HandleSyncRequest");
     const auto guard = LockService();
 
     Result result = ResultSuccess;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -20,6 +20,7 @@
 #include "common/common_types.h"
 #include "common/logging.h"
 #include "common/page_table.h"
+#include "common/profiling.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "common/swap.h"
@@ -648,6 +649,7 @@ struct Memory::Impl {
     /// @returns The instance of T read from the specified virtual address.
     template <typename T>
     inline T Read(Common::ProcessAddress vaddr) noexcept requires(std::is_trivially_copyable_v<T>) {
+        CITRON_PROFILE_MEM_SCOPE("Memory::Read");
         auto const addr_c1 = GetInteger(vaddr);
         if constexpr (sizeof(T) <= 1) {
             if (auto const ptr_c1 = GetPointerImpl(addr_c1, [addr_c1] {
@@ -706,6 +708,7 @@ struct Memory::Impl {
     /// @tparam T The data type to write to memory.
     template <typename T>
     inline void Write(Common::ProcessAddress vaddr, const T data) noexcept requires(std::is_trivially_copyable_v<T>) {
+        CITRON_PROFILE_MEM_SCOPE("Memory::Write");
         auto const addr_c1 = GetInteger(vaddr);
         if constexpr (sizeof(T) <= 1) {
             if (auto const ptr_c1 = GetPointerImpl(addr_c1, [addr_c1] {

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
+#include "common/profiling.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "common/thread.h"
@@ -31,6 +32,7 @@ static void RunThread(std::stop_token stop_token, Core::System& system, VideoCor
         if (stop_token.stop_requested()) {
             break;
         }
+        CITRON_PROFILE_SCOPE("GPUThread::ProcessCommand");
         if (auto* submit_list = std::get_if<SubmitListCommand>(&next.data)) {
             scheduler.Push(submit_list->channel, std::move(submit_list->entries));
         } else if (std::holds_alternative<GPUTickCommand>(next.data)) {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -13,6 +13,7 @@
 #include <fmt/ranges.h>
 
 #include "common/logging.h"
+#include "common/profiling.h"
 #include <ranges>
 #include "common/scope_exit.h"
 #include "common/settings.h"
@@ -169,6 +170,7 @@ void RendererVulkan::Composite(std::span<const Tegra::FramebufferConfig> framebu
                                swapchain.GetImageViewFormat());
     scheduler.Flush(*frame->render_ready);
     present_manager.Present(frame);
+    CITRON_PROFILE_FRAME_MARK();
 
     // Update frame timing for frame skipping
     const auto frame_end_time = std::chrono::steady_clock::now();

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -13,6 +13,7 @@
 #include "common/cityhash.h"
 #include "common/fs/fs.h"
 #include "common/fs/path_util.h"
+#include "common/profiling.h"
 #include "common/settings.h"
 #include "common/thread_worker.h"
 #include "core/core.h"
@@ -604,6 +605,7 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
         file.read(reinterpret_cast<char*>(&key), sizeof(key));
 
         workers.QueueWork([this, key, env_ = std::move(env), &state, &callback]() mutable {
+            CITRON_PROFILE_SCOPE("Vulkan::PipelineCacheWorker");
             ShaderPools pools;
             auto pipeline{CreateComputePipeline(pools, key, env_, state.statistics.get(), false)};
             std::scoped_lock lock{state.mutex};
@@ -643,6 +645,7 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
             return;
         }
         workers.QueueWork([this, key, envs_ = std::move(envs), &state, &callback]() mutable {
+            CITRON_PROFILE_SCOPE("Vulkan::PipelineCacheWorker");
             ShaderPools pools;
             boost::container::static_vector<Shader::Environment*, 5> env_ptrs;
             for (auto& env : envs_) {
@@ -856,6 +859,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline() {
         return pipeline;
     }
     serialization_thread.QueueWork([this, key = graphics_key, envs = std::move(environments.envs)] {
+        CITRON_PROFILE_SCOPE("Vulkan::PipelineCacheSerialize");
         boost::container::static_vector<const GenericEnvironment*,
                                         Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram>
             env_ptrs;
@@ -882,6 +886,7 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
         return pipeline;
     }
     serialization_thread.QueueWork([this, key, env_ = std::move(env)] {
+        CITRON_PROFILE_SCOPE("Vulkan::PipelineCacheSerialize");
         SerializePipeline(key, std::array<const GenericEnvironment*, 1>{&env_},
                           pipeline_cache_filename, CACHE_VERSION);
     });

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -9,6 +9,7 @@
 #include "video_core/renderer_vulkan/vk_query_cache.h"
 
 #include "common/thread.h"
+#include "common/profiling.h"
 #include "video_core/renderer_vulkan/vk_command_pool.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -177,7 +178,10 @@ void Scheduler::WorkerThread(std::stop_token stop_token) {
             // Perform the work, tracking whether the chunk was a submission
             // before executing.
             const bool has_submit = work->HasSubmit();
-            work->ExecuteAll(current_cmdbuf, current_upload_cmdbuf);
+            {
+                CITRON_PROFILE_SCOPE("Vulkan::WorkerExecute");
+                work->ExecuteAll(current_cmdbuf, current_upload_cmdbuf);
+            }
 
             // If the chunk was a submission, reallocate the command buffer.
             if (has_submit) {
@@ -212,6 +216,7 @@ void Scheduler::AllocateWorkerCommandBuffer() {
 }
 
 u64 Scheduler::SubmitExecution(VkSemaphore signal_semaphore, VkSemaphore wait_semaphore) {
+    CITRON_PROFILE_SCOPE("Vulkan::SubmitExecution");
     EndPendingOperations();
     InvalidateState();
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -14,6 +14,7 @@
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "common/polyfill_thread.h"
+#include "common/profiling.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -122,7 +123,7 @@ public:
         return *master_semaphore;
     }
 
-    std::mutex submit_mutex;
+    CITRON_PROFILE_LOCKABLE(std::mutex, submit_mutex);
 
 private:
     class Command {

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "common/logging.h"
+#include "common/profiling.h"
 #include <ranges>
 #include "common/settings.h"
 #include "core/core.h"
@@ -181,6 +182,7 @@ bool Swapchain::AcquireNextImage() {
 }
 
 void Swapchain::Present(VkSemaphore render_semaphore) {
+    CITRON_PROFILE_SCOPE("Vulkan::Present");
     const auto present_queue{device.GetPresentQueue()};
     const VkPresentInfoKHR present_info{
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -184,6 +184,7 @@ bool Swapchain::AcquireNextImage() {
 
 void Swapchain::Present(VkSemaphore render_semaphore) {
     CITRON_PROFILE_SCOPE("Vulkan::Present");
+#if defined(CITRON_ENABLE_TRACY) && CITRON_ENABLE_TRACY
     {
         static auto last_present = std::chrono::steady_clock::now();
         const auto now = std::chrono::steady_clock::now();
@@ -192,6 +193,7 @@ void Swapchain::Present(VkSemaphore render_semaphore) {
         last_present = now;
         CITRON_PROFILE_PLOT("Frame Time (ms)", frame_ms);
     }
+#endif
     const auto present_queue{device.GetPresentQueue()};
     const VkPresentInfoKHR present_info{
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <limits>
 #include <vector>
 
@@ -183,6 +184,14 @@ bool Swapchain::AcquireNextImage() {
 
 void Swapchain::Present(VkSemaphore render_semaphore) {
     CITRON_PROFILE_SCOPE("Vulkan::Present");
+    {
+        static auto last_present = std::chrono::steady_clock::now();
+        const auto now = std::chrono::steady_clock::now();
+        const double frame_ms =
+            std::chrono::duration<double, std::milli>(now - last_present).count();
+        last_present = now;
+        CITRON_PROFILE_PLOT("Frame Time (ms)", frame_ms);
+    }
     const auto present_queue{device.GetPresentQueue()};
     const VkPresentInfoKHR present_info{
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,


### PR DESCRIPTION
New Tracy profiler integration for CPM builds only, gated behind CITRON_ENABLE_TRACY (default off, zero cost when disabled). Adds zone-level CPU/GPU timing, frame marks, and memory tracking, viewable live in the Tracy client. Supported on Linux, Windows (llvm-mingw and clang-cl), and macOS.
Commits so far: 60d35577, 685e8985, 055ade39, b6875e4a.

Changes

New common/profiling.h macros (CITRON_PROFILE_SCOPE, CITRON_PROFILE_FRAME_MARK, etc.), no-ops when disabled.
CPM-fetched TracyClient, linked into common and propagated to consumers.
Instrumentation on CPU thread dispatch, memory, fiber/thread naming, and Vulkan rendering (pipeline cache, scheduler, swapchain).
Whole-archive/force-load linking on every toolchain so TracyClient's static initializer survives: -Wl,--whole-archive (GNU/LLD, Linux + llvm-mingw), /WHOLEARCHIVE (MSVC/clang-cl), -force_load (Apple/ld64).
--tracy build flag support in both build-citron-linux.sh and build-clangtron-windows.sh, across every build stage on each.
TRACY_DELAYED_INIT enabled — profiler initializes lazily on first use instead of during process startup.
Tracy's own build opts out of LTO/PGO regardless of the enclosing build's settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Tracy profiling with build-time toggles for core profiling, memory profiling, and heap allocation tracking (heap tracking requires profiling).
  * Added richer runtime instrumentation: named fibers/threads, profiling scopes/frame markers, lock tracking, and Vulkan frame-time measurement/plots.

* **Bug Fixes**
  * Added configure-time validation for invalid flag combinations and missing Tracy availability.
  * Updated build/link integration so Tracy components are included and preserved correctly across toolchains/link modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->