### PR TITLE
fix: distinguish packed content and repair Android dumps

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -562,7 +562,8 @@ object NativeLibrary {
      * Dumps the RomFS from a game to the dump directory
      * @param gamePath Path to the game file
      * @param programId String representation of the game's program ID
-     * @param dumpPath Optional custom dump path. If null or empty, uses default dump directory
+     * @param dumpPath Ignored. Native dumping always uses the default dump root; custom
+     * destinations are handled by copyDumpToSelectedDirectory
      * @param callback Progress callback. Return true to cancel. Parameters: (max: Long, progress: Long)
      * @return true if successful, false otherwise
      */
@@ -577,8 +578,9 @@ object NativeLibrary {
      * Dumps the ExeFS from a game to the dump directory
      * @param gamePath Path to the game file
      * @param programId String representation of the game's program ID
-     * @param dumpPath Optional custom dump path. If null or empty, uses default dump directory
-     * @param callback Progress callback. Return true to cancel. Parameters: (max: Long, progress: Long)
+     * @param dumpPath Ignored. Output always uses GetModificationDumpRoot; custom destinations
+     * are handled by copyDumpToSelectedDirectory
+     * @param callback Ignored. ExeFS dumping does not report progress or support cancellation
      * @return true if successful, false otherwise
      */
     external fun dumpExeFS(

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -480,6 +480,10 @@ object NativeLibrary {
      */
     external fun removeUpdate(programId: String): Boolean
 
+    external fun hasInstalledUpdate(programId: String): Boolean
+
+    external fun hasInstalledDLC(programId: String): Boolean
+
     /**
      * Removes a single installed DLC with the given [titleId]
      * @param titleId String representation of the DLC title ID

--- a/src/android/app/src/main/java/org/citron/citron_emu/fragments/GamePropertiesFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/fragments/GamePropertiesFragment.kt
@@ -42,7 +42,6 @@ import org.citron.citron_emu.model.InstallableProperty
 import org.citron.citron_emu.model.SubmenuProperty
 import org.citron.citron_emu.model.TaskState
 import org.citron.citron_emu.utils.DirectoryInitialization
-import org.citron.citron_emu.utils.DocumentsTree
 import org.citron.citron_emu.utils.FileUtil
 import org.citron.citron_emu.utils.GameIconUtils
 import org.citron.citron_emu.utils.GpuDriverHelper
@@ -364,7 +363,16 @@ class GamePropertiesFragment : Fragment() {
             return
         }
 
-        val targets = InstalledContentTarget.entries.toTypedArray()
+        val programId = args.game.programId
+        val targets = buildList {
+            add(InstalledContentTarget.Game)
+            if (NativeLibrary.hasInstalledUpdate(programId)) {
+                add(InstalledContentTarget.Update)
+            }
+            if (NativeLibrary.hasInstalledDLC(programId)) {
+                add(InstalledContentTarget.DLC)
+            }
+        }.toTypedArray()
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.remove_installed_content)
             .setItems(targets.map { getString(it.titleId) }.toTypedArray()) { _, position ->
@@ -671,35 +679,16 @@ class GamePropertiesFragment : Fragment() {
             R.string.dump_romfs_extracting,
             false
         ) { _, _ ->
-            // Convert URI to file path if needed
-            val dumpPathString = dumpPathUri?.let { uriString ->
-                try {
-                    val uri = android.net.Uri.parse(uriString)
-                    // For document tree URIs, try to get the actual file path
-                    if (DocumentsTree.isNativePath(uriString)) {
-                        uriString
-                    } else {
-                        // Try to extract file path from document URI
-                        // For document tree URIs, we can't easily get a native path
-                        // So we'll pass the URI and let the native code handle it
-                        // or extract path using DocumentFile
-                        val docFile = DocumentFile.fromTreeUri(requireContext(), uri)
-                        docFile?.uri?.path ?: uriString
-                    }
-                } catch (e: Exception) {
-                    null
-                }
-            }
-
-            val success = NativeLibrary.dumpRomFS(
+            val dumped = NativeLibrary.dumpRomFS(
                 args.game.path,
-                args.game.programIdHex,
-                dumpPathString,
+                args.game.programId,
+                null,
                 { max, progress ->
                     // Progress callback - return true to cancel
                     false
                 }
             )
+            val success = dumped && copyDumpToSelectedDirectory(dumpPathUri, "romfs")
             if (success) {
                 getString(R.string.dump_success)
             } else {
@@ -724,37 +713,52 @@ class GamePropertiesFragment : Fragment() {
             R.string.dump_exefs_extracting,
             false
         ) { _, _ ->
-            // Convert URI to file path if needed
-            val dumpPathString = dumpPathUri?.let { uriString ->
-                try {
-                    val uri = android.net.Uri.parse(uriString)
-                    // For document tree URIs, try to get the actual file path
-                    if (DocumentsTree.isNativePath(uriString)) {
-                        uriString
-                    } else {
-                        // Try to extract file path from document URI
-                        val docFile = DocumentFile.fromTreeUri(requireContext(), uri)
-                        docFile?.uri?.path ?: uriString
-                    }
-                } catch (e: Exception) {
-                    null
-                }
-            }
-
-            val success = NativeLibrary.dumpExeFS(
+            val dumped = NativeLibrary.dumpExeFS(
                 args.game.path,
-                args.game.programIdHex,
-                dumpPathString,
+                args.game.programId,
+                null,
                 { max, progress ->
                     // Progress callback - return true to cancel
                     false
                 }
             )
+            val success = dumped && copyDumpToSelectedDirectory(dumpPathUri, "exefs")
             if (success) {
                 getString(R.string.dump_success)
             } else {
                 getString(R.string.dump_failed)
             }
         }.show(parentFragmentManager, ProgressDialogFragment.TAG)
+    }
+
+    private fun copyDumpToSelectedDirectory(treeUri: String?, contentType: String): Boolean {
+        if (treeUri == null) {
+            return true
+        }
+
+        val source = File(
+            "${DirectoryInitialization.userDirectory}/dump/" +
+                "${args.game.programIdHex}/$contentType"
+        )
+        val root = DocumentFile.fromTreeUri(requireContext(), Uri.parse(treeUri)) ?: return false
+        val titleDirectory = root.findFile(args.game.programIdHex)
+            ?: root.createDirectory(args.game.programIdHex)
+            ?: return false
+        if (!titleDirectory.isDirectory) {
+            return false
+        }
+        val destination = titleDirectory.findFile(contentType)
+            ?: titleDirectory.createDirectory(contentType)
+            ?: return false
+        if (!destination.isDirectory) {
+            return false
+        }
+
+        val copied = with(FileUtil) { source.copyFilesTo(destination) }
+        if (copied) {
+            source.deleteRecursively()
+            source.parentFile?.takeIf { it.listFiles()?.isEmpty() == true }?.delete()
+        }
+        return copied
     }
 }

--- a/src/android/app/src/main/java/org/citron/citron_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/utils/FileUtil.kt
@@ -423,6 +423,53 @@ object FileUtil {
         }
     }
 
+    fun File.copyFilesTo(documentDirectory: DocumentFile): Boolean {
+        if (!isDirectory || !documentDirectory.isDirectory) {
+            Log.error("[FileUtil] Source and destination must both be directories")
+            return false
+        }
+
+        return try {
+            listFiles()?.all { source ->
+                if (source.isDirectory) {
+                    val existing = documentDirectory.findFile(source.name)
+                    val destination = when {
+                        existing == null -> documentDirectory.createDirectory(source.name)
+                        existing.isDirectory -> existing
+                        else -> null
+                    }
+                    destination != null && source.copyFilesTo(destination)
+                } else {
+                    val existing = documentDirectory.findFile(source.name)
+                    if (existing?.isDirectory == true) {
+                        return@all false
+                    }
+                    val destination = existing ?: documentDirectory.createFile(
+                        APPLICATION_OCTET_STREAM,
+                        source.name
+                    )
+                    if (destination == null) {
+                        return@all false
+                    }
+
+                    val outputStream = context.contentResolver.openOutputStream(
+                        destination.uri,
+                        "rwt"
+                    ) ?: return@all false
+                    source.inputStream().buffered().use { input ->
+                        outputStream.use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                    true
+                }
+            } ?: false
+        } catch (e: Exception) {
+            Log.error("[FileUtil] Failed copying directory to SAF destination: ${e.message}")
+            false
+        }
+    }
+
     fun isRootTreeUri(uri: Uri): Boolean {
         val paths = uri.pathSegments
         return paths.size == 2 && PATH_TREE == paths[0]

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -588,8 +588,15 @@ void EmulationSession::ChangeProgram(std::size_t program_index) {
 u64 EmulationSession::GetProgramId(JNIEnv* env, jstring jprogramId) {
     auto program_id_string = Common::Android::GetJString(env, jprogramId);
     try {
-        return std::stoull(program_id_string);
+        std::size_t parsed_length = 0;
+        const auto program_id = std::stoull(program_id_string, &parsed_length, 10);
+        if (parsed_length != program_id_string.size()) {
+            LOG_ERROR(Frontend, "Invalid decimal program ID '{}'", program_id_string);
+            return 0;
+        }
+        return program_id;
     } catch (...) {
+        LOG_ERROR(Frontend, "Failed to parse program ID '{}'", program_id_string);
         return 0;
     }
 }
@@ -1252,6 +1259,20 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_removeUpdate(JNIEnv* env, job
         EmulationSession::GetInstance().System().GetFileSystemController(), program_id);
 }
 
+jboolean Java_org_citron_citron_1emu_NativeLibrary_hasInstalledUpdate(JNIEnv* env, jobject jobj,
+                                                                      jstring jprogramId) {
+    const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    return ContentManager::HasUpdate(
+        EmulationSession::GetInstance().System().GetFileSystemController(), program_id);
+}
+
+jboolean Java_org_citron_citron_1emu_NativeLibrary_hasInstalledDLC(JNIEnv* env, jobject jobj,
+                                                                   jstring jprogramId) {
+    const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    return ContentManager::HasDLC(
+        EmulationSession::GetInstance().System().GetFileSystemController(), program_id);
+}
+
 void Java_org_citron_citron_1emu_NativeLibrary_removeDLC(JNIEnv* env, jobject jobj,
                                                      jstring jtitleId) {
     const auto title_id = EmulationSession::GetProgramId(env, jtitleId);
@@ -1374,6 +1395,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_areKeysPresent(JNIEnv* env, j
 jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobject jobj,
                                                          jstring jgamePath, jstring jprogramId,
                                                          jstring jdumpPath, jobject jcallback) {
+    (void)jdumpPath;
     // Check if emulation is running - dumping while emulation is active can cause crashes
     if (EmulationSession::GetInstance().IsRunning()) {
         LOG_ERROR(Frontend, "Cannot dump RomFS while emulation is running. Please close the game first.");
@@ -1382,14 +1404,26 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
 
     const auto game_path = Common::Android::GetJString(env, jgamePath);
     const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    if (program_id == 0) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: invalid program ID");
+        return false;
+    }
 
     auto& system = EmulationSession::GetInstance().System();
     auto& vfs = *system.GetFilesystem();
 
-    const auto loader = Loader::GetLoader(system, vfs.OpenFile(game_path, FileSys::OpenMode::Read));
-    if (loader == nullptr) {
+    const auto game_file = vfs.OpenFile(game_path, FileSys::OpenMode::Read);
+    if (game_file == nullptr) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: failed to open game file '{}'", game_path);
         return false;
     }
+    const auto loader = Loader::GetLoader(system, game_file);
+    if (loader == nullptr) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: no loader for '{}'", game_path);
+        return false;
+    }
+
+    EmulationSession::GetInstance().ConfigureFilesystemProvider(game_path);
 
     FileSys::VirtualFile packed_update_raw{};
     loader->ReadUpdateRaw(packed_update_raw);
@@ -1415,6 +1449,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
             }
         }
         if (!found || !base_nca) {
+            LOG_ERROR(Frontend, "Cannot dump RomFS: no base Program NCA for {:016X}", program_id);
             return false;
         }
     }
@@ -1428,28 +1463,11 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
 
     const auto base_romfs = base_nca->GetRomFS();
     if (!base_romfs) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: base NCA {:016X} has no RomFS", title_id);
         return false;
     }
 
-    // Use custom dump path if provided, otherwise use default
-    std::filesystem::path dump_dir;
-    if (jdumpPath != nullptr) {
-        const auto custom_path = Common::Android::GetJString(env, jdumpPath);
-        if (!custom_path.empty()) {
-            // Check if it's a native path (starts with /) or try to use it as-is
-            if (custom_path[0] == '/') {
-                dump_dir = std::filesystem::path(custom_path);
-            } else {
-                // Try to parse as URI and extract path
-                // For document tree URIs, we can't easily get a native path
-                // So fall back to default
-                dump_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::DumpDir);
-            }
-        }
-    }
-    if (dump_dir.empty()) {
-        dump_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::DumpDir);
-    }
+    const auto dump_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::DumpDir);
     const auto romfs_dir = fmt::format("{:016X}/romfs", title_id);
     const auto path = dump_dir / romfs_dir;
 
@@ -1457,11 +1475,13 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
     auto romfs = pm.PatchRomFS(base_nca.get(), base_romfs, type, packed_update_raw, false);
 
     if (!romfs) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: failed to patch RomFS for {:016X}", title_id);
         return false;
     }
 
     const auto extracted = FileSys::ExtractRomFS(romfs);
     if (extracted == nullptr) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: failed to extract RomFS for {:016X}", title_id);
         return false;
     }
 
@@ -1469,6 +1489,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
     const auto path_str = Common::FS::PathToUTF8String(path);
     const auto out_dir = vfs.CreateDirectory(path_str, FileSys::OpenMode::ReadWrite);
     if (!out_dir || !out_dir->IsWritable()) {
+        LOG_ERROR(Frontend, "Cannot dump RomFS: output directory '{}' is not writable", path_str);
         return false;
     }
 
@@ -1509,6 +1530,8 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
                 }
                 const auto out_file = dest->CreateFile(file->GetName());
                 if (!FileSys::VfsRawCopy(file, out_file)) {
+                    LOG_ERROR(Frontend, "Cannot dump RomFS: failed to copy '{}'",
+                              file->GetFullPath());
                     return false;
                 }
                 if (callback(file->GetSize())) {
@@ -1536,6 +1559,8 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpRomFS(JNIEnv* env, jobjec
 jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobject jobj,
                                                           jstring jgamePath, jstring jprogramId,
                                                           jstring jdumpPath, jobject jcallback) {
+    (void)jdumpPath;
+    (void)jcallback;
     // Check if emulation is running - dumping while emulation is active can cause crashes
     if (EmulationSession::GetInstance().IsRunning()) {
         LOG_ERROR(Frontend, "Cannot dump ExeFS while emulation is running. Please close the game first.");
@@ -1544,14 +1569,26 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobjec
 
     const auto game_path = Common::Android::GetJString(env, jgamePath);
     const auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    if (program_id == 0) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: invalid program ID");
+        return false;
+    }
 
     auto& system = EmulationSession::GetInstance().System();
     auto& vfs = *system.GetFilesystem();
 
-    const auto loader = Loader::GetLoader(system, vfs.OpenFile(game_path, FileSys::OpenMode::Read));
-    if (loader == nullptr) {
+    const auto game_file = vfs.OpenFile(game_path, FileSys::OpenMode::Read);
+    if (game_file == nullptr) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: failed to open game file '{}'", game_path);
         return false;
     }
+    const auto loader = Loader::GetLoader(system, game_file);
+    if (loader == nullptr) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: no loader for '{}'", game_path);
+        return false;
+    }
+
+    EmulationSession::GetInstance().ConfigureFilesystemProvider(game_path);
 
     const auto& installed = system.GetContentProvider();
 
@@ -1559,7 +1596,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobjec
     u64 title_id = program_id;
     const auto type = FileSys::ContentRecordType::Program;
     auto base_nca = installed.GetEntry(title_id, type);
-    if (!base_nca) {
+    if (!base_nca || base_nca->GetStatus() != Loader::ResultStatus::Success) {
         // Try to find any matching entry
         const auto entries = installed.ListEntriesFilter(FileSys::TitleType::Application, type);
         for (const auto& entry : entries) {
@@ -1572,6 +1609,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobjec
             }
         }
         if (!base_nca || base_nca->GetStatus() != Loader::ResultStatus::Success) {
+            LOG_ERROR(Frontend, "Cannot dump ExeFS: no base Program NCA for {:016X}", program_id);
             return false;
         }
     }
@@ -1584,6 +1622,7 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobjec
             exefs = update_nca->GetExeFS();
         }
         if (!exefs) {
+            LOG_ERROR(Frontend, "Cannot dump ExeFS: no ExeFS for {:016X}", title_id);
             return false;
         }
     }
@@ -1593,36 +1632,29 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_dumpExeFS(JNIEnv* env, jobjec
     exefs = pm.PatchExeFS(exefs);
 
     if (!exefs) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: failed to patch ExeFS for {:016X}", title_id);
         return false;
     }
 
-    // Use custom dump path if provided, otherwise use default
-    FileSys::VirtualDir dump_dir;
-    if (jdumpPath != nullptr) {
-        const auto custom_path = Common::Android::GetJString(env, jdumpPath);
-        if (!custom_path.empty() && custom_path[0] == '/') {
-            // Create directory using VFS (native path only)
-            dump_dir = vfs.CreateDirectory(custom_path, FileSys::OpenMode::ReadWrite);
-            if (!dump_dir || !dump_dir->IsWritable()) {
-                dump_dir = nullptr;
-            }
-        }
-    }
+    const auto dump_dir = system.GetFileSystemController().GetModificationDumpRoot(title_id);
     if (!dump_dir) {
-        // Fall back to default dump directory
-        dump_dir = system.GetFileSystemController().GetModificationDumpRoot(title_id);
-        if (!dump_dir) {
-            return false;
-        }
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: failed to open dump root for {:016X}", title_id);
+        return false;
     }
 
     const auto exefs_dir = FileSys::GetOrCreateDirectoryRelative(dump_dir, "/exefs");
     if (!exefs_dir) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: failed to create output directory for {:016X}",
+                  title_id);
         return false;
     }
 
     // Copy ExeFS - callback is unused for ExeFS as it's typically small
-    return FileSys::VfsRawCopyD(exefs, exefs_dir);
+    if (!FileSys::VfsRawCopyD(exefs, exefs_dir)) {
+        LOG_ERROR(Frontend, "Cannot dump ExeFS: failed to copy files for {:016X}", title_id);
+        return false;
+    }
+    return true;
 }
 
 } // extern "C"

--- a/src/citron/game_list.cpp
+++ b/src/citron/game_list.cpp
@@ -101,6 +101,7 @@
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/hle/service/acc/profile_manager.h"
+#include "frontend_common/content_manager.h"
 
 // A helper struct to cleanly pass game data
 struct SurpriseGame {
@@ -3322,8 +3323,11 @@ void GameList::AddGamePopup(QMenu& context_menu, const QModelIndex& index, u64 p
     open_mod_location->setVisible(program_id != 0);
     open_sdmc_mod_menu->menuAction()->setVisible(program_id != 0);
     open_transferable_shader_cache->setVisible(program_id != 0);
-    remove_update->setVisible(program_id != 0);
-    remove_dlc->setVisible(program_id != 0);
+    remove_update->setVisible(
+        program_id != 0 &&
+        ContentManager::HasUpdate(system.GetFileSystemController(), program_id));
+    remove_dlc->setVisible(
+        program_id != 0 && ContentManager::HasDLC(system.GetFileSystemController(), program_id));
     remove_vk_shader_cache->setVisible(program_id != 0);
     remove_shader_cache->setVisible(program_id != 0);
     remove_all_content->setVisible(program_id != 0);

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -93,7 +93,12 @@ const LanguageEntry& NACP::GetLanguageEntry() const {
 }
 
 void NACP::DecompressTitleBlock() {
-    if (raw.title_compression == 0) {
+    if (raw.title_compression != 1) {
+        if (raw.title_compression != 0) {
+            LOG_WARNING(Service_FS,
+                        "Unknown NACP title compression flag 0x{:02X}; using uncompressed titles",
+                        raw.title_compression);
+        }
         std::memcpy(language_entries_.data(), raw.language_entries.data(),
                      sizeof(LanguageEntry) * UncompressedLanguageCount);
         return;

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -736,11 +736,16 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
     };
     bool is_installed_control = true;
     bool is_installed_program = true;
+    bool has_packaged_update = false;
     if (content_provider_union) {
         is_installed_control = is_removable_origin(
             content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Control));
         is_installed_program = is_removable_origin(
             content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Program));
+        const auto* frontend_manual = content_provider_union->GetSlotProvider(
+            ContentProviderUnionSlot::FrontendManual);
+        has_packaged_update =
+            frontend_manual && frontend_manual->HasEntry(update_tid, ContentRecordType::Program);
     }
 
     Metadata metadata{};
@@ -890,7 +895,7 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
         }
     }
 
-    if (out.empty() && update_raw != nullptr) {
+    if (has_packaged_update || (out.empty() && update_raw != nullptr)) {
         Patch update_patch = {.enabled = !update_disabled,
                               .name = "NAND Files/Update",
                               .version = "PACKED",

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -726,27 +726,31 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
     // --- 1. Update (NAND/External) ---
     // First, check for system updates (NAND/SDMC)
     const auto update_tid = GetUpdateTitleID(title_id);
-    PatchManager update_mgr{update_tid, fs_controller, content_provider};
-    const auto metadata = update_mgr.GetControlMetadata();
-    const auto& nacp = metadata.first;
     const auto update_disabled =
         std::find(disabled.cbegin(), disabled.cend(), "Update") != disabled.cend();
 
     const auto* content_provider_union = GetUnionProvider(content_provider);
-    bool is_nand_control = true;
-    bool is_nand_program = true;
+    const auto is_removable_origin = [](std::optional<ContentProviderUnionSlot> origin) {
+        return origin && (*origin == ContentProviderUnionSlot::UserNAND ||
+                          *origin == ContentProviderUnionSlot::SDMC);
+    };
+    bool is_installed_control = true;
+    bool is_installed_program = true;
     if (content_provider_union) {
-        auto slot_control = content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Control);
-        if (slot_control && *slot_control == ContentProviderUnionSlot::External) {
-            is_nand_control = false;
-        }
-        auto slot_program = content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Program);
-        if (slot_program && *slot_program == ContentProviderUnionSlot::External) {
-            is_nand_program = false;
-        }
+        is_installed_control = is_removable_origin(
+            content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Control));
+        is_installed_program = is_removable_origin(
+            content_provider_union->GetSlotForEntry(update_tid, ContentRecordType::Program));
     }
 
-    if (nacp != nullptr && is_nand_control) {
+    Metadata metadata{};
+    if (is_installed_control) {
+        PatchManager update_mgr{update_tid, fs_controller, content_provider};
+        metadata = update_mgr.GetControlMetadata();
+    }
+    const auto& nacp = metadata.first;
+
+    if (nacp != nullptr && is_installed_control) {
         // System update found
         const auto version_str = CleanNacpVersion(nacp->GetVersionString());
         const auto name = fmt::format("NAND Files/Update v{}", version_str);
@@ -758,9 +762,11 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
                               .version = version_str,
                               .type = PatchType::Update,
                               .program_id = title_id,
-                              .title_id = title_id};
+                              .title_id = title_id,
+                              .removable = true};
         out.push_back(update_patch);
-    } else if (content_provider.HasEntry(update_tid, ContentRecordType::Program) && is_nand_program) {
+    } else if (content_provider.HasEntry(update_tid, ContentRecordType::Program) &&
+               is_installed_program) {
         // Fallback for system update without control NCA (rare)
         const auto meta_ver = content_provider.GetEntryVersion(update_tid);
         if (meta_ver.value_or(0) != 0) {
@@ -774,7 +780,8 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
                                   .version = version_str,
                                   .type = PatchType::Update,
                                   .program_id = title_id,
-                                  .title_id = title_id};
+                                  .title_id = title_id,
+                                  .removable = true};
             out.push_back(update_patch);
         }
     }
@@ -786,15 +793,15 @@ std::vector<Patch> PatchManager::GetPatches(VirtualFile update_raw) const {
         // resolves across the WHOLE union including External) so an external-only update
         // can never be misread as a NAND version and wrongly deduped against itself.
         std::optional<u32> nand_numeric_version;
-        if (is_nand_control || is_nand_program) {
-            if (const auto* sys = content_provider_union->GetSlotProvider(
-                    ContentProviderUnionSlot::SysNAND)) {
-                nand_numeric_version = sys->GetEntryVersion(update_tid);
+        if (is_installed_control || is_installed_program) {
+            if (const auto* user = content_provider_union->GetSlotProvider(
+                    ContentProviderUnionSlot::UserNAND)) {
+                nand_numeric_version = user->GetEntryVersion(update_tid);
             }
             if (!nand_numeric_version) {
-                if (const auto* user = content_provider_union->GetSlotProvider(
-                        ContentProviderUnionSlot::UserNAND)) {
-                    nand_numeric_version = user->GetEntryVersion(update_tid);
+                if (const auto* sdmc = content_provider_union->GetSlotProvider(
+                        ContentProviderUnionSlot::SDMC)) {
+                    nand_numeric_version = sdmc->GetEntryVersion(update_tid);
                 }
             }
         }

--- a/src/frontend_common/content_manager.h
+++ b/src/frontend_common/content_manager.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <boost/algorithm/string.hpp>
 #include "common/common_types.h"
 #include "common/literals.h"
@@ -32,6 +34,33 @@ enum class GameVerificationResult {
     Failed,
     NotImplemented,
 };
+
+inline bool HasUpdate(const Service::FileSystem::FileSystemController& fs_controller,
+                      const u64 program_id) {
+    const auto update_id = FileSys::GetUpdateTitleID(program_id);
+    const auto has_update = [update_id](const FileSys::RegisteredCache* cache) {
+        return cache != nullptr &&
+               cache->HasEntry(update_id, FileSys::ContentRecordType::Program);
+    };
+    return has_update(fs_controller.GetUserNANDContents()) ||
+           has_update(fs_controller.GetSDMCContents());
+}
+
+inline bool HasDLC(const Service::FileSystem::FileSystemController& fs_controller,
+                   const u64 program_id) {
+    const auto has_dlc = [program_id](const FileSys::RegisteredCache* cache) {
+        if (cache == nullptr) {
+            return false;
+        }
+        const auto entries = cache->ListEntriesFilter(FileSys::TitleType::AOC,
+                                                      FileSys::ContentRecordType::Data);
+        return std::any_of(entries.cbegin(), entries.cend(), [program_id](const auto& entry) {
+            return FileSys::GetBaseTitleID(entry.title_id) == program_id;
+        });
+    };
+    return has_dlc(fs_controller.GetUserNANDContents()) ||
+           has_dlc(fs_controller.GetSDMCContents());
+}
 
 /**
  * \brief Removes a single installed DLC


### PR DESCRIPTION
## Description
* Mark updates and DLC inside XCI/NSP packages as non-removable; only NAND/SDMC content can be uninstalled.
* Fix Android RomFS/ExeFS dumps passing hexadecimal title IDs to a decimal parser.
* Correct SAF custom dump destination handling.
* Add clearer dump failure logging and NACP compression fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Game management options now show removal actions only when an installed update or DLC exists.
  - ROMFS and ExeFS dumps can be saved by copying the dump results into a user-selected folder.
  - Enhanced detection of installed updates and DLC for more accurate UI behavior.
- **Bug Fixes**
  - Improved dump success/failure reporting to include destination copy issues, with clearer error diagnostics.
  - More robust handling of unexpected title metadata (nonstandard title-compression values).
  - Better diagnostics for missing/invalid game content and stricter program-id validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->