### PR TITLE
Fix: Added new VIDS option in Zep Zone

### DIFF
--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/BooleanSetting.kt
@@ -32,6 +32,7 @@ enum class BooleanSetting(override val key: String) : AbstractBooleanSetting {
     SHOW_SHADER_BUILDING_OVERLAY("show_shader_building_overlay"),
     SHOW_PERFORMANCE_GRAPH("show_performance_graph"),
     USE_CONDITIONAL_RENDERING("use_conditional_rendering"),
+    RENDERER_VERTEX_INPUT_DYNAMIC_STATE("vertex_input_dynamic_state"),
     ANDROID_ARM64_REGISTER_GUARDS("android_arm64_register_guards"),
     AIRPLANE_MODE("airplane_mode"),
 

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/model/view/SettingsItem.kt
@@ -457,6 +457,13 @@ abstract class SettingsItem(
             )
             put(
                 SwitchSetting(
+                    BooleanSetting.RENDERER_VERTEX_INPUT_DYNAMIC_STATE,
+                    titleId = R.string.vertex_input_dynamic_state,
+                    descriptionId = R.string.vertex_input_dynamic_state_description
+                )
+            )
+            put(
+                SwitchSetting(
                     BooleanSetting.USE_CONDITIONAL_RENDERING,
                     titleId = R.string.use_conditional_rendering,
                     descriptionId = R.string.use_conditional_rendering_description

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsDialogFragment.kt
@@ -18,6 +18,7 @@ import org.citron.citron_emu.databinding.DialogEditTextBinding
 import org.citron.citron_emu.databinding.DialogSliderBinding
 import org.citron.citron_emu.features.input.NativeInput
 import org.citron.citron_emu.features.input.model.AnalogDirection
+import org.citron.citron_emu.features.settings.model.IntSetting
 import org.citron.citron_emu.features.settings.model.view.AnalogInputSetting
 import org.citron.citron_emu.features.settings.model.view.ButtonInputSetting
 import org.citron.citron_emu.features.settings.model.view.IntSingleChoiceSetting
@@ -220,6 +221,9 @@ class SettingsDialogFragment : DialogFragment(), DialogInterface.OnClickListener
                 val scSetting = settingsViewModel.clickedItem as SingleChoiceSetting
                 val value = getValueForSingleChoiceSelection(scSetting, which)
                 scSetting.setSelectedValue(value)
+                if (scSetting.setting.key == IntSetting.EXTENDED_DYNAMIC_STATE.key) {
+                    settingsViewModel.setShouldReloadSettingsList(true)
+                }
             }
 
             is StringSingleChoiceSetting -> {

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsDialogFragment.kt
@@ -96,7 +96,11 @@ class SettingsDialogFragment : DialogFragment(), DialogInterface.OnClickListener
                             }
 
                             else -> {
-                                settingsViewModel.clickedItem!!.setting.reset()
+                                val setting = settingsViewModel.clickedItem!!.setting
+                                setting.reset()
+                                if (setting.key == IntSetting.EXTENDED_DYNAMIC_STATE.key) {
+                                    settingsViewModel.setShouldReloadSettingsList(true)
+                                }
                                 settingsViewModel.setAdapterItemChanged(position)
                             }
                         }

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1048,6 +1048,9 @@ class SettingsFragmentPresenter(
 
             add(HeaderSetting(R.string.advanced_graphics_header))
             add(IntSetting.EXTENDED_DYNAMIC_STATE.key)
+            if (IntSetting.EXTENDED_DYNAMIC_STATE.getInt() == 3) {
+                add(BooleanSetting.RENDERER_VERTEX_INPUT_DYNAMIC_STATE.key)
+            }
             add(BooleanSetting.USE_CONDITIONAL_RENDERING.key)
             add(BooleanSetting.ANDROID_ARM64_REGISTER_GUARDS.key)
 

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -233,6 +233,8 @@
     <string name="renderer_reactive_flushing_description">牺牲性能，提高某些游戏的渲染精度。</string>
     <string name="android_arm64_register_guards">ARM64 驱动寄存器保护</string>
     <string name="android_arm64_register_guards_description">保护模拟器状态免受受影响 Android GPU 驱动的寄存器损坏。仅在诊断时关闭。</string>
+    <string name="vertex_input_dynamic_state">顶点输入动态状态（VIDS）</string>
+    <string name="vertex_input_dynamic_state_description">在启用 EDS3 时使用动态顶点输入。部分 GPU 驱动出现 3D 画面缺失、灰屏或花屏时，可关闭此项进行排查。</string>
     <string name="use_disk_shader_cache">磁盘着色器缓存</string>
     <string name="use_disk_shader_cache_description">将生成的着色器缓存于磁盘中并进行读取，以减少卡顿。</string>
     <string name="anisotropic_filtering">各向异性过滤</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -1327,6 +1327,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <string name="astc_recompression_description">Controls how ASTC textures are recompressed when GPU doesn\'t support them natively.</string>
     <string name="extended_dynamic_state">Extended Dynamic State</string>
     <string name="extended_dynamic_state_description">Controls which Vulkan Extended Dynamic State features are enabled. EDS3 (default) enables all features for maximum compatibility. EDS2/EDS1 limit features for troubleshooting graphics issues. Disabled turns off all EDS features. Try lower settings if you experience rendering problems in some games.</string>
+    <string name="vertex_input_dynamic_state">Vertex Input Dynamic State (VIDS)</string>
+    <string name="vertex_input_dynamic_state_description">Uses dynamic vertex input while EDS3 is enabled. Disable this to troubleshoot missing, gray, or corrupted 3D rendering on some GPU drivers.</string>
     <string name="use_conditional_rendering">Use Conditional Rendering</string>
     <string name="use_conditional_rendering_description">Enables conditional rendering based on query results. Disabling this can fix flickering objects in some games but may impact performance. Try disabling if you see objects appearing and disappearing rapidly.</string>
     <string name="frame_skipping">Frame Skipping</string>

--- a/src/citron/configuration/shared_translation.cpp
+++ b/src/citron/configuration/shared_translation.cpp
@@ -266,6 +266,10 @@ std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent) {
            "EDS1: Enables basic Extended Dynamic State features only.\n"
            "Disabled: Disables all Extended Dynamic State features (may reduce compatibility)."));
     INSERT(
+        Settings, vertex_input_dynamic_state, tr("Vertex Input Dynamic State"),
+        tr("Uses dynamic vertex input when EDS3 is enabled. Disable this to troubleshoot "
+           "rendering issues on affected GPU drivers."));
+    INSERT(
         Settings, use_conditional_rendering, tr("Use conditional rendering"),
         tr("Enables conditional rendering based on query results.\n"
            "Disabling this can fix flickering objects in some games but may impact performance.\n"

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -532,6 +532,8 @@ struct Values {
         ExtendedDynamicState::EDS3,
         "extended_dynamic_state",
         Category::RendererAdvanced};
+    SwitchableSetting<bool> vertex_input_dynamic_state{
+        linkage, true, "vertex_input_dynamic_state", Category::RendererAdvanced};
     SwitchableSetting<bool> use_conditional_rendering{linkage, true, "use_conditional_rendering",
                                                       Category::RendererAdvanced};
     SwitchableSetting<bool> android_arm64_register_guards{

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -460,7 +460,9 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
             allow_eds3 && device.IsExtExtendedDynamicState3BlendingSupported(),
         .has_extended_dynamic_state_3_enables =
             allow_eds3 && device.IsExtExtendedDynamicState3EnablesSupported(),
-        .has_dynamic_vertex_input = allow_eds3 && device.IsExtVertexInputDynamicStateSupported(),
+        .has_dynamic_vertex_input = allow_eds3 &&
+                                    Settings::values.vertex_input_dynamic_state.GetValue() &&
+                                    device.IsExtVertexInputDynamicStateSupported(),
         .has_transform_feedback = device.IsExtTransformFeedbackSupported(),
     };
 }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1710,7 +1710,9 @@ void RasterizerVulkan::UpdateStencilTestEnable(Tegra::Engines::Maxwell3D::Regs& 
 
 void RasterizerVulkan::UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs) {
     auto& dirty{maxwell3d->dirty.flags};
-    if (!dirty[Dirty::VertexInput]) {
+    const bool vertex_input_dirty{dirty[Dirty::VertexInput]};
+    const bool vertex_buffers_dirty{dirty[VideoCommon::Dirty::VertexBuffers]};
+    if (!vertex_input_dirty && !vertex_buffers_dirty) {
         return;
     }
     dirty[Dirty::VertexInput] = false;
@@ -1718,39 +1720,34 @@ void RasterizerVulkan::UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs) 
     boost::container::static_vector<VkVertexInputBindingDescription2EXT, 32> bindings;
     boost::container::static_vector<VkVertexInputAttributeDescription2EXT, 32> attributes;
 
-    // There seems to be a bug on Nvidia's driver where updating only higher attributes ends up
-    // generating dirty state. Track the highest dirty attribute and update all attributes until
-    // that one.
-    size_t highest_dirty_attr{};
-    for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes; ++index) {
-        if (dirty[Dirty::VertexAttribute0 + index]) {
-            highest_dirty_attr = index;
-        }
-    }
-    for (size_t index = 0; index < highest_dirty_attr; ++index) {
+    const u32 max_attributes = static_cast<u32>(
+        std::min<size_t>(Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes,
+                         device.GetMaxVertexInputAttributes()));
+    const u32 max_bindings =
+        static_cast<u32>(std::min<size_t>(Tegra::Engines::Maxwell3D::Regs::NumVertexArrays,
+                                          device.GetMaxVertexInputBindings()));
+
+    // vkCmdSetVertexInputEXT replaces the complete vertex input state. Rebuild every active
+    // attribute and binding instead of attempting a partial dirty-state update, which can leave
+    // stale locations or strides behind after a scene changes its vertex layout.
+    for (u32 index = 0; index < max_attributes; ++index) {
         const Tegra::Engines::Maxwell3D::Regs::VertexAttribute attribute{
             regs.vertex_attrib_format[index]};
         const u32 binding{attribute.buffer};
-        dirty[Dirty::VertexAttribute0 + index] = false;
-        dirty[Dirty::VertexBinding0 + static_cast<size_t>(binding)] = true;
-        if (!attribute.constant) {
-            attributes.push_back({
-                .sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
-                .pNext = nullptr,
-                .location = static_cast<u32>(index),
-                .binding = binding,
-                .format = MaxwellToVK::VertexFormat(device, attribute.type, attribute.size),
-                .offset = attribute.offset,
-            });
-        }
-    }
-    for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes; ++index) {
-        if (!dirty[Dirty::VertexBinding0 + index]) {
+        if (attribute.constant || binding >= max_bindings) {
             continue;
         }
-        dirty[Dirty::VertexBinding0 + index] = false;
+        attributes.push_back({
+            .sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
+            .pNext = nullptr,
+            .location = index,
+            .binding = binding,
+            .format = MaxwellToVK::VertexFormat(device, attribute.type, attribute.size),
+            .offset = attribute.offset,
+        });
+    }
 
-        const u32 binding{static_cast<u32>(index)};
+    for (u32 binding = 0; binding < max_bindings; ++binding) {
         const auto& input_binding{regs.vertex_streams[binding]};
         const bool is_instanced{regs.vertex_stream_instances.IsInstancingEnabled(binding)};
         bindings.push_back({
@@ -1762,6 +1759,14 @@ void RasterizerVulkan::UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs) 
             .divisor = is_instanced ? input_binding.frequency : 1,
         });
     }
+
+    for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes; ++index) {
+        dirty[Dirty::VertexAttribute0 + index] = false;
+    }
+    for (size_t index = 0; index < Tegra::Engines::Maxwell3D::Regs::NumVertexArrays; ++index) {
+        dirty[Dirty::VertexBinding0 + index] = false;
+    }
+
     scheduler.Record([bindings, attributes](vk::CommandBuffer cmdbuf) {
         cmdbuf.SetVertexInputEXT(bindings, attributes);
     });


### PR DESCRIPTION
Pokémon Legends Z-A’s post-station rendering issue is temporarily resolved. Keep EDS3 enabled and disable the new VIDS option in Zep Zone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an advanced graphics setting to enable or disable Vertex Input Dynamic State (VIDS).
  - The setting appears when Extended Dynamic State 3 is enabled and includes troubleshooting guidance.
  - Added Simplified Chinese localization for the new setting.

- **Bug Fixes**
  - Improved Vulkan vertex input handling on supported devices.
  - Vertex input state now rebuilds reliably when attributes or buffers change.
  - Dynamic vertex input activates only when the required settings and hardware support are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->