### PR TITLE
fix: nce patch to follow null guard for invalid guest objects

### DIFF
--- a/src/core/arm/nce/arm_nce.cpp
+++ b/src/core/arm/nce/arm_nce.cpp
@@ -210,6 +210,35 @@ bool ArmNce::HandleFailedGuestFault(GuestContext* guest_ctx, void* raw_info, voi
     // For data aborts, skip the instruction and return to guest code.
     // This preserves the historical NCE behavior while branch relocation fallback is tested.
     if (!is_prefetch_abort) {
+        // Some guest object wrappers guard a pointer with CBZ immediately before loading its
+        // type field. A packed handle can incorrectly reach this path as a non-null pointer. If
+        // this exact sequence faults, follow the wrapper's own null-object return path.
+        u32 fault_instruction{};
+        u32 null_check_instruction{};
+        std::memcpy(&fault_instruction, reinterpret_cast<const void*>(host_ctx.pc),
+                    sizeof(fault_instruction));
+        std::memcpy(&null_check_instruction, reinterpret_cast<const void*>(host_ctx.pc - 4),
+                    sizeof(null_check_instruction));
+        constexpr u32 LoadTypeFromX0 = 0xB9400808; // ldr w8, [x0, #8]
+        constexpr u32 CbzX0Mask = 0xFF00001F;
+        constexpr u32 CbzX0 = 0xB4000000;
+        const s64 fault_delta = static_cast<s64>(reinterpret_cast<u64>(info->si_addr)) -
+                                static_cast<s64>(host_ctx.regs[0]);
+        if (fault_instruction == LoadTypeFromX0 &&
+            (null_check_instruction & CbzX0Mask) == CbzX0 && fault_delta == 8) {
+            const s64 branch_words = static_cast<s32>(null_check_instruction << 8) >> 13;
+            const u64 null_return_pc = host_ctx.pc - 4 + branch_words * 4;
+            if (null_return_pc > host_ctx.pc && null_return_pc - host_ctx.pc <= 0x100) {
+                LOG_WARNING(Core_ARM,
+                            "Recovered invalid NCE object through null guard: pc={:#x}, "
+                            "x0={:#x}, null_return_pc={:#x}",
+                            host_ctx.pc, host_ctx.regs[0], null_return_pc);
+                host_ctx.regs[0] = 0;
+                host_ctx.pc = null_return_pc;
+                return true;
+            }
+        }
+
         host_ctx.pc += 4;
         return true;
     }


### PR DESCRIPTION
## Summary

Fixes an NCE freeze in the World 4 secret stage of Super Mario Bros. Wonder.

## Cause

A packed handle reached a guest object wrapper as a non-null pointer. This bypassed the wrapper's `CBZ x0` null check and faulted on:

```asm
ldr w8, [x0, #8]
```
The historical NCE fallback skipped the faulting load, allowing execution to continue into a null indirect branch and eventually suspending the emulated core with a PC=0 prefetch abort.
## Fix
When NCE encounters this exact instruction pattern, it:
- Validates the preceding instruction is CBZ x0.
- Validates the fault occurred at x0 + 8.
- Decodes and bounds-checks the forward branch target.
- Sets x0 to zero and follows the guest wrapper's existing null-object return path.
Other data aborts retain the existing behavior.
## Validation
Tested on an Android ARM64 device with NCE enabled.
Both affected guest wrappers recovered through their null-return paths, the World 4 secret stage loaded successfully, and no subsequent PC=0 prefetch abort occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of a specific invalid guest memory access pattern.
  * In eligible cases, execution now continues safely instead of stopping on the fault.
  * Other data-abort handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->