### PR TITLE
fix android: fall back from missing per-game GPU drivers

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
@@ -147,7 +147,7 @@ class DriverViewModel : ViewModel() {
     fun onLaunchGame() {
         _isDriverReady.value = false
 
-        val selectedDriverFile = File(StringSetting.DRIVER_PATH.getString())
+        val selectedDriverFile = GpuDriverHelper.customDriverSettingFile
         val selectedDriverMetadata = GpuDriverHelper.customDriverSettingData
         if (GpuDriverHelper.installedCustomDriverData == selectedDriverMetadata) {
             setDriverReady()

--- a/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/model/DriverViewModel.kt
@@ -147,15 +147,16 @@ class DriverViewModel : ViewModel() {
     fun onLaunchGame() {
         _isDriverReady.value = false
 
-        val selectedDriverFile = GpuDriverHelper.customDriverSettingFile
-        val selectedDriverMetadata = GpuDriverHelper.customDriverSettingData
-        if (GpuDriverHelper.installedCustomDriverData == selectedDriverMetadata) {
-            setDriverReady()
-            return
-        }
-
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
+                val selectedDriverFile = GpuDriverHelper.resolveCustomDriverFile()
+                val selectedDriverMetadata =
+                    GpuDriverHelper.getMetadataFromZip(selectedDriverFile)
+                if (GpuDriverHelper.installedCustomDriverData == selectedDriverMetadata) {
+                    setDriverReady()
+                    return@withContext
+                }
+
                 if (selectedDriverMetadata.name == null) {
                     GpuDriverHelper.installDefaultDriver()
                     setDriverReady()

--- a/src/android/app/src/main/java/org/citron/citron_emu/utils/GpuDriverHelper.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/utils/GpuDriverHelper.kt
@@ -12,7 +12,6 @@ import java.io.IOException
 import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.CitronApplication
 import org.citron.citron_emu.features.settings.model.StringSetting
-import java.util.zip.ZipException
 import java.util.zip.ZipFile
 
 object GpuDriverHelper {
@@ -190,8 +189,11 @@ object GpuDriverHelper {
                     }
                 }
             }
-        } catch (_: ZipException) {
-        } catch (_: IOException) {
+        } catch (exception: IOException) {
+            Log.debug(
+                "[GpuDriverHelper] Failed to read GPU driver metadata from ${driver.path}: " +
+                    exception.message
+            )
         }
         return GpuDriverMetadata()
     }
@@ -225,29 +227,29 @@ object GpuDriverHelper {
     val installedCustomDriverData: GpuDriverMetadata
         get() = GpuDriverMetadata(File(driverInstallationPath + META_JSON_FILENAME))
 
-    val customDriverSettingFile: File
-        get() {
-            val driverPath = StringSetting.DRIVER_PATH.getString()
-            val missingPerGameDriver =
-                NativeConfig.isPerGameConfigLoaded() &&
-                    !StringSetting.DRIVER_PATH.global &&
-                    driverPath.isNotEmpty() &&
-                    !File(driverPath).isFile
+    @Synchronized
+    fun resolveCustomDriverFile(): File {
+        val driverPath = StringSetting.DRIVER_PATH.getString()
+        val missingPerGameDriver =
+            NativeConfig.isPerGameConfigLoaded() &&
+                !StringSetting.DRIVER_PATH.global &&
+                driverPath.isNotEmpty() &&
+                !File(driverPath).isFile
 
-            if (!missingPerGameDriver) {
-                return File(driverPath)
-            }
-
-            // A globally removed driver may still be referenced by a per-game override. Persist
-            // the fallback so future launches use the current global driver instead of repeatedly
-            // trying to open a stale path.
-            StringSetting.DRIVER_PATH.global = true
-            NativeConfig.savePerGameConfig()
-            return File(StringSetting.DRIVER_PATH.getString(needsGlobal = true))
+        if (!missingPerGameDriver) {
+            return File(driverPath)
         }
 
+        // A globally removed driver may still be referenced by a per-game override. Persist
+        // the fallback so future launches use the current global driver instead of repeatedly
+        // trying to open a stale path.
+        StringSetting.DRIVER_PATH.global = true
+        NativeConfig.savePerGameConfig()
+        return File(StringSetting.DRIVER_PATH.getString(needsGlobal = true))
+    }
+
     val customDriverSettingData: GpuDriverMetadata
-        get() = getMetadataFromZip(customDriverSettingFile)
+        get() = getMetadataFromZip(File(StringSetting.DRIVER_PATH.getString()))
 
     fun initializeDirectories() {
         // Ensure the file redirection directory exists.

--- a/src/android/app/src/main/java/org/citron/citron_emu/utils/GpuDriverHelper.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/utils/GpuDriverHelper.kt
@@ -12,7 +12,6 @@ import java.io.IOException
 import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.CitronApplication
 import org.citron.citron_emu.features.settings.model.StringSetting
-import java.io.FileNotFoundException
 import java.util.zip.ZipException
 import java.util.zip.ZipFile
 
@@ -192,7 +191,7 @@ object GpuDriverHelper {
                 }
             }
         } catch (_: ZipException) {
-        } catch (_: FileNotFoundException) {
+        } catch (_: IOException) {
         }
         return GpuDriverMetadata()
     }
@@ -226,8 +225,29 @@ object GpuDriverHelper {
     val installedCustomDriverData: GpuDriverMetadata
         get() = GpuDriverMetadata(File(driverInstallationPath + META_JSON_FILENAME))
 
+    val customDriverSettingFile: File
+        get() {
+            val driverPath = StringSetting.DRIVER_PATH.getString()
+            val missingPerGameDriver =
+                NativeConfig.isPerGameConfigLoaded() &&
+                    !StringSetting.DRIVER_PATH.global &&
+                    driverPath.isNotEmpty() &&
+                    !File(driverPath).isFile
+
+            if (!missingPerGameDriver) {
+                return File(driverPath)
+            }
+
+            // A globally removed driver may still be referenced by a per-game override. Persist
+            // the fallback so future launches use the current global driver instead of repeatedly
+            // trying to open a stale path.
+            StringSetting.DRIVER_PATH.global = true
+            NativeConfig.savePerGameConfig()
+            return File(StringSetting.DRIVER_PATH.getString(needsGlobal = true))
+        }
+
     val customDriverSettingData: GpuDriverMetadata
-        get() = getMetadataFromZip(File(StringSetting.DRIVER_PATH.getString()))
+        get() = getMetadataFromZip(customDriverSettingFile)
 
     fun initializeDirectories() {
         // Ensure the file redirection directory exists.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom graphics driver handling when a previously selected per-game driver is no longer available.
  * Automatically falls back to the configured global driver, helping games launch with a valid driver selection.
  * Improved resilience when reading driver metadata from packaged files, reducing failures caused by file access issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->