### PR TITLE
video_core: fix Normal fence stalls and binary waiter deadlock

### DIFF
--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -71,7 +71,7 @@ public:
     }
 
     void SignalFence(std::function<void()>&& func) {
-        bool delay_fence = Settings::IsGPULevelNormal();
+        const bool delay_fence = Settings::IsGPULevelHigh();
         if constexpr (!can_async_check) {
             TryReleasePendingFences<false>();
         }

--- a/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
+++ b/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
@@ -207,7 +207,9 @@ void MasterSemaphore::WaitThread(std::stop_token token) {
             free_queue.push_front(std::move(fence));
             gpu_tick.store(host_tick);
         }
-        free_cv.notify_one();
+        // Waiters can have different target ticks. Waking only one can leave another waiter
+        // asleep indefinitely even though gpu_tick already satisfies its predicate.
+        free_cv.notify_all();
     }
 }
 


### PR DESCRIPTION
## Summary

- restore early fence callbacks at Normal GPU accuracy, while retaining delayed callbacks for High and Extreme
- wake every binary-semaphore tick waiter when `gpu_tick` advances

## Chronic frame-stall mechanism

Commit `9090a24c2` changed `FenceManager::SignalFence()` from `IsGPULevelHigh()` to
`IsGPULevelNormal()` when Low accuracy was added. Because the latter includes Normal, High and
Extreme, the default Normal mode began placing every callback behind a new host GPU fence.
`RasterizerVulkan::ReleaseFences()` then blocks the GPU command thread in
`WaitPendingFences(true)` until host GPU completion.

On an AArch64 Snapdragon 8 Gen 2 / Turnip device, an exact same-binary toggle produced:

| 120-second fixed scene | current policy | restored policy |
|---|---:|---:|
| game FPS | 39.22 | 59.99 |
| median forced wait | 7.832 ms | 0.009 ms |
| time in forced waits | 39,531.821 ms | 95.959 ms |

`vkAcquireNextImageKHR` and `vkQueuePresentKHR` remained below 4 ms, so the recovered time is in
the forced fence wait rather than WSI. A sampled blocked stack was:

```text
pthread_cond_wait
  -> FenceManager<Vulkan::FenceManagerParams>::WaitPendingFences(true)
  -> RasterizerVulkan::ReleaseFences()
  -> DmaPusher::CallMethod()
  -> DmaPusher::ProcessCommands()
  -> GPUThread::RunThread()
```

The first commit restores the pre-regression High-or-Extreme policy.

## Binary fallback lost wakeup

Turnip selects `MasterSemaphore`'s binary-fence fallback. Its waiters can sleep on one `free_cv`
with different target-tick predicates. `notify_one()` can wake a waiter whose later target is not
yet eligible, followed by waking a different waiter at the next tick, leaving the now-eligible
waiter asleep indefinitely even though `gpu_tick` satisfies its predicate.

A lossless startup trace captured exactly that sequence for target ticks 21 and 22, leaving the
tick-22 compositor waiter asleep for the remaining 197.776 seconds with `gpu_tick == 22` and an
empty helper queue. The visible result was a permanent black screen. `notify_all()` makes every
target predicate re-evaluate whenever the shared tick advances.

## Validation

- full AArch64 RelWithDebInfo build completed
- `clang-format` and `git diff --check` passed
- exact clean payload verified on the device in two moving-gameplay runs around 60-61 FPS after scene entry
- three consecutive cold launches rendered; the third was a dedicated black-screen regression check with two distinct moving frames
- no trace code, runtime toggles or device-specific behavior is included in these commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graphics synchronization on higher-performance GPU configurations.
  - Fixed an issue where multiple pending rendering operations could remain blocked after GPU progress, improving Vulkan rendering responsiveness and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->