### PR TITLE
android: allow composing text in HLE keyboard

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -8,6 +8,7 @@ package org.citron.citron_emu.applets.keyboard
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.text.InputType
 import android.view.KeyEvent
 import android.view.View
 import android.view.WindowInsets
@@ -99,6 +100,27 @@ object SoftwareKeyboard {
     fun getInlineInitialText(): String = inlineConfig?.initial_text.orEmpty()
 
     fun getInlineInitialCursorPosition(): Int = inlineConfig?.initial_cursor_position ?: 0
+
+    fun getInlineEditorInputType(): Int =
+        inlineConfig?.let(::getEditorInputType) ?: InputType.TYPE_CLASS_TEXT
+
+    fun getEditorInputType(config: KeyboardConfig): Int {
+        val passwordEnabled = config.password_mode == SwkbdPasswordMode.Enabled.ordinal
+        return when (config.type) {
+            SwkbdType.NumberPad.ordinal -> {
+                InputType.TYPE_CLASS_NUMBER or
+                    if (passwordEnabled) InputType.TYPE_NUMBER_VARIATION_PASSWORD else 0
+            }
+            else -> {
+                InputType.TYPE_CLASS_TEXT or
+                    if (passwordEnabled) {
+                        InputType.TYPE_TEXT_VARIATION_PASSWORD
+                    } else {
+                        InputType.TYPE_TEXT_VARIATION_NORMAL
+                    }
+            }
+        }
+    }
 
     fun clearInlineConfig() {
         inlineConfig = null

--- a/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/ui/KeyboardDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/applets/keyboard/ui/KeyboardDialogFragment.kt
@@ -7,7 +7,6 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.text.InputFilter
-import android.text.InputType
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.citron.citron_emu.R
@@ -30,35 +29,7 @@ class KeyboardDialogFragment : DialogFragment() {
         binding.editText.filters =
             arrayOf<InputFilter>(InputFilter.LengthFilter(config.max_text_length))
 
-        // Handle input type
-        var inputType: Int
-        when (config.type) {
-            SoftwareKeyboard.SwkbdType.Normal.ordinal,
-            SoftwareKeyboard.SwkbdType.Qwerty.ordinal,
-            SoftwareKeyboard.SwkbdType.Unknown3.ordinal,
-            SoftwareKeyboard.SwkbdType.Latin.ordinal,
-            SoftwareKeyboard.SwkbdType.SimplifiedChinese.ordinal,
-            SoftwareKeyboard.SwkbdType.TraditionalChinese.ordinal,
-            SoftwareKeyboard.SwkbdType.Korean.ordinal -> {
-                inputType = InputType.TYPE_CLASS_TEXT
-                if (config.password_mode == SoftwareKeyboard.SwkbdPasswordMode.Enabled.ordinal) {
-                    inputType = inputType or InputType.TYPE_TEXT_VARIATION_PASSWORD
-                }
-            }
-            SoftwareKeyboard.SwkbdType.NumberPad.ordinal -> {
-                inputType = InputType.TYPE_CLASS_NUMBER
-                if (config.password_mode == SoftwareKeyboard.SwkbdPasswordMode.Enabled.ordinal) {
-                    inputType = inputType or InputType.TYPE_NUMBER_VARIATION_PASSWORD
-                }
-            }
-            else -> {
-                inputType = InputType.TYPE_CLASS_TEXT
-                if (config.password_mode == SoftwareKeyboard.SwkbdPasswordMode.Enabled.ordinal) {
-                    inputType = inputType or InputType.TYPE_TEXT_VARIATION_PASSWORD
-                }
-            }
-        }
-        binding.editText.inputType = inputType
+        binding.editText.inputType = SoftwareKeyboard.getEditorInputType(config)
 
         val headerText =
             config.header_text!!.ifEmpty { resources.getString(R.string.software_keyboard) }

--- a/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
@@ -105,9 +105,8 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
         Selection.setSelection(keyboardEditable, initialCursorPosition)
         keyboardLastSubmittedText = initialText
 
-        // Password/visible-password variations disable composing input in IMEs such as Gboard.
-        // Use the software keyboard's actual type so Chinese, Japanese, and Korean IMEs can
-        // compose text while numeric and password keyboards retain their intended behavior.
+        // Treating every field as visible-password/no-suggestions can disable composing
+        // behavior in IMEs such as Gboard. Use the actual software keyboard type instead.
         outAttrs.inputType = SoftwareKeyboard.getInlineEditorInputType()
 
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_ACTION_DONE

--- a/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/overlay/InputOverlay.kt
@@ -14,7 +14,6 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.VectorDrawable
 import android.os.Build
 import android.text.Editable
-import android.text.InputType
 import android.text.Selection
 import android.util.AttributeSet
 import android.view.HapticFeedbackConstants
@@ -106,9 +105,10 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
         Selection.setSelection(keyboardEditable, initialCursorPosition)
         keyboardLastSubmittedText = initialText
 
-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT or
-            InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS or
-            InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+        // Password/visible-password variations disable composing input in IMEs such as Gboard.
+        // Use the software keyboard's actual type so Chinese, Japanese, and Korean IMEs can
+        // compose text while numeric and password keyboards retain their intended behavior.
+        outAttrs.inputType = SoftwareKeyboard.getInlineEditorInputType()
 
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_ACTION_DONE
         outAttrs.initialSelStart = initialCursorPosition


### PR DESCRIPTION
## Summary
Fix Chinese and other composing IME input in the HLE software keyboard.
*Use the appropriate Android input type instead of treating all text fields as visible passwords.
*Preserve numeric and password keyboard behavior.
*Share the input-type configuration between inline and dialog keyboards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android keyboard behavior for text, numeric, and password fields by using the correct input mode for each field.
  * Password entries now apply secure input handling instead of treating all fields as generic text.
  * Numeric and password keyboards provide better compatibility with Android input methods and composition.
  * Inline keyboard fields now respect their configured input type (rather than a fixed text setup), improving IME behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->