### PR TITLE
Fix: file_sys: import tickets from merged XCI partitions

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -7,6 +7,7 @@
 #include <fmt/ostream.h>
 
 #include "common/logging.h"
+#include "common/string_util.h"
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/card_image.h"
 #include "core/file_sys/content_archive.h"
@@ -54,6 +55,10 @@ XCI::XCI(VirtualFile file_, u64 program_id, size_t program_index)
 
         partitions_raw[static_cast<std::size_t>(partition)] = std::move(raw);
     }
+
+    // Converted or merged XCIs may carry tickets in any partition. Import them before
+    // constructing an NCA so rights-managed content can resolve its title key immediately.
+    ImportTicketKeys();
 
     secure_partition = std::make_shared<NSP>(
         main_hfs.GetFile(partition_names[static_cast<std::size_t>(XCIPartition::Secure)]),
@@ -277,6 +282,42 @@ std::array<u8, 0x200> XCI::GetCertificate() const {
     std::array<u8, 0x200> out;
     file->Read(out.data(), out.size(), GAMECARD_CERTIFICATE_OFFSET);
     return out;
+}
+
+void XCI::ImportTicketKeys() {
+    std::size_t tickets_found = 0;
+    std::size_t tickets_imported = 0;
+
+    for (const auto partition :
+         {XCIPartition::Update, XCIPartition::Normal, XCIPartition::Secure, XCIPartition::Logo}) {
+        const auto partition_index = static_cast<std::size_t>(partition);
+        const auto partition_dir = GetPartition(partition);
+        if (partition_dir == nullptr) {
+            continue;
+        }
+
+        for (const auto& partition_file : partition_dir->GetFiles()) {
+            if (Common::ToLower(partition_file->GetExtension()) != "tik") {
+                continue;
+            }
+
+            ++tickets_found;
+            const auto ticket = Core::Crypto::Ticket::Read(partition_file);
+            if (!keys.AddAndPersistTicket(ticket)) {
+                LOG_WARNING(Common_Filesystem,
+                            "Could not import or persist XCI ticket {}/{}",
+                            partition_names[partition_index], partition_file->GetName());
+                continue;
+            }
+
+            ++tickets_imported;
+        }
+    }
+
+    if (tickets_found != 0) {
+        LOG_INFO(Common_Filesystem, "Imported {} of {} ticket(s) found in XCI partitions",
+                 tickets_imported, tickets_found);
+    }
 }
 
 Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -135,6 +135,7 @@ public:
     std::array<u8, 0x200> GetCertificate() const;
 
 private:
+    void ImportTicketKeys();
     Loader::ResultStatus AddNCAFromPartition(XCIPartition part);
     Loader::ResultStatus TryReadHeader();
 

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <utility>
 
+#include "common/hex_util.h"
 #include "common/logging.h"
 #include <ranges>
 #include "core/crypto/aes_util.h"
@@ -70,6 +71,11 @@ NCA::NCA(VirtualFile file_, const NCA* base_nca)
             auto titlekey = keys.GetKey(Core::Crypto::S128KeyType::Titlekey, rights_id_u128[1],
                                         rights_id_u128[0]);
             if (titlekey == Core::Crypto::Key128{}) {
+                LOG_ERROR(Loader,
+                          "Missing title key for NCA '{}': title_id={:016X}, rights_id={}, "
+                          "key_generation={}",
+                          file->GetName(), reader->GetProgramId(),
+                          Common::HexToString(rights_id, false), reader->GetKeyGeneration());
                 status = Loader::ResultStatus::ErrorMissingTitlekey;
                 return;
             }


### PR DESCRIPTION
## Summary

- Scan all XCI partitions for embedded `.tik` files.
- Import and persist tickets before constructing NCAs.
- Log the NCA filename, Title ID, Rights ID, and key generation when a title key is missing.

## Why

Some merged/converted XCIs contain rights-managed content and embedded tickets outside the expected secure NSP path. On a clean NAND, these games can fail with `ErrorMissingTitlekey` but start after the corresponding split NSP has previously registered its ticket.

This ensures available XCI tickets are loaded before encrypted NCAs are parsed and provides clearer diagnostics when no usable ticket exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rights-managed content by automatically importing ticket keys from supported XCI partitions.
  * Added clearer error details when a required title key is missing or invalid, helping identify affected content and key-generation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->