### PR TITLE
video_core: avoid command-list copies on submit

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cstring>
+#include <vector>
+
 #include "common/assert.h"
 #include "common/logging.h"
 #include "core/core.h"
@@ -270,8 +272,7 @@ NvResult nvhost_gpu::AllocateObjectContext(IoctlAllocObjCtx& params) {
 
 }
 
-static boost::container::small_vector<Tegra::CommandHeader, 512> BuildWaitCommandList(
-    NvFence fence) {
+static std::vector<Tegra::CommandHeader> BuildWaitCommandList(NvFence fence) {
     return {
         Tegra::BuildCommandHeader(Tegra::BufferMethods::SyncpointPayload, 1,
                                   Tegra::SubmissionMode::Increasing),
@@ -282,9 +283,8 @@ static boost::container::small_vector<Tegra::CommandHeader, 512> BuildWaitComman
     };
 }
 
-static boost::container::small_vector<Tegra::CommandHeader, 512> BuildIncrementCommandList(
-    NvFence fence) {
-    boost::container::small_vector<Tegra::CommandHeader, 512> result{
+static std::vector<Tegra::CommandHeader> BuildIncrementCommandList(NvFence fence) {
+    std::vector<Tegra::CommandHeader> result{
         Tegra::BuildCommandHeader(Tegra::BufferMethods::SyncpointPayload, 1,
                                   Tegra::SubmissionMode::Increasing),
         {}};
@@ -299,9 +299,8 @@ static boost::container::small_vector<Tegra::CommandHeader, 512> BuildIncrementC
     return result;
 }
 
-static boost::container::small_vector<Tegra::CommandHeader, 512> BuildIncrementWithWfiCommandList(
-    NvFence fence) {
-    boost::container::small_vector<Tegra::CommandHeader, 512> result{
+static std::vector<Tegra::CommandHeader> BuildIncrementWithWfiCommandList(NvFence fence) {
+    std::vector<Tegra::CommandHeader> result{
         Tegra::BuildCommandHeader(Tegra::BufferMethods::WaitForIdle, 1,
                                   Tegra::SubmissionMode::Increasing),
         {}};

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -4,10 +4,9 @@
 #pragma once
 
 #include <array>
+#include <queue>
 #include <span>
 #include <vector>
-#include <boost/container/small_vector.hpp>
-#include <queue>
 
 #include "common/bit_field.h"
 #include "common/common_types.h"
@@ -103,12 +102,11 @@ inline CommandHeader BuildCommandHeader(BufferMethods method, u32 arg_count, Sub
 struct CommandList final {
     CommandList() = default;
     explicit CommandList(std::size_t size) : command_lists(size) {}
-    explicit CommandList(
-        boost::container::small_vector<CommandHeader, 512>&& prefetch_command_list_)
+    explicit CommandList(std::vector<CommandHeader>&& prefetch_command_list_)
         : prefetch_command_list{std::move(prefetch_command_list_)} {}
 
-    boost::container::small_vector<CommandListHeader, 512> command_lists;
-    boost::container::small_vector<CommandHeader, 512> prefetch_command_list;
+    std::vector<CommandListHeader> command_lists;
+    std::vector<CommandHeader> prefetch_command_list;
 };
 
 /**


### PR DESCRIPTION
From eden [#4399](https://git.eden-emu.dev/eden-emu/eden/pulls/4399). Remove heavy memcpy on each cmd submit