### PR TITLE
dynarmic: fix stale code-page snapshot and single-core icache invalid…

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -174,8 +174,9 @@ public:
     const bool m_debugger_enabled{};
     const bool m_check_memory_access{};
     static constexpr u64 MinimumRunCycles = 10000U;
+    static constexpr u64 kNoCachedCodePage = ~u64{0};
     Dynarmic::CodePage cached_code_page;
-    u64 last_code_addr = 0;
+    u64 last_code_addr = kNoCachedCodePage;
 };
 
 std::shared_ptr<Dynarmic::A32::Jit> ArmDynarmic32::MakeJit(Common::PageTable* page_table) const {
@@ -450,11 +451,14 @@ void ArmDynarmic32::SignalInterrupt(Kernel::KThread* thread) {
 
 void ArmDynarmic32::ClearInstructionCache() {
     CITRON_PROFILE_SCOPE("Dynarmic32::ClearCache");
+    // MemoryReadCode()'s page snapshot goes stale as soon as the guest rewrites that page.
+    m_cb->last_code_addr = DynarmicCallbacks32::kNoCachedCodePage;
     m_jit->ClearCache();
 }
 
 void ArmDynarmic32::InvalidateCacheRange(u64 addr, std::size_t size) {
     CITRON_PROFILE_SCOPE("Dynarmic32::InvalidateCacheRange");
+    m_cb->last_code_addr = DynarmicCallbacks32::kNoCachedCodePage;
     m_jit->InvalidateCacheRange(static_cast<u32>(addr), size);
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -5,6 +5,7 @@
 #include <dynarmic/interface/code_page.h>
 #include "common/profiling.h"
 #include "common/settings.h"
+#include "core/arm/debug.h"
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/arm/dynarmic/arm_dynarmic_64.h"
 #include "core/arm/dynarmic/dynarmic_exclusive_monitor.h"
@@ -111,13 +112,16 @@ public:
             static constexpr u64 ICACHE_LINE_SIZE = 64;
 
             const u64 cache_line_start = value & ~(ICACHE_LINE_SIZE - 1);
-            m_parent.InvalidateCacheRange(cache_line_start, ICACHE_LINE_SIZE);
+            // Every core of this process, not just the current one: guest threads migrate, so
+            // invalidating only the core that happened to run `ic ivau` leaves the others
+            // executing stale translations of code the guest has already rewritten.
+            Core::InvalidateInstructionCacheRange(m_process, cache_line_start, ICACHE_LINE_SIZE);
             break;
         }
         case Dynarmic::A64::InstructionCacheOperation::InvalidateAllToPoU:
+        case Dynarmic::A64::InstructionCacheOperation::InvalidateAllToPoUInnerSharable:
             m_parent.ClearInstructionCache();
             break;
-        case Dynarmic::A64::InstructionCacheOperation::InvalidateAllToPoUInnerSharable:
         default:
             LOG_DEBUG(Core_ARM, "Unprocesseed instruction cache operation: {}", op);
             break;
@@ -233,8 +237,9 @@ public:
     const bool m_check_memory_access{};
     u32 m_consecutive_faults{};
     static constexpr u64 MinimumRunCycles = 10000U;
+    static constexpr u64 kNoCachedCodePage = ~u64{0};
     Dynarmic::CodePage cached_code_page;
-    u64 last_code_addr = 0;
+    u64 last_code_addr = kNoCachedCodePage;
 };
 
 std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* page_table,
@@ -494,11 +499,14 @@ void ArmDynarmic64::SignalInterrupt(Kernel::KThread* thread) {
 
 void ArmDynarmic64::ClearInstructionCache() {
     CITRON_PROFILE_SCOPE("Dynarmic64::ClearCache");
+    // MemoryReadCode()'s page snapshot goes stale as soon as the guest rewrites that page.
+    m_cb->last_code_addr = DynarmicCallbacks64::kNoCachedCodePage;
     m_jit->ClearCache();
 }
 
 void ArmDynarmic64::InvalidateCacheRange(u64 addr, std::size_t size) {
     CITRON_PROFILE_SCOPE("Dynarmic64::InvalidateCacheRange");
+    m_cb->last_code_addr = DynarmicCallbacks64::kNoCachedCodePage;
     m_jit->InvalidateCacheRange(addr, size);
 }
 


### PR DESCRIPTION
…ation

Two bugs that made any guest which regenerates code at a reused address execute stale translations. Found while bringing up an ARM64 homebrew that links and runs code at runtime, but neither is specific to it.

MemoryReadCode() caches a whole 4 KB guest page in cached_code_page and only refills it when the requested page changes. Nothing ever reset last_code_addr, so once a page had been read, a guest rewriting that page and issuing `ic ivau` got its blocks dropped and then recompiled from the *stale* snapshot. Symptom is an UnallocatedEncoding raised at a PC whose memory reads back as a perfectly valid instruction. Reset the snapshot in both ClearInstructionCache() and InvalidateCacheRange().

InstructionCacheOperationRaised() invalidated only the core that happened to execute the cache op, so any other core kept translations of code the guest had already overwritten. Threads migrate freely between cores, so this went wrong nondeterministically. Route through InvalidateInstructionCacheRange(), which covers every core of the process, matching what the kernel-side callers in k_page_table_base already do. Also handle InvalidateAllToPoUInnerSharable, the broadcast form, instead of ignoring it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale code-cache snapshots after guest code rewrites, ensuring updated instructions are read correctly.
  - Improved instruction-cache invalidation across processor cores for more reliable execution.
  - Corrected cache reset behavior after full or range-based invalidation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->