### PR TITLE
feat: Clear all shader caches on Android

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -200,8 +200,8 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.2.0")
     implementation("androidx.window:window:1.5.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.9.8")
-    implementation("androidx.navigation:navigation-ui-ktx:2.9.8")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.10.0")
+    implementation("androidx.navigation:navigation-ui-ktx:2.10.0")
     implementation("info.debatty:java-string-similarity:2.0.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }

--- a/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/NativeLibrary.kt
@@ -153,6 +153,12 @@ object NativeLibrary {
     external fun isRunning(): Boolean
 
     /**
+     * Clears the native shader cache while holding the emulation session lock.
+     * @return 0 on success, 1 if emulation is active, or 2 on filesystem failure.
+     */
+    external fun clearShaderCache(): Int
+
+    /**
      * Returns true if emulation is paused.
      */
     external fun isPaused(): Boolean

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/multiplayer/ui/RoomDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/multiplayer/ui/RoomDialogFragment.kt
@@ -46,9 +46,7 @@ class RoomDialogFragment : DialogFragment() {
             .create()
             .also { dialog ->
                 dialog.setOnShowListener {
-                    dialog.window?.setSoftInputMode(
-                        WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
-                    )
+                    enableImeResize(dialog)
                     val disconnectButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
                     disconnectButton.setOnClickListener {
                         disconnectButton.isEnabled = false
@@ -73,6 +71,11 @@ class RoomDialogFragment : DialogFragment() {
                     observeRoomContent()
                 }
             }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun enableImeResize(dialog: AlertDialog) {
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
 
     override fun onDestroy() {

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
@@ -19,6 +19,7 @@ import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialSharedAxis
+import org.citron.citron_emu.NativeLibrary
 import org.citron.citron_emu.R
 import org.citron.citron_emu.databinding.FragmentSettingsBinding
 import org.citron.citron_emu.features.input.NativeInput
@@ -27,7 +28,6 @@ import org.citron.citron_emu.fragments.MessageDialogFragment
 import org.citron.citron_emu.utils.DirectoryInitialization
 import org.citron.citron_emu.utils.ViewUtils.updateMargins
 import org.citron.citron_emu.utils.collect
-import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -168,18 +168,22 @@ class SettingsFragment : Fragment() {
             descriptionId = R.string.clear_all_shader_caches_warning_description,
             positiveAction = {
                 viewLifecycleOwner.lifecycleScope.launch {
-                    val cleared = withContext(Dispatchers.IO) {
-                        val userDirectory = DirectoryInitialization.userDirectory
-                        userDirectory != null && File(userDirectory, "cache/shader").let {
-                            !it.exists() || it.deleteRecursively()
+                    val result = withContext(Dispatchers.IO) {
+                        when {
+                            DirectoryInitialization.userDirectory == null ->
+                                SHADER_CACHE_CLEAR_FILESYSTEM_FAILURE
+                            NativeLibrary.isRunning() -> SHADER_CACHE_CLEAR_EMULATION_ACTIVE
+                            else -> NativeLibrary.clearShaderCache()
                         }
                     }
                     Toast.makeText(
                         requireContext(),
-                        if (cleared) {
-                            R.string.cleared_all_shader_caches_successfully
-                        } else {
-                            R.string.clear_all_shader_caches_failed
+                        when (result) {
+                            SHADER_CACHE_CLEAR_SUCCESS ->
+                                R.string.cleared_all_shader_caches_successfully
+                            SHADER_CACHE_CLEAR_EMULATION_ACTIVE ->
+                                R.string.clear_all_shader_caches_emulation_active
+                            else -> R.string.clear_all_shader_caches_failed
                         },
                         Toast.LENGTH_SHORT
                     ).show()
@@ -218,5 +222,11 @@ class SettingsFragment : Fragment() {
             binding.appbarSettings.updateMargins(left = leftInsets, right = rightInsets)
             windowInsets
         }
+    }
+
+    companion object {
+        private const val SHADER_CACHE_CLEAR_SUCCESS = 0
+        private const val SHADER_CACHE_CLEAR_EMULATION_ACTIVE = 1
+        private const val SHADER_CACHE_CLEAR_FILESYSTEM_FAILURE = 2
     }
 }

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragment.kt
@@ -8,11 +8,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -22,8 +24,13 @@ import org.citron.citron_emu.databinding.FragmentSettingsBinding
 import org.citron.citron_emu.features.input.NativeInput
 import org.citron.citron_emu.features.settings.model.Settings
 import org.citron.citron_emu.fragments.MessageDialogFragment
+import org.citron.citron_emu.utils.DirectoryInitialization
 import org.citron.citron_emu.utils.ViewUtils.updateMargins
 import org.citron.citron_emu.utils.collect
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingsFragment : Fragment() {
     private lateinit var presenter: SettingsFragmentPresenter
@@ -128,6 +135,12 @@ class SettingsFragment : Fragment() {
                 ).show(parentFragmentManager, MessageDialogFragment.TAG)
             }
         }
+        settingsViewModel.shouldShowClearShaderCacheDialog.collect(
+            viewLifecycleOwner,
+            resetState = { settingsViewModel.setShouldShowClearShaderCacheDialog(false) }
+        ) {
+            if (it) showClearShaderCacheDialog()
+        }
         if (args.menuTag == Settings.MenuTag.SECTION_ROOT) {
             binding.toolbarSettings.inflateMenu(R.menu.menu_settings)
             binding.toolbarSettings.setOnMenuItemClickListener {
@@ -146,6 +159,34 @@ class SettingsFragment : Fragment() {
         presenter.onViewCreated()
 
         setInsets()
+    }
+
+    private fun showClearShaderCacheDialog() {
+        MessageDialogFragment.newInstance(
+            activity = requireActivity(),
+            titleId = R.string.clear_all_shader_caches,
+            descriptionId = R.string.clear_all_shader_caches_warning_description,
+            positiveAction = {
+                viewLifecycleOwner.lifecycleScope.launch {
+                    val cleared = withContext(Dispatchers.IO) {
+                        val userDirectory = DirectoryInitialization.userDirectory
+                        userDirectory != null && File(userDirectory, "cache/shader").let {
+                            !it.exists() || it.deleteRecursively()
+                        }
+                    }
+                    Toast.makeText(
+                        requireContext(),
+                        if (cleared) {
+                            R.string.cleared_all_shader_caches_successfully
+                        } else {
+                            R.string.clear_all_shader_caches_failed
+                        },
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            },
+            showNegativeButton = true
+        ).show(parentFragmentManager, MessageDialogFragment.TAG)
     }
 
     private fun getPlayerIndex(): Int =

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -200,6 +200,14 @@ class SettingsFragmentPresenter(
             add(IntSetting.VERTICAL_ALIGNMENT.key)
             add(BooleanSetting.PICTURE_IN_PICTURE.key)
             add(BooleanSetting.RENDERER_USE_DISK_SHADER_CACHE.key)
+            add(
+                RunnableSetting(
+                    titleId = R.string.clear_all_shader_caches,
+                    descriptionId = R.string.clear_all_shader_caches_description,
+                    isRunnable = !NativeLibrary.isRunning(),
+                    iconId = R.drawable.ic_delete
+                ) { settingsViewModel.setShouldShowClearShaderCacheDialog(true) }
+            )
             add(BooleanSetting.RENDERER_FORCE_MAX_CLOCK.key)
             add(BooleanSetting.RENDERER_ASYNCHRONOUS_SHADERS.key)
             add(BooleanSetting.RENDERER_REACTIVE_FLUSHING.key)

--- a/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsViewModel.kt
+++ b/src/android/app/src/main/java/org/citron/citron_emu/features/settings/ui/SettingsViewModel.kt
@@ -54,6 +54,9 @@ class SettingsViewModel : ViewModel() {
     private val _shouldShowResetInputDialog = MutableStateFlow(false)
     val shouldShowResetInputDialog = _shouldShowResetInputDialog.asStateFlow()
 
+    private val _shouldShowClearShaderCacheDialog = MutableStateFlow(false)
+    val shouldShowClearShaderCacheDialog = _shouldShowClearShaderCacheDialog.asStateFlow()
+
     fun setShouldRecreate(value: Boolean) {
         _shouldRecreate.value = value
     }
@@ -101,6 +104,10 @@ class SettingsViewModel : ViewModel() {
 
     fun setShouldShowResetInputDialog(value: Boolean) {
         _shouldShowResetInputDialog.value = value
+    }
+
+    fun setShouldShowClearShaderCacheDialog(value: Boolean) {
+        _shouldShowClearShaderCacheDialog.value = value
     }
 
     fun getCurrentDeviceParams(defaultParams: ParamPackage): ParamPackage =

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -953,6 +953,21 @@ jboolean Java_org_citron_citron_1emu_NativeLibrary_isRunning(JNIEnv* env, jclass
     return static_cast<jboolean>(session.IsRunning() || session.IsShuttingDown());
 }
 
+jint Java_org_citron_citron_1emu_NativeLibrary_clearShaderCache(JNIEnv* env, jclass clazz) {
+    constexpr jint Success = 0;
+    constexpr jint EmulationActive = 1;
+    constexpr jint FilesystemFailure = 2;
+
+    auto& session = EmulationSession::GetInstance();
+    const auto session_lock = session.AcquireSessionLock();
+    if (session.IsRunning() || session.IsShuttingDown()) {
+        return EmulationActive;
+    }
+
+    const auto shader_dir = Common::FS::GetCitronPath(Common::FS::CitronPath::ShaderDir);
+    return Common::FS::RemoveDirRecursively(shader_dir) ? Success : FilesystemFailure;
+}
+
 jboolean Java_org_citron_citron_1emu_NativeLibrary_isPaused(JNIEnv* env, jclass clazz) {
     return static_cast<jboolean>(EmulationSession::GetInstance().IsPaused());
 }

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -432,6 +432,7 @@
     <string name="clear_all_shader_caches_warning_description">所有已编译的着色器和管线缓存都将被删除。缓存重新生成时游戏可能出现卡顿，是否继续？</string>
     <string name="cleared_all_shader_caches_successfully">所有着色器缓存已清除</string>
     <string name="clear_all_shader_caches_failed">无法清除所有着色器缓存</string>
+    <string name="clear_all_shader_caches_emulation_active">请先停止模拟再清除着色器缓存</string>
     <string name="addons_game">附加项: %1$s</string>
     <string name="save_data">保存数据</string>
     <string name="save_data_description">管理此游戏的保存数据</string>

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -427,6 +427,11 @@
     <string name="clear_shader_cache_description">删除此游戏的所有着色器缓存</string>
     <string name="clear_shader_cache_warning_description">由于着色器缓存需要重新生成，您将遇到更多卡顿</string>
     <string name="cleared_shaders_successfully">着色器缓存清除成功</string>
+    <string name="clear_all_shader_caches">清除所有着色器缓存</string>
+    <string name="clear_all_shader_caches_description">删除所有游戏的着色器缓存，需要先停止模拟</string>
+    <string name="clear_all_shader_caches_warning_description">所有已编译的着色器和管线缓存都将被删除。缓存重新生成时游戏可能出现卡顿，是否继续？</string>
+    <string name="cleared_all_shader_caches_successfully">所有着色器缓存已清除</string>
+    <string name="clear_all_shader_caches_failed">无法清除所有着色器缓存</string>
     <string name="addons_game">附加项: %1$s</string>
     <string name="save_data">保存数据</string>
     <string name="save_data_description">管理此游戏的保存数据</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -581,6 +581,11 @@
     <string name="clear_shader_cache_description">Removes all shaders built while playing this game</string>
     <string name="clear_shader_cache_warning_description">You will experience more stuttering as the shader cache regenerates</string>
     <string name="cleared_shaders_successfully">Cleared shaders successfully</string>
+    <string name="clear_all_shader_caches">Clear all shader caches</string>
+    <string name="clear_all_shader_caches_description">Deletes shader caches for every game. Emulation must be stopped.</string>
+    <string name="clear_all_shader_caches_warning_description">All compiled shader and pipeline caches will be deleted. Games may stutter while the caches are rebuilt. Continue?</string>
+    <string name="cleared_all_shader_caches_successfully">Cleared all shader caches successfully</string>
+    <string name="clear_all_shader_caches_failed">Failed to clear all shader caches</string>
     <string name="addons_game">Addons: %1$s</string>
     <string name="save_data">Save data</string>
     <string name="save_data_description">Manage save data specific to this game</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -586,6 +586,7 @@
     <string name="clear_all_shader_caches_warning_description">All compiled shader and pipeline caches will be deleted. Games may stutter while the caches are rebuilt. Continue?</string>
     <string name="cleared_all_shader_caches_successfully">Cleared all shader caches successfully</string>
     <string name="clear_all_shader_caches_failed">Failed to clear all shader caches</string>
+    <string name="clear_all_shader_caches_emulation_active">Stop emulation before clearing shader caches</string>
     <string name="addons_game">Addons: %1$s</string>
     <string name="save_data">Save data</string>
     <string name="save_data_description">Manage save data specific to this game</string>

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -18,6 +18,6 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.9.8")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.10.0")
     }
 }


### PR DESCRIPTION
## Summary
- Update Android Navigation dependencies to 2.10.0 to resolve generated Safe Args warnings.
- Scope the deprecated soft-input API suppression in RoomDialogFragment.
- Add a global “Clear all shader caches” action under Graphics settings, with confirmation and success/failure feedback.

The cache action is disabled while emulation is running to avoid file access conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option in Graphics settings to clear all compiled shader and pipeline caches.
  * Added confirmation prompts, success or failure feedback, and localized messaging.
  * The option is unavailable while emulation is running.

* **Improvements**
  * Updated Android Navigation components to version 2.10.0.
  * Improved keyboard resizing behavior in multiplayer room dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->